### PR TITLE
Fix typos in Elm.Syntax.Type

### DIFF
--- a/src/Elm/Syntax/Type.elm
+++ b/src/Elm/Syntax/Type.elm
@@ -3,12 +3,15 @@ module Elm.Syntax.Type exposing
     , encode, decoder
     )
 
-{-| #Type Syntax
+{-|
+
+
+# Type Syntax
 
 This syntax represents custom types.
 For example:
 
-    {-| This is a person
+    {-| This is a color
     -}
     type Color
         = Blue
@@ -33,7 +36,7 @@ import Json.Decode as JD exposing (Decoder)
 import Json.Encode as JE exposing (Value)
 
 
-{-| Type alias that deines the syntax for a custom type.
+{-| Type alias that defines the syntax for a custom type.
 All information that you can define in on type alias is embedded.
 -}
 type alias Type =
@@ -44,7 +47,7 @@ type alias Type =
     }
 
 
-{-| Syntax for a custom type value constructor
+{-| Syntax for a custom type value constructor.
 -}
 type alias ValueConstructor =
     { name : Node String


### PR DESCRIPTION
- The title was not showing up as expected.
- Fixed the example documentation
- Added dots at the end of sentences for consistency.

The documentation for [`Type`](https://package.elm-lang.org/packages/stil4m/elm-syntax/latest/Elm-Syntax-Type) still has a sentence which I can't make sense of, and I am not sure how it should be fixed:

> All information that you can define in on type alias is embedded.

Also, I fixed the title, but I am not sure it is necessary, since the packages website already puts the title at the top of the page, which is now duplicated information. This duplication looks to be there on every exposed module.