### PR TITLE
Import module alias can only be a string, not a list of strings

### DIFF
--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -21,13 +21,13 @@ importDefinition =
                 |> Combine.continueWith Layout.layout
                 |> Combine.continueWith (Node.parser moduleName)
 
-        asDefinition : Parser State (Node ModuleName)
+        asDefinition : Parser State (Node String)
         asDefinition =
             asToken
                 |> Combine.continueWith Layout.layout
-                |> Combine.continueWith (Node.parser moduleName)
+                |> Combine.continueWith (Node.parser Elm.Parser.Tokens.typeName)
 
-        parseExposingDefinition : Node ModuleName -> Maybe (Node ModuleName) -> Parser State Import
+        parseExposingDefinition : Node ModuleName -> Maybe (Node String) -> Parser State Import
         parseExposingDefinition mod asDef =
             Combine.choice
                 [ Node.parser exposeDefinition

--- a/src/Elm/Syntax/Import.elm
+++ b/src/Elm/Syntax/Import.elm
@@ -36,7 +36,7 @@ import Json.Encode as JE exposing (Value)
 -}
 type alias Import =
     { moduleName : Node ModuleName
-    , moduleAlias : Maybe (Node ModuleName)
+    , moduleAlias : Maybe (Node String)
     , exposingList : Maybe (Node Exposing)
     }
 
@@ -49,7 +49,7 @@ encode { moduleName, moduleAlias, exposingList } =
         [ ( "moduleName", Node.encode ModuleName.encode moduleName )
         , ( "moduleAlias"
           , moduleAlias
-                |> Maybe.map (Node.encode ModuleName.encode)
+                |> Maybe.map (Node.encode JE.string)
                 |> Maybe.withDefault JE.null
           )
         , ( "exposingList"
@@ -66,5 +66,5 @@ decoder : Decoder Import
 decoder =
     JD.map3 Import
         (JD.field "moduleName" <| Node.decoder ModuleName.decoder)
-        (JD.field "moduleAlias" (JD.nullable <| Node.decoder ModuleName.decoder))
+        (JD.field "moduleAlias" (JD.nullable <| Node.decoder JD.string))
         (JD.field "exposingList" (JD.nullable <| Node.decoder Exposing.decoder))

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -173,7 +173,7 @@ writeImport { moduleName, moduleAlias, exposingList } =
     spaced
         [ string "import"
         , writeModuleName <| Node.value moduleName
-        , maybe (Maybe.map (Node.value >> writeModuleName >> (\x -> spaced [ string "as", x ])) moduleAlias)
+        , maybe (Maybe.map (Node.value >> string >> (\x -> spaced [ string "as", x ])) moduleAlias)
         , maybe (Maybe.map (Node.value >> writeExposureExpose) exposingList)
         ]
 

--- a/tests/tests/Elm/Parser/ImportsTests.elm
+++ b/tests/tests/Elm/Parser/ImportsTests.elm
@@ -64,7 +64,7 @@ all =
                         (Just <|
                             Node emptyRange <|
                                 { moduleName = Node emptyRange <| [ "Foo" ]
-                                , moduleAlias = Just <| Node emptyRange <| [ "Bar" ]
+                                , moduleAlias = Just <| Node emptyRange <| "Bar"
                                 , exposingList = Nothing
                                 }
                         )

--- a/tests/tests/Elm/Syntax/ImportTests.elm
+++ b/tests/tests/Elm/Syntax/ImportTests.elm
@@ -28,7 +28,7 @@ suite =
         [ describe "serialization"
             [ test "case 1" <|
                 \() ->
-                    symmetric (Import (Node emptyRange [ "A", "B" ]) (Just <| Node emptyRange [ "C" ]) (Just <| Node emptyRange <| All emptyRange))
+                    symmetric (Import (Node emptyRange [ "A", "B" ]) (Just <| Node emptyRange "C") (Just <| Node emptyRange <| All emptyRange))
                         Import.encode
                         Import.decoder
             , test "import Html exposing (beginnerProgram, div, button, text)" <|

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -34,7 +34,7 @@ suite =
                         }
                     , Node emptyRange
                         { moduleName = Node emptyRange <| [ "C" ]
-                        , moduleAlias = Just (Node emptyRange [ "D" ])
+                        , moduleAlias = Just (Node emptyRange "D")
                         , exposingList = Just (Node emptyRange <| All emptyRange)
                         }
                     ]


### PR DESCRIPTION
Fix for https://github.com/stil4m/elm-syntax/issues/44