### PR TITLE
Fix operator precedence

### DIFF
--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -228,12 +228,12 @@ findNextSplit dict exps =
 lowestPrecedence : List ( String, Infix ) -> Dict String Infix
 lowestPrecedence input =
     let
-        maxi =
+        mini =
             input
                 |> List.map (Tuple.second >> .precedence >> Node.value)
                 |> List.minimum
     in
-    maxi
+    mini
         |> Maybe.map (\m -> List.filter (Tuple.second >> .precedence >> Node.value >> (==) m) input)
         |> Maybe.withDefault []
         |> Dict.fromList

--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -38,7 +38,7 @@ import Elm.Syntax.Infix exposing (Infix, InfixDirection(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range as Range
-import List exposing (maximum)
+import List
 import List.Extra as List
 
 
@@ -167,7 +167,7 @@ fixApplication operators head expressions =
                                 }
                         )
                     )
-                |> highestPrecedence
+                |> lowestPrecedence
 
         fixExprs : List (Node Expression) -> Expression
         fixExprs exps =
@@ -225,13 +225,13 @@ findNextSplit dict exps =
         |> Maybe.map (\x -> ( prefix, x, suffix ))
 
 
-highestPrecedence : List ( String, Infix ) -> Dict String Infix
-highestPrecedence input =
+lowestPrecedence : List ( String, Infix ) -> Dict String Infix
+lowestPrecedence input =
     let
         maxi =
             input
                 |> List.map (Tuple.second >> .precedence >> Node.value)
-                |> maximum
+                |> List.minimum
     in
     maxi
         |> Maybe.map (\m -> List.filter (Tuple.second >> .precedence >> Node.value >> (==) m) input)

--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -227,13 +227,9 @@ findNextSplit dict exps =
 
 lowestPrecedence : List ( String, Infix ) -> Dict String Infix
 lowestPrecedence input =
-    let
-        mini =
-            input
-                |> List.map (Tuple.second >> .precedence >> Node.value)
-                |> List.minimum
-    in
-    mini
+    input
+        |> List.map (Tuple.second >> .precedence >> Node.value)
+        |> List.minimum
         |> Maybe.map (\m -> List.filter (Tuple.second >> .precedence >> Node.value >> (==) m) input)
         |> Maybe.withDefault []
         |> Dict.fromList


### PR DESCRIPTION
This should fix https://github.com/stil4m/elm-syntax/issues/41

As far as I can tell, two problems occurred. One was a bug in elm-syntax and one was a mistake in the bug report. 

The bug in elm-syntax (which this PR fixes) is that operator precedence is handled in reverse order. So in `1 * 2 + 3`, elm-syntax would incorrectly parse it as `1 * (2 + 3)`. It should now correctly parse it as `(1 * 2) + 3`

The mistake with the bug report was that, unless the operator definitions are also parsed, elm-syntax treats all operators with the same precedence. This is why, in the bug report SSCCE, elm-syntax appeared to have no handling for operator precedence and would just nest operators left to right.

@stil4m Assuming I've gotten all this right, can this be made as a patch release? (as opposed to getting bundled with breaking changes and waiting until a major release)