### PR TITLE
Add Elm.Syntax.Module.isEffectModule

### DIFF
--- a/src/Elm/Syntax/Module.elm
+++ b/src/Elm/Syntax/Module.elm
@@ -5,6 +5,7 @@ module Elm.Syntax.Module
         , Import
         , Module(..)
         , exposingList
+        , isEffectModule
         , isPortModule
         , moduleName
         )
@@ -16,7 +17,7 @@ module Elm.Syntax.Module
 
 @docs Module, DefaultModuleData, EffectModuleData
 
-@docs exposingList, moduleName, isPortModule
+@docs exposingList, moduleName, isPortModule, isEffectModule
 
 
 # Import
@@ -95,6 +96,18 @@ exposingList m =
 
         EffectModule x ->
             x.exposingList
+
+
+{-| Check whether a module is defined as an effect-module
+-}
+isEffectModule : Module -> Bool
+isEffectModule m =
+    case m of
+        EffectModule _ ->
+            True
+
+        _ ->
+            False
 
 
 {-| Check whether a module is defined as a port-module


### PR DESCRIPTION
A friendly helper function in the spirit of `isPortModule` :)

Didn't know where to push it and what to base it off, so I went with the 0.19 (as I'm currently using `elm-syntax` with 0.19 alpha -- thanks for upgrading it!)