### PR TITLE
Fix extra = sign on type declaration and indentation on case statement

### DIFF
--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -1,4 +1,4 @@
-module Elm.Writer exposing (write, writeExpression, writeFile, writePattern, writeTypeAnnotation)
+module Elm.Writer exposing (write, writeDeclaration, writeExpression, writeFile, writePattern, writeTypeAnnotation)
 
 {-|
 
@@ -7,7 +7,7 @@ module Elm.Writer exposing (write, writeExpression, writeFile, writePattern, wri
 
 Write a file to a string.
 
-@docs write, writeFile, writePattern, writeExpression, writeTypeAnnotation
+@docs write, writeFile, writePattern, writeExpression, writeTypeAnnotation, writeDeclaration
 
 -}
 
@@ -200,6 +200,8 @@ writeLetDeclaration ( _, letDeclaration ) =
             writeDestructuring pattern expression
 
 
+{-| Write a declaration
+-}
 writeDeclaration : Ranged Declaration -> Writer
 writeDeclaration ( _, decl ) =
     case decl of
@@ -283,7 +285,6 @@ writeType type_ =
             [ string "type"
             , string type_.name
             , spaced (List.map string type_.generics)
-            , string "="
             ]
         , let
             diffLines =

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -484,15 +484,15 @@ writeExpression ( range, inner ) =
         CaseExpression caseBlock ->
             let
                 writeCaseBranch ( pattern, expression ) =
-                    breaked
-                        [ spaced [ writePattern pattern, string "->" ]
-                        , indent 2 (writeExpression expression)
-                        ]
+                    indent 2 <|
+                        breaked
+                            [ spaced [ writePattern pattern, string "->" ]
+                            , indent 2 (writeExpression expression)
+                            ]
             in
             breaked
                 [ spaced [ string "case", writeExpression caseBlock.expression, string "of" ]
-                , indent 2
-                    (breaked (List.map writeCaseBranch caseBlock.cases))
+                , breaked (List.map writeCaseBranch caseBlock.cases)
                 ]
 
         LambdaExpression lambda ->

--- a/tests/Elm/WriterTests.elm
+++ b/tests/Elm/WriterTests.elm
@@ -1,9 +1,11 @@
 module Elm.WriterTests exposing (..)
 
+import Elm.Syntax.Declaration exposing (..)
 import Elm.Syntax.Exposing exposing (..)
 import Elm.Syntax.Expression exposing (..)
 import Elm.Syntax.Module exposing (..)
 import Elm.Syntax.Range exposing (emptyRange)
+import Elm.Syntax.Type exposing (..)
 import Elm.Syntax.TypeAnnotation
 import Elm.Writer as Writer
 import Expect
@@ -85,5 +87,24 @@ import B  """
                         |> Writer.writeTypeAnnotation
                         |> Writer.write
                         |> Expect.equal "List (Dict String Int)"
+            ]
+        , describe "Declaration"
+            [ test "write type declaration" <|
+                \() ->
+                    ( emptyRange
+                    , TypeDecl
+                        (Type "Sample"
+                            []
+                            [ ValueConstructor "Foo" [] emptyRange
+                            , ValueConstructor "Bar" [] emptyRange
+                            ]
+                        )
+                    )
+                        |> Writer.writeDeclaration
+                        |> Writer.write
+                        |> Expect.equal
+                            ("type Sample \n"
+                                ++ "=Foo |Bar "
+                            )
             ]
         ]

--- a/tests/Elm/WriterTests.elm
+++ b/tests/Elm/WriterTests.elm
@@ -1,9 +1,11 @@
 module Elm.WriterTests exposing (..)
 
+import Elm.Syntax.Base exposing (..)
 import Elm.Syntax.Declaration exposing (..)
 import Elm.Syntax.Exposing exposing (..)
 import Elm.Syntax.Expression exposing (..)
 import Elm.Syntax.Module exposing (..)
+import Elm.Syntax.Pattern exposing (..)
 import Elm.Syntax.Range exposing (emptyRange)
 import Elm.Syntax.Type exposing (..)
 import Elm.Syntax.TypeAnnotation
@@ -105,6 +107,39 @@ import B  """
                         |> Expect.equal
                             ("type Sample \n"
                                 ++ "=Foo |Bar "
+                            )
+            , test "write function with case expression using the right indentations" <|
+                \() ->
+                    let
+                        body =
+                            CaseExpression
+                                (CaseBlock ( emptyRange, FunctionOrValue "someCase" )
+                                    [ ( ( emptyRange, IntPattern 1 ), ( emptyRange, FunctionOrValue "doSomething" ) )
+                                    , ( ( emptyRange, IntPattern 2 ), ( emptyRange, FunctionOrValue "doSomethingElse" ) )
+                                    ]
+                                )
+
+                        function =
+                            FuncDecl
+                                (Function Nothing
+                                    Nothing
+                                    (FunctionDeclaration False
+                                        (VariablePointer "functionName" emptyRange)
+                                        []
+                                        ( emptyRange, body )
+                                    )
+                                )
+                    in
+                    ( emptyRange, function )
+                        |> Writer.writeDeclaration
+                        |> Writer.write
+                        |> Expect.equal
+                            ("\n\nfunctionName  =\n"
+                                ++ "    case someCase of\n"
+                                ++ "          1 ->\n"
+                                ++ "              doSomething\n"
+                                ++ "          2 ->\n"
+                                ++ "              doSomethingElse"
                             )
             ]
         ]


### PR DESCRIPTION
Hello,

I'm using this lib to write an elm code generator, and I found a few bugs as you can see on the gif below:

![new route generator](https://user-images.githubusercontent.com/792201/41133113-62ca9eda-6a9b-11e8-9056-99895361d72c.gif)

The changes fixes those bugs