### PR TITLE
Allow empty record expressions

### DIFF
--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -129,7 +129,7 @@ escapedChar =
             , '\x0C' <$ char 'f'
             , '\x0D' <$ char 'r'
             , '\x0B' <$ char 'v'
-            , (char 'x' *> regex "[0-9A-Fa-f]{2}")
+            , (char 'x' *> regex "([0-9A-Fa-f]{2}){1,2}")
                 >>= (\l ->
                         case Hex.fromString <| String.toLower l of
                             Ok x ->

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -76,6 +76,23 @@ all =
                                     }
                                 }
                         )
+        , test "function declaration with empty record" <|
+            \() ->
+                parseFullStringWithNullState "foo = {}" Parser.function
+                    |> Maybe.map (Tuple.second >> noRangeDeclaration)
+                    |> Expect.equal
+                        (Just <|
+                            FuncDecl
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
+                                    { operatorDefinition = False
+                                    , name = { value = "foo", range = emptyRange }
+                                    , arguments = []
+                                    , expression = emptyRanged <| RecordExpr []
+                                    }
+                                }
+                        )
         , test "operator declarations" <|
             \() ->
                 parseFullStringWithNullState "(&>) = flip Maybe.andThen" Parser.function

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -159,6 +159,18 @@ all =
             \() ->
                 parseFullString "'\\x0D'" Parser.characterLiteral
                     |> Expect.equal (Just '\x0D')
+        , test "character escaped 3" <|
+            \() ->
+                parseFullString "'\\n'" Parser.characterLiteral
+                    |> Expect.equal (Just '\n')
+        , test "character escaped 4" <|
+            \() ->
+                parseFullString "'\\x200B'" Parser.characterLiteral
+                    |> Expect.equal (Just '\x200B')
+        , test "string escaped" <|
+            \() ->
+                parseFullString "\"foo\\\\\"" Parser.stringLiteral
+                    |> Expect.equal (Just "foo\\")
         , test "string escaped 2" <|
             \() ->
                 parseFullString "\"\\x07\"" Parser.stringLiteral
@@ -167,14 +179,6 @@ all =
             \() ->
                 parseFullString "\"\\\"\"" Parser.stringLiteral
                     |> Expect.equal (Just "\"")
-        , test "string escaped" <|
-            \() ->
-                parseFullString "\"foo\\\\\"" Parser.stringLiteral
-                    |> Expect.equal (Just "foo\\")
-        , test "character escaped 3" <|
-            \() ->
-                parseFullString "'\\n'" Parser.characterLiteral
-                    |> Expect.equal (Just '\n')
         , test "long string" <|
             \() ->
                 parseFullString longString Parser.stringLiteral


### PR DESCRIPTION
Record expressions like `{}` are valid Elm, but trip up the parser.

(I'm lazy so it's based on #17 but feel free to rebase!)