### PR TITLE
Include both expression and field name in RecordAccess range

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -190,10 +190,9 @@ liftRecordAccess e =
     lazy
         (\() ->
             or
-                ((Node.parser <|
-                    Combine.map (RecordAccess e)
-                        (string "." |> Combine.continueWith (Node.parser functionName))
-                 )
+                (string "."
+                    |> Combine.continueWith (Node.parser functionName)
+                    |> Combine.map (\f -> Node.combine RecordAccess e f)
                     |> Combine.andThen liftRecordAccess
                 )
                 (succeed e)

--- a/tests/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/tests/Elm/Parser/ExpressionTests.elm
@@ -280,9 +280,16 @@ all =
         , test "record access" <|
             \() ->
                 parseFullStringWithNullState "foo.bar" expression
-                    |> Maybe.map noRangeExpression
-                    |> Maybe.map Node.value
-                    |> Expect.equal (Just (RecordAccess (Node emptyRange <| FunctionOrValue [] "foo") (Node emptyRange "bar")))
+                    |> Expect.equal
+                        (Just
+                            (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 8 } } <|
+                                RecordAccess
+                                    (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } <|
+                                        FunctionOrValue [] "foo"
+                                    )
+                                    (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 8 } } "bar")
+                            )
+                        )
         , test "multiple record access operations" <|
             \() ->
                 parseFullStringWithNullState "foo.bar.baz" expression


### PR DESCRIPTION
Otherwise the range of a RecordAccess node is just the field name.