### PR TITLE
Fix qualified expressions

### DIFF
--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -512,7 +512,7 @@ writeExpression ( range, inner ) =
             sepHelper bracketsComma (List.map recurRangeHelper xs)
 
         QualifiedExpr moduleName name ->
-            join [ writeModuleName moduleName, string name ]
+            join [ writeModuleName moduleName, string ".", string name ]
 
         RecordAccess expression accessor ->
             join [ writeExpression expression, string ".", string accessor ]

--- a/tests/Elm/WriterTests.elm
+++ b/tests/Elm/WriterTests.elm
@@ -48,12 +48,20 @@ import B  """
                             ++ """import C as D exposing (..)
 """
                         )
-        , test "write simple expression" <|
-            \() ->
-                ( Elm.Syntax.Range.emptyRange, Application [ ( Elm.Syntax.Range.emptyRange, FunctionOrValue "abc" ), ( Elm.Syntax.Range.emptyRange, UnitExpr ) ] )
-                    |> Writer.writeExpression
-                    |> Writer.write
-                    |> Expect.equal "abc ()"
+        , describe "Expression"
+            [ test "write simple expression" <|
+                \() ->
+                    ( Elm.Syntax.Range.emptyRange, Application [ ( Elm.Syntax.Range.emptyRange, FunctionOrValue "abc" ), ( Elm.Syntax.Range.emptyRange, UnitExpr ) ] )
+                        |> Writer.writeExpression
+                        |> Writer.write
+                        |> Expect.equal "abc ()"
+            , test "write qualified expression" <|
+                \() ->
+                    ( Elm.Syntax.Range.emptyRange, QualifiedExpr [ "Foo", "Bar" ] "baz" )
+                        |> Writer.writeExpression
+                        |> Writer.write
+                        |> Expect.equal "Foo.Bar.baz"
+            ]
         , describe "TypeAnnotation"
             [ test "write simple type" <|
                 \() ->


### PR DESCRIPTION
It was missing a dot, qualified expressions were outputting like this:

```elm
Htmlmap
```

now it outputs correctly:

```elm
Html.map
```