### PR TITLE
Fix writing subfunctions type signatures

### DIFF
--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -365,10 +365,19 @@ writeTypeAnnotation ( _, typeAnnotation ) =
                 ]
 
         FunctionTypeAnnotation left right ->
+            let
+                addParensForSubTypeAnnotation type_ =
+                    case type_ of
+                        ( _, FunctionTypeAnnotation _ _ ) ->
+                            join [ string "(", writeTypeAnnotation type_, string ")" ]
+
+                        _ ->
+                            writeTypeAnnotation type_
+            in
             spaced
-                [ writeTypeAnnotation left
+                [ addParensForSubTypeAnnotation left
                 , string "->"
-                , writeTypeAnnotation right
+                , addParensForSubTypeAnnotation right
                 ]
 
 

--- a/tests/Elm/WriterTests.elm
+++ b/tests/Elm/WriterTests.elm
@@ -97,6 +97,20 @@ import B  """
                         |> Writer.writeTypeAnnotation
                         |> Writer.write
                         |> Expect.equal "List (Dict String Int)"
+            , test "write type arguments that are functions" <|
+                \() ->
+                    ( emptyRange
+                    , Elm.Syntax.TypeAnnotation.FunctionTypeAnnotation
+                        ( emptyRange
+                        , Elm.Syntax.TypeAnnotation.FunctionTypeAnnotation
+                            ( emptyRange, Elm.Syntax.TypeAnnotation.GenericType "a" )
+                            ( emptyRange, Elm.Syntax.TypeAnnotation.GenericType "b" )
+                        )
+                        ( emptyRange, Elm.Syntax.TypeAnnotation.Typed [] "Int" [] )
+                    )
+                        |> Writer.writeTypeAnnotation
+                        |> Writer.write
+                        |> Expect.equal "(a -> b) -> Int"
             ]
         , describe "Declaration"
             [ test "write type declaration" <|


### PR DESCRIPTION
The writing was outputting `a -> b -> c` instead of `(a -> b) -> c`