### PR TITLE
Encode `StringPattern` using `"string"`

### DIFF
--- a/src/Elm/Json/Encode.elm
+++ b/src/Elm/Json/Encode.elm
@@ -387,7 +387,7 @@ encodePattern ( r, pattern ) =
                         )
 
                 StringPattern v ->
-                    encodeTyped "char"
+                    encodeTyped "string"
                         (JE.object
                             [ ( "value", string v )
                             ]


### PR DESCRIPTION
As this is what the decoder expects, too.