### PR TITLE
Allow longer escaped character literals like '\x200b'

### DIFF
--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -129,7 +129,7 @@ escapedChar =
             , '\x0C' <$ char 'f'
             , '\x0D' <$ char 'r'
             , '\x0B' <$ char 'v'
-            , (char 'x' *> regex "[0-9A-Fa-f]{2}")
+            , (char 'x' *> regex "([0-9A-Fa-f]{2}){1,2}")
                 >>= (\l ->
                         case Hex.fromString <| String.toLower l of
                             Ok x ->

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -159,6 +159,18 @@ all =
             \() ->
                 parseFullString "'\\x0D'" Parser.characterLiteral
                     |> Expect.equal (Just '\x0D')
+        , test "character escaped 3" <|
+            \() ->
+                parseFullString "'\\n'" Parser.characterLiteral
+                    |> Expect.equal (Just '\n')
+        , test "character escaped 4" <|
+            \() ->
+                parseFullString "'\\x200B'" Parser.characterLiteral
+                    |> Expect.equal (Just '\x200B')
+        , test "string escaped" <|
+            \() ->
+                parseFullString "\"foo\\\\\"" Parser.stringLiteral
+                    |> Expect.equal (Just "foo\\")
         , test "string escaped 2" <|
             \() ->
                 parseFullString "\"\\x07\"" Parser.stringLiteral
@@ -167,14 +179,6 @@ all =
             \() ->
                 parseFullString "\"\\\"\"" Parser.stringLiteral
                     |> Expect.equal (Just "\"")
-        , test "string escaped" <|
-            \() ->
-                parseFullString "\"foo\\\\\"" Parser.stringLiteral
-                    |> Expect.equal (Just "foo\\")
-        , test "character escaped 3" <|
-            \() ->
-                parseFullString "'\\n'" Parser.characterLiteral
-                    |> Expect.equal (Just '\n')
         , test "long string" <|
             \() ->
                 parseFullString longString Parser.stringLiteral


### PR DESCRIPTION
In 0.18, `\x200b` is a valid character literal for the zero width space. Essentially, the regex should match pairs of 2.

There are some issues with how 0.18 represents characters outside the BMP (surrogate pairs are weird and complicated) so I didn't really bother trying to include those.