### PR TITLE
Add parentheses around tuples in Writer

### DIFF
--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -490,7 +490,7 @@ writeExpression (Node range inner) =
             string ("'" ++ String.fromList [ c ] ++ "'")
 
         TupledExpression t ->
-            sepHelper sepByComma (List.map recurRangeHelper t)
+            join [ string "(", sepHelper sepByComma (List.map recurRangeHelper t), string ")" ]
 
         ParenthesizedExpression x ->
             join [ string "(", writeExpression x, string ")" ]

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -166,4 +166,17 @@ import B  """
                                 ++ "        doSomethingElse"
                             )
             ]
+        , describe "Tuple"
+            [ test "write tuple" <|
+                \() ->
+                    (Node emptyRange <|
+                        TupledExpression
+                            [ Node emptyRange <| Integer 1
+                            , Node emptyRange <| Integer 2
+                            ]
+                    )
+                        |> Writer.writeExpression
+                        |> Writer.write
+                        |> Expect.equal "(1, 2)"
+            ]
         ]


### PR DESCRIPTION
I was experimenting with the code-to-ast-to-code and noticed that the tuples in the output didn't have their parentheses. I've added a small test and a code change to try adjust for this. Perhaps I have the wrong approach but it seems ok?

Thanks for the project. It is really interesting stuff to dig into.

Commit message:

> It seems that tuples are being written out without the surrounding parentheses. This adds a test to cover that case and adjusts the Writer logic to includ the parentheses in the same manner as the ParenthesizedExpression below it.