### PR TITLE
Change type signature on Application expression

### DIFF
--- a/src/Elm/Inspector.elm
+++ b/src/Elm/Inspector.elm
@@ -321,8 +321,8 @@ inspectInnerExpression config expression context =
         GLSLExpression _ ->
             context
 
-        Application expressionList ->
-            List.foldl (inspectExpression config) context expressionList
+        Application head expressionList ->
+            List.foldl (inspectExpression config) context (head :: expressionList)
 
         OperatorApplication op dir left right ->
             actionLambda config.onOperatorApplication

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -217,7 +217,7 @@ expression =
                                         _ ->
                                             Node
                                                 (Range.combine (Node.range first :: List.map Node.range rest))
-                                                (Application (first :: List.reverse rest))
+                                                (Application first (List.reverse rest))
 
                             promoter rest =
                                 Layout.optimisticLayoutWith

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -85,7 +85,7 @@ type alias FunctionImplementation =
 -}
 type Expression
     = UnitExpr
-    | Application (List (Node Expression))
+    | Application (Node Expression) (List (Node Expression))
     | OperatorApplication String InfixDirection (Node Expression) (Node Expression)
     | FunctionOrValue ModuleName String
     | IfBlock (Node Expression) (Node Expression) (Node Expression)
@@ -231,8 +231,8 @@ encode expr =
         UnitExpr ->
             encodeTyped "unit" JE.null
 
-        Application l ->
-            encodeTyped "application" (JE.list (Node.encode encode) l)
+        Application head l ->
+            encodeTyped "application" (JE.list (Node.encode encode) (head :: l))
 
         OperatorApplication op dir left right ->
             encodeTyped "operatorapplication" (encodeOperatorApplication op dir left right)
@@ -424,7 +424,18 @@ decoder =
         (\() ->
             decodeTyped
                 [ ( "unit", JD.succeed UnitExpr )
-                , ( "application", JD.list decodeNested |> JD.map Application )
+                , ( "application"
+                  , JD.list decodeNested
+                        |> JD.andThen
+                            (\list ->
+                                case list of
+                                    head :: rest ->
+                                        Application head rest |> JD.succeed
+
+                                    [] ->
+                                        JD.fail "Application expression must have at least one subexpression."
+                            )
+                  )
                 , ( "operatorapplication", decodeOperatorApplication )
                 , ( "functionOrValue", JD.map2 FunctionOrValue (JD.field "moduleName" ModuleName.decoder) (JD.field "name" JD.string) )
                 , ( "ifBlock", JD.map3 IfBlock (JD.field "clause" decodeNested) (JD.field "then" decodeNested) (JD.field "else" decodeNested) )

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -412,17 +412,14 @@ writeExpression (Node range inner) =
         UnitExpr ->
             string "()"
 
-        Application xs ->
+        Application head xs ->
             case xs of
                 [] ->
-                    epsilon
+                    writeExpression head
 
-                [ x ] ->
-                    writeExpression x
-
-                x :: rest ->
+                rest ->
                     spaced
-                        [ writeExpression x
+                        [ writeExpression head
                         , sepHelper sepBySpace (List.map recurRangeHelper rest)
                         ]
 

--- a/tests/tests/Elm/Parser/CaseExpressionTests.elm
+++ b/tests/tests/Elm/Parser/CaseExpressionTests.elm
@@ -169,16 +169,16 @@ all =
                                     [ ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Increment") []
                                       , Node emptyRange <|
                                             Application
-                                                [ Node emptyRange <| FunctionOrValue [] "model"
-                                                , Node emptyRange <| Operator "+"
+                                                (Node emptyRange <| FunctionOrValue [] "model")
+                                                [ Node emptyRange <| Operator "+"
                                                 , Node emptyRange <| Integer 1
                                                 ]
                                       )
                                     , ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Decrement") []
                                       , Node emptyRange <|
                                             Application
-                                                [ Node emptyRange <| FunctionOrValue [] "model"
-                                                , Node emptyRange <| Operator "-"
+                                                (Node emptyRange <| FunctionOrValue [] "model")
+                                                [ Node emptyRange <| Operator "-"
                                                 , Node emptyRange <| Integer 1
                                                 ]
                                       )

--- a/tests/tests/Elm/Parser/CombineTestUtil.elm
+++ b/tests/tests/Elm/Parser/CombineTestUtil.elm
@@ -357,8 +357,8 @@ noRangeRecordSetter ( a, b ) =
 noRangeInnerExpression : Expression -> Expression
 noRangeInnerExpression inner =
     case inner of
-        Application xs ->
-            Application <| List.map noRangeExpression xs
+        Application head xs ->
+            Application (noRangeExpression head) (List.map noRangeExpression xs)
 
         OperatorApplication op dir left right ->
             OperatorApplication op dir (noRangeExpression left) (noRangeExpression right)

--- a/tests/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/tests/Elm/Parser/DeclarationsTests.elm
@@ -209,8 +209,8 @@ all =
                                         , expression =
                                             Node emptyRange <|
                                                 Application
-                                                    [ Node emptyRange <| FunctionOrValue [] "x"
-                                                    , Node emptyRange <| Operator "+"
+                                                    (Node emptyRange <| FunctionOrValue [] "x")
+                                                    [ Node emptyRange <| Operator "+"
                                                     , Node emptyRange <| Integer 1
                                                     ]
                                         }
@@ -289,8 +289,8 @@ all =
                                         , expression =
                                             Node emptyRange <|
                                                 Application
-                                                    [ Node emptyRange <| FunctionOrValue [] "beginnerProgram"
-                                                    , Node emptyRange <|
+                                                    (Node emptyRange <| FunctionOrValue [] "beginnerProgram")
+                                                    [ Node emptyRange <|
                                                         RecordExpr
                                                             [ Node emptyRange ( Node emptyRange "model", Node emptyRange <| Integer 0 )
                                                             , Node emptyRange ( Node emptyRange "view", Node emptyRange <| FunctionOrValue [] "view" )
@@ -322,16 +322,16 @@ all =
                                                         [ ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Increment") []
                                                           , Node emptyRange <|
                                                                 Application
-                                                                    [ Node emptyRange <| FunctionOrValue [] "model"
-                                                                    , Node emptyRange <| Operator "+"
+                                                                    (Node emptyRange <| FunctionOrValue [] "model")
+                                                                    [ Node emptyRange <| Operator "+"
                                                                     , Node emptyRange <| Integer 1
                                                                     ]
                                                           )
                                                         , ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Decrement") []
                                                           , Node emptyRange <|
                                                                 Application
-                                                                    [ Node emptyRange <| FunctionOrValue [] "model"
-                                                                    , Node emptyRange <| Operator "-"
+                                                                    (Node emptyRange <| FunctionOrValue [] "model")
+                                                                    [ Node emptyRange <| Operator "-"
                                                                     , Node emptyRange <| Integer 1
                                                                     ]
                                                           )
@@ -409,9 +409,8 @@ all =
                                         , expression =
                                             Node emptyRange <|
                                                 Application
-                                                    [ Node emptyRange <| FunctionOrValue [] "text"
-                                                    , Node emptyRange <| Literal "Hello, World!"
-                                                    ]
+                                                    (Node emptyRange <| FunctionOrValue [] "text")
+                                                    [ Node emptyRange <| Literal "Hello, World!" ]
                                         }
                                 }
                         )
@@ -433,9 +432,8 @@ all =
                                         , expression =
                                             Node emptyRange <|
                                                 Application
-                                                    [ Node emptyRange <| FunctionOrValue [] "text"
-                                                    , Node emptyRange <| Literal "Hello, World!"
-                                                    ]
+                                                    (Node emptyRange <| FunctionOrValue [] "text")
+                                                    [ Node emptyRange <| Literal "Hello, World!" ]
                                         }
                                 }
                         )
@@ -472,15 +470,14 @@ all =
                                         , expression =
                                             Node emptyRange <|
                                                 Application
-                                                    [ Node emptyRange <| FunctionOrValue [] "curry"
-                                                    , Node emptyRange <| Operator "<|"
+                                                    (Node emptyRange <| FunctionOrValue [] "curry")
+                                                    [ Node emptyRange <| Operator "<|"
                                                     , Node emptyRange <|
                                                         ParenthesizedExpression
                                                             (Node emptyRange <|
                                                                 Application
-                                                                    [ Node emptyRange <| FunctionOrValue [] "uncurry"
-                                                                    , Node emptyRange <| FunctionOrValue [] "update"
-                                                                    ]
+                                                                    (Node emptyRange <| FunctionOrValue [] "uncurry")
+                                                                    [ Node emptyRange <| FunctionOrValue [] "update" ]
                                                             )
                                                     , Node emptyRange <| Operator ">>"
                                                     , Node emptyRange <| FunctionOrValue [] "batchStateCmds"
@@ -513,16 +510,16 @@ all =
                                                         [ ( Node emptyRange <| NamedPattern { moduleName = [], name = "Increment" } []
                                                           , Node emptyRange <|
                                                                 Application
-                                                                    [ Node emptyRange <| FunctionOrValue [] "model"
-                                                                    , Node emptyRange <| Operator "+"
+                                                                    (Node emptyRange <| FunctionOrValue [] "model")
+                                                                    [ Node emptyRange <| Operator "+"
                                                                     , Node emptyRange <| Integer 1
                                                                     ]
                                                           )
                                                         , ( Node emptyRange <| NamedPattern { moduleName = [], name = "Decrement" } []
                                                           , Node emptyRange <|
                                                                 Application
-                                                                    [ Node emptyRange <| FunctionOrValue [] "model"
-                                                                    , Node emptyRange <| Operator "-"
+                                                                    (Node emptyRange <| FunctionOrValue [] "model")
+                                                                    [ Node emptyRange <| Operator "-"
                                                                     , Node emptyRange <| Integer 1
                                                                     ]
                                                           )

--- a/tests/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/tests/Elm/Parser/ExpressionTests.elm
@@ -82,8 +82,8 @@ all =
                         (Just
                             (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 15 } } <|
                                 Application
-                                    [ Node { start = { row = 1, column = 1 }, end = { row = 1, column = 12 } } <| FunctionOrValue [ "List" ] "concat"
-                                    , Node { start = { row = 1, column = 13 }, end = { row = 1, column = 15 } } <| ListExpr []
+                                    (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 12 } } <| FunctionOrValue [ "List" ] "concat")
+                                    [ Node { start = { row = 1, column = 13 }, end = { row = 1, column = 15 } } <| ListExpr []
                                     ]
                             )
                         )
@@ -94,8 +94,8 @@ all =
                         (Just
                             (Node (Range { column = 1, row = 1 } { column = 10, row = 1 }) <|
                                 Application
-                                    [ Node { end = { column = 6, row = 1 }, start = { column = 1, row = 1 } } <| FunctionOrValue [] "model"
-                                    , Node { end = { column = 8, row = 1 }, start = { column = 7, row = 1 } } <| Operator "+"
+                                    (Node { end = { column = 6, row = 1 }, start = { column = 1, row = 1 } } <| FunctionOrValue [] "model")
+                                    [ Node { end = { column = 8, row = 1 }, start = { column = 7, row = 1 } } <| Operator "+"
                                     , Node { end = { column = 10, row = 1 }, start = { column = 9, row = 1 } } <| Integer 1
                                     ]
                             )
@@ -110,14 +110,15 @@ all =
                                     [ Node { start = { row = 1, column = 2 }, end = { row = 1, column = 4 } } <| Literal ""
                                     , Node { start = { row = 1, column = 6 }, end = { row = 1, column = 47 } } <|
                                         Application
-                                            [ Node { start = { row = 1, column = 6 }, end = { row = 1, column = 12 } } <| FunctionOrValue [] "always"
-                                            , Node { start = { row = 1, column = 13 }, end = { row = 1, column = 47 } } <|
+                                            (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 12 } } <| FunctionOrValue [] "always")
+                                            [ Node { start = { row = 1, column = 13 }, end = { row = 1, column = 47 } } <|
                                                 ParenthesizedExpression
                                                     (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 46 } } <|
                                                         Application
-                                                            [ Node { start = { row = 1, column = 14 }, end = { row = 1, column = 25 } } <|
+                                                            (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 25 } } <|
                                                                 FunctionOrValue [ "List" ] "concat"
-                                                            , Node { start = { row = 1, column = 26 }, end = { row = 1, column = 46 } } <|
+                                                            )
+                                                            [ Node { start = { row = 1, column = 26 }, end = { row = 1, column = 46 } } <|
                                                                 ListExpr
                                                                     [ Node { start = { row = 1, column = 28 }, end = { row = 1, column = 40 } } <|
                                                                         ListExpr
@@ -147,10 +148,10 @@ all =
                     |> Expect.equal
                         (Just
                             (Application
-                                [ Node emptyRange <|
+                                (Node emptyRange <|
                                     FunctionOrValue [ "Task" ] "succeed"
-                                , Node emptyRange <| UnitExpr
-                                ]
+                                )
+                                [ Node emptyRange <| UnitExpr ]
                             )
                         )
         , test "compoundExpression" <|
@@ -161,9 +162,8 @@ all =
                     |> Expect.equal
                         (Just
                             (Application
-                                [ Node emptyRange <| FunctionOrValue [] "foo"
-                                , Node emptyRange <| FunctionOrValue [] "bar"
-                                ]
+                                (Node emptyRange <| FunctionOrValue [] "foo")
+                                [ Node emptyRange <| FunctionOrValue [] "bar" ]
                             )
                         )
         , test "compoundExpression 2" <|
@@ -174,8 +174,8 @@ all =
                     |> Expect.equal
                         (Just
                             (Application
-                                [ Node emptyRange <| RecordExpr [ Node emptyRange ( Node emptyRange "key", Node emptyRange <| FunctionOrValue [] "value" ) ]
-                                , Node emptyRange <| Operator "!"
+                                (Node emptyRange <| RecordExpr [ Node emptyRange ( Node emptyRange "key", Node emptyRange <| FunctionOrValue [] "value" ) ])
+                                [ Node emptyRange <| Operator "!"
                                 , Node emptyRange <| ListExpr []
                                 ]
                             )
@@ -246,8 +246,8 @@ all =
                     |> Expect.equal
                         (Just
                             (ListExpr
-                                [ Node emptyRange <| Application [ Node emptyRange <| FunctionOrValue [] "class", Node emptyRange <| Literal "a" ]
-                                , Node emptyRange <| Application [ Node emptyRange <| FunctionOrValue [] "text", Node emptyRange <| Literal "Foo" ]
+                                [ Node emptyRange <| Application (Node emptyRange <| FunctionOrValue [] "class") [ Node emptyRange <| Literal "a" ]
+                                , Node emptyRange <| Application (Node emptyRange <| FunctionOrValue [] "text") [ Node emptyRange <| Literal "Foo" ]
                                 ]
                             )
                         )
@@ -351,8 +351,8 @@ all =
                     |> Expect.equal
                         (Just
                             (Application
-                                [ Node emptyRange <| FunctionOrValue [ "List" ] "map"
-                                , Node emptyRange <| RecordAccessFunction ".name"
+                                (Node emptyRange <| FunctionOrValue [ "List" ] "map")
+                                [ Node emptyRange <| RecordAccessFunction ".name"
                                 , Node emptyRange <| FunctionOrValue [] "people"
                                 ]
                             )
@@ -367,9 +367,8 @@ all =
                             (ParenthesizedExpression
                                 (Node emptyRange <|
                                     Application
-                                        [ Node emptyRange <| RecordAccessFunction ".spaceEvenly"
-                                        , Node emptyRange <| FunctionOrValue [ "Internal", "Style" ] "classes"
-                                        ]
+                                        (Node emptyRange <| RecordAccessFunction ".spaceEvenly")
+                                        [ Node emptyRange <| FunctionOrValue [ "Internal", "Style" ] "classes" ]
                                 )
                             )
                         )
@@ -381,9 +380,8 @@ all =
                     |> Expect.equal
                         (Just <|
                             Application
-                                [ Node emptyRange <| PrefixOperator "::"
-                                , Node emptyRange <| FunctionOrValue [] "x"
-                                ]
+                                (Node emptyRange <| PrefixOperator "::")
+                                [ Node emptyRange <| FunctionOrValue [] "x" ]
                         )
         , test "negated expression for value" <|
             \() ->
@@ -399,9 +397,8 @@ all =
                     |> Expect.equal
                         (Just
                             (Application
-                                [ Node emptyRange <| FunctionOrValue [] "toFloat"
-                                , Node emptyRange <| Negation (Node emptyRange <| Integer 5)
-                                ]
+                                (Node emptyRange <| FunctionOrValue [] "toFloat")
+                                [ Node emptyRange <| Negation (Node emptyRange <| Integer 5) ]
                             )
                         )
         , test "negated expression for parenthesized" <|
@@ -416,8 +413,8 @@ all =
                                     ParenthesizedExpression
                                         (Node emptyRange <|
                                             Application
-                                                [ Node emptyRange <| FunctionOrValue [] "x"
-                                                , Node emptyRange <| Operator "-"
+                                                (Node emptyRange <| FunctionOrValue [] "x")
+                                                [ Node emptyRange <| Operator "-"
                                                 , Node emptyRange <| FunctionOrValue [] "y"
                                                 ]
                                         )
@@ -432,8 +429,8 @@ all =
                     |> Expect.equal
                         (Just
                             (Application
-                                [ Node emptyRange (FunctionOrValue [] "chompWhile")
-                                , Node emptyRange
+                                (Node emptyRange (FunctionOrValue [] "chompWhile"))
+                                [ Node emptyRange
                                     (ParenthesizedExpression
                                         (Node emptyRange
                                             (LambdaExpression
@@ -441,8 +438,8 @@ all =
                                                 , expression =
                                                     Node emptyRange
                                                         (Application
-                                                            [ Node emptyRange (FunctionOrValue [] "c")
-                                                            , Node emptyRange (Operator "==")
+                                                            (Node emptyRange (FunctionOrValue [] "c"))
+                                                            [ Node emptyRange (Operator "==")
                                                             , Node emptyRange (CharLiteral ' ')
                                                             , Node emptyRange (Operator "||")
                                                             , Node emptyRange (FunctionOrValue [] "c")

--- a/tests/tests/Elm/Parser/LambdaExpressionTests.elm
+++ b/tests/tests/Elm/Parser/LambdaExpressionTests.elm
@@ -46,8 +46,8 @@ all =
                                 , expression =
                                     Node emptyRange <|
                                         Application
-                                            [ Node emptyRange <| FunctionOrValue [] "a"
-                                            , Node emptyRange <| Operator "+"
+                                            (Node emptyRange <| FunctionOrValue [] "a")
+                                            [ Node emptyRange <| Operator "+"
                                             , Node emptyRange <| FunctionOrValue [] "b"
                                             ]
                                 }
@@ -67,7 +67,7 @@ all =
                                             , Node emptyRange <| VarPattern "b"
                                             ]
                                     ]
-                                , expression = Node emptyRange <| Application [ Node emptyRange <| FunctionOrValue [] "a", Node emptyRange <| Operator "+", Node emptyRange <| FunctionOrValue [] "b" ]
+                                , expression = Node emptyRange <| Application (Node emptyRange <| FunctionOrValue [] "a") [ Node emptyRange <| Operator "+", Node emptyRange <| FunctionOrValue [] "b" ]
                                 }
                             )
                         )

--- a/tests/tests/Elm/Parser/LetExpressionTests.elm
+++ b/tests/tests/Elm/Parser/LetExpressionTests.elm
@@ -193,9 +193,8 @@ all =
                                                     , expression =
                                                         Node emptyRange <|
                                                             Application
-                                                                [ Node emptyRange <| FunctionOrValue [ "String" ] "length"
-                                                                , Node emptyRange <| FunctionOrValue [] "s"
-                                                                ]
+                                                                (Node emptyRange <| FunctionOrValue [ "String" ] "length")
+                                                                [ Node emptyRange <| FunctionOrValue [] "s" ]
                                                     }
                                             }
                                     ]

--- a/tests/tests/Elm/ProcessingTests.elm
+++ b/tests/tests/Elm/ProcessingTests.elm
@@ -19,13 +19,10 @@ import Test exposing (..)
 functionWithDocs : ( String, String, File )
 functionWithDocs =
     ( "functionWithDocs"
-    , """
-module Bar exposing (..)
-
-{-| The docs
--}
-bar = 1
-"""
+    , "\nmodule Bar exposing (..)\n\n"
+        ++ "{-| The docs\n"
+        ++ "-}\n"
+        ++ "bar = 1\n"
     , { moduleDefinition =
             Node { start = { row = 1, column = 1 }, end = { row = 1, column = 25 } } <|
                 NormalModule
@@ -56,14 +53,11 @@ bar = 1
 functionWithDocsAndSignature : ( String, String, File )
 functionWithDocsAndSignature =
     ( "functionWithDocsAndSignature"
-    , """
-module Bar exposing (..)
-
-{-| The docs
--}
-bar : Int
-bar = 1
-"""
+    , "\nmodule Bar exposing (..)\n\n"
+        ++ "{-| The docs\n"
+        ++ "-}\n"
+        ++ "bar : Int\n"
+        ++ "bar = 1\n"
     , { moduleDefinition =
             Node { start = { row = 1, column = 1 }, end = { row = 1, column = 25 } } <|
                 NormalModule
@@ -101,12 +95,9 @@ bar = 1
 functionWithSingleLineCommentAsDoc : ( String, String, File )
 functionWithSingleLineCommentAsDoc =
     ( "functionWithSingleLineCommentAsDoc"
-    , """
-module Bar exposing (..)
-
---The Doc
-bar = 1
-"""
+    , "\nmodule Bar exposing (..)\n\n"
+        ++ "--The Doc\n"
+        ++ "bar = 1\n"
     , { moduleDefinition =
             Node { start = { row = 1, column = 1 }, end = { row = 1, column = 25 } } <|
                 NormalModule

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -44,16 +44,14 @@ suite =
                     |> Writer.writeFile
                     |> Writer.write
                     |> Expect.equal
-                        ("""module A exposing (..)
-import B  """
-                            ++ "\n"
-                            ++ """import C as D exposing (..)
-"""
+                        ("module A exposing (..)\n"
+                            ++ "import B  \n"
+                            ++ "import C as D exposing (..)\n"
                         )
         , describe "Expression"
             [ test "write simple expression" <|
                 \() ->
-                    (Node emptyRange <| Application [ Node emptyRange <| FunctionOrValue [] "abc", Node emptyRange <| UnitExpr ])
+                    (Node emptyRange <| Application (Node emptyRange <| FunctionOrValue [] "abc") [ Node emptyRange <| UnitExpr ])
                         |> Writer.writeExpression
                         |> Writer.write
                         |> Expect.equal "abc ()"


### PR DESCRIPTION
I went ahead and fixed the impossible state for application expressions mentioned in this issue https://github.com/stil4m/elm-syntax/issues/43

It's now defined as `Application (Node Expression) (List (NodeExpression))` instead of `Application (List (NodeExpression))`.