### PR TITLE
Fix #39, add regression tests

### DIFF
--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -143,6 +143,6 @@ recordPart =
                     between
                         (string "{" |> Combine.continueWith (maybe Layout.layout))
                         (maybe Layout.layout |> Combine.continueWith (string "}"))
-                        (sepBy1 (string ",") (Layout.maybeAroundBothSides (Node.parser functionName)))
+                        (sepBy (string ",") (Layout.maybeAroundBothSides (Node.parser functionName)))
                 )
         )

--- a/tests/tests/Elm/Parser/PatternTests.elm
+++ b/tests/tests/Elm/Parser/PatternTests.elm
@@ -42,7 +42,7 @@ all =
                                 )
                             )
                         )
-        , test "quaified pattern without and with spacing should parse to the same" <|
+        , test "qualified pattern without and with spacing should parse to the same" <|
             \() ->
                 let
                     a =
@@ -112,6 +112,11 @@ all =
                                 ListPattern [ Node (Range (Location 1 2) (Location 1 3)) <| IntPattern 1 ]
                             )
                         )
+        , test "empty list pattern" <|
+            \() ->
+                parseFullStringState emptyState "[]" Parser.pattern
+                    |> Maybe.map noRangePattern
+                    |> Expect.equal (Just (Node emptyRange (ListPattern [])))
         , test "float pattern" <|
             \() ->
                 parseFullStringState emptyState "1.2" Parser.pattern
@@ -129,6 +134,11 @@ all =
                                     ]
                             )
                         )
+        , test "empty record pattern" <|
+            \() ->
+                parseFullStringState emptyState "{}" Parser.pattern
+                    |> Maybe.map noRangePattern
+                    |> Expect.equal (Just (Node emptyRange (RecordPattern [])))
         , test "named pattern" <|
             \() ->
                 parseFullStringState emptyState "True" Parser.pattern


### PR DESCRIPTION
The famous 1-character bugfix. :)

Empty record pattern matching is legal in Elm. Many don't seem to know this, Elm-format had [the exact same bug](https://github.com/avh4/elm-format/issues/576), haha.