### PR TITLE
Make sure RecordUpdateExpression has at least one field 

### DIFF
--- a/src/Elm/Inspector.elm
+++ b/src/Elm/Inspector.elm
@@ -371,10 +371,10 @@ inspectInnerExpression config expression context =
         RecordExpr expressionStringList ->
             List.foldl (\a b -> inspectExpression config (Tuple.second <| Node.value a) b) context expressionStringList
 
-        RecordUpdateExpression name updates ->
+        RecordUpdateExpression name firstUpdate updates ->
             actionLambda config.onRecordUpdate
-                (\c -> List.foldl (\a b -> inspectExpression config (Tuple.second <| Node.value a) b) c updates)
-                ( name, updates )
+                (\c -> List.foldl (\a b -> inspectExpression config (Tuple.second <| Node.value a) b) c (firstUpdate :: updates))
+                ( name, firstUpdate :: updates )
                 context
 
 

--- a/src/Elm/Inspector.elm
+++ b/src/Elm/Inspector.elm
@@ -46,7 +46,7 @@ type alias Config context =
     , onCase : Order context Case
     , onFunctionOrValue : Order context ( ModuleName, String )
     , onRecordAccess : Order context ( Node Expression, Node String )
-    , onRecordUpdate : Order context ( Node String, List (Node RecordSetter) )
+    , onRecordUpdate : Order context ( Node String, Node RecordSetter, List (Node RecordSetter) )
     }
 
 
@@ -374,7 +374,7 @@ inspectInnerExpression config expression context =
         RecordUpdateExpression name firstUpdate updates ->
             actionLambda config.onRecordUpdate
                 (\c -> List.foldl (\a b -> inspectExpression config (Tuple.second <| Node.value a) b) c (firstUpdate :: updates))
-                ( name, firstUpdate :: updates )
+                ( name, firstUpdate, updates )
                 context
 
 

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -326,7 +326,15 @@ recordExpression =
                     string "|"
                         |> Combine.ignore (maybe Layout.layout)
                         |> Combine.continueWith recordFields
-                        |> Combine.map (\e -> RecordUpdateExpression fname e)
+                        |> Combine.andThen
+                            (\e ->
+                                case e of
+                                    head :: rest ->
+                                        RecordUpdateExpression fname head rest |> Combine.succeed
+
+                                    [] ->
+                                        Combine.fail "Record update must have at least one field being updated."
+                            )
                         |> Combine.ignore (string "}")
 
                 recordContents : Parser State Expression

--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -371,10 +371,11 @@ visitExpressionInner visitor context (Node range expression) =
             ListExpr expressionList ->
                 ListExpr (List.map subVisit expressionList)
 
-            RecordUpdateExpression name updates ->
-                updates
-                    |> List.map (Node.map (Tuple.mapSecond subVisit))
-                    |> RecordUpdateExpression name
+            RecordUpdateExpression name firstUpdate updates ->
+                RecordUpdateExpression
+                    name
+                    (Node.map (Tuple.mapSecond subVisit) firstUpdate)
+                    (List.map (Node.map (Tuple.mapSecond subVisit)) updates)
 
             _ ->
                 expression

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -106,7 +106,7 @@ type Expression
     | ListExpr (List (Node Expression))
     | RecordAccess (Node Expression) (Node String)
     | RecordAccessFunction String
-    | RecordUpdateExpression (Node String) (List (Node RecordSetter))
+    | RecordUpdateExpression (Node String) (Node RecordSetter) (List (Node RecordSetter))
     | GLSLExpression String
 
 
@@ -308,8 +308,8 @@ encode expr =
         RecordExpr xs ->
             encodeTyped "record" (JE.list (Node.encode encodeRecordSetter) xs)
 
-        RecordUpdateExpression name updates ->
-            encodeTyped "recordUpdate" (encodeRecordUpdate name updates)
+        RecordUpdateExpression name firstUpdate updates ->
+            encodeTyped "recordUpdate" (encodeRecordUpdate name firstUpdate updates)
 
         GLSLExpression x ->
             encodeTyped "glsl" (JE.string x)
@@ -333,11 +333,11 @@ encodeLetBlock { declarations, expression } =
         ]
 
 
-encodeRecordUpdate : Node String -> List (Node RecordSetter) -> Value
-encodeRecordUpdate name updates =
+encodeRecordUpdate : Node String -> Node RecordSetter -> List (Node RecordSetter) -> Value
+encodeRecordUpdate name firstUpdate updates =
     JE.object
         [ ( "name", Node.encode JE.string name )
-        , ( "updates", JE.list (Node.encode encodeRecordSetter) updates )
+        , ( "updates", JE.list (Node.encode encodeRecordSetter) (firstUpdate :: updates) )
         ]
 
 
@@ -416,6 +416,20 @@ decodeNested =
     JD.lazy (\() -> Node.decoder decoder)
 
 
+decodeNonemptyList : Decoder a -> Decoder ( a, List a )
+decodeNonemptyList decodeA =
+    JD.list decodeA
+        |> JD.andThen
+            (\list ->
+                case list of
+                    head :: rest ->
+                        JD.succeed ( head, rest )
+
+                    [] ->
+                        JD.fail "List must have at least one element."
+            )
+
+
 {-| JSON decoder for an `Expression` syntax element.
 -}
 decoder : Decoder Expression
@@ -425,16 +439,7 @@ decoder =
             decodeTyped
                 [ ( "unit", JD.succeed UnitExpr )
                 , ( "application"
-                  , JD.list decodeNested
-                        |> JD.andThen
-                            (\list ->
-                                case list of
-                                    head :: rest ->
-                                        Application head rest |> JD.succeed
-
-                                    [] ->
-                                        JD.fail "Application expression must have at least one subexpression."
-                            )
+                  , decodeNonemptyList decodeNested |> JD.map (\( head, rest ) -> Application head rest)
                   )
                 , ( "operatorapplication", decodeOperatorApplication )
                 , ( "functionOrValue", JD.map2 FunctionOrValue (JD.field "moduleName" ModuleName.decoder) (JD.field "name" JD.string) )
@@ -457,9 +462,9 @@ decoder =
                 , ( "recordAccessFunction", JD.string |> JD.map RecordAccessFunction )
                 , ( "record", JD.list (Node.decoder decodeRecordSetter) |> JD.map RecordExpr )
                 , ( "recordUpdate"
-                  , JD.map2 RecordUpdateExpression
+                  , JD.map2 (\name ( firstUpdate, restOfUpdates ) -> RecordUpdateExpression name firstUpdate restOfUpdates)
                         (JD.field "name" <| Node.decoder JD.string)
-                        (JD.field "updates" (JD.list <| Node.decoder decodeRecordSetter))
+                        (JD.field "updates" (decodeNonemptyList <| Node.decoder decodeRecordSetter))
                   )
                 , ( "glsl", JD.string |> JD.map GLSLExpression )
                 ]

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -539,12 +539,12 @@ writeExpression (Node range inner) =
         RecordAccessFunction s ->
             join [ string ".", string s ]
 
-        RecordUpdateExpression name updates ->
+        RecordUpdateExpression name firstUpdate updates ->
             spaced
                 [ string "{"
                 , string <| Node.value name
                 , string "|"
-                , sepHelper sepByComma (List.map (Node.value >> writeRecordSetter) updates)
+                , sepHelper sepByComma (List.map (Node.value >> writeRecordSetter) (firstUpdate :: updates))
                 , string "}"
                 ]
 

--- a/tests/tests/Elm/Parser/CombineTestUtil.elm
+++ b/tests/tests/Elm/Parser/CombineTestUtil.elm
@@ -382,8 +382,11 @@ noRangeInnerExpression inner =
                     , args = List.map noRangePattern lambda.args
                 }
 
-        RecordUpdateExpression name updates ->
-            RecordUpdateExpression (unRanged identity name) (List.map (unRanged noRangeRecordSetter) updates)
+        RecordUpdateExpression name firstUpdate updates ->
+            RecordUpdateExpression
+                (unRanged identity name)
+                (unRanged noRangeRecordSetter firstUpdate)
+                (List.map (unRanged noRangeRecordSetter) updates)
 
         CaseExpression { cases, expression } ->
             CaseExpression

--- a/tests/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/tests/Elm/Parser/ExpressionTests.elm
@@ -331,9 +331,8 @@ all =
                         (Just
                             (RecordUpdateExpression
                                 (Node emptyRange "model")
-                                [ Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 )
-                                , Node emptyRange ( Node emptyRange "loading", Node emptyRange <| FunctionOrValue [] "True" )
-                                ]
+                                ( Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 ))
+                                [ Node emptyRange ( Node emptyRange "loading", Node emptyRange <| FunctionOrValue [] "True" ) ]
                             )
                         )
         , test "record update no spacing" <|
@@ -345,9 +344,8 @@ all =
                         (Just
                             (RecordUpdateExpression
                                 (Node emptyRange "model")
-                                [ Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 )
-                                , Node emptyRange ( Node emptyRange "loading", Node emptyRange <| FunctionOrValue [] "True" )
-                                ]
+                                ( Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 ) )
+                                [ Node emptyRange ( Node emptyRange "loading", Node emptyRange <| FunctionOrValue [] "True" ) ]
                             )
                         )
         , test "record access as function" <|

--- a/tests/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/tests/Elm/Parser/ExpressionTests.elm
@@ -331,7 +331,7 @@ all =
                         (Just
                             (RecordUpdateExpression
                                 (Node emptyRange "model")
-                                ( Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 ))
+                                (Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 ))
                                 [ Node emptyRange ( Node emptyRange "loading", Node emptyRange <| FunctionOrValue [] "True" ) ]
                             )
                         )
@@ -344,7 +344,7 @@ all =
                         (Just
                             (RecordUpdateExpression
                                 (Node emptyRange "model")
-                                ( Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 ) )
+                                (Node emptyRange ( Node emptyRange "count", Node emptyRange <| Integer 1 ))
                                 [ Node emptyRange ( Node emptyRange "loading", Node emptyRange <| FunctionOrValue [] "True" ) ]
                             )
                         )


### PR DESCRIPTION
I've changed `RecordUpdateExpression (Node String) (List (Node RecordSetter))` to `RecordUpdateExpression (Node String) (Node RecordSetter) (List (Node RecordSetter))` to make sure it's not possible to have a record update with no fields.

This fixes the first bullet point in this issue https://github.com/stil4m/elm-syntax/issues/43