### PR TITLE
Compare Ranges

### DIFF
--- a/src/Elm/Syntax/Range.elm
+++ b/src/Elm/Syntax/Range.elm
@@ -1,7 +1,7 @@
 module Elm.Syntax.Range exposing
     ( Range, Location
     , emptyRange, combine
-    , compareLocations, comparePositions
+    , compare, compareLocations
     , encode, decoder
     )
 
@@ -22,7 +22,7 @@ module Elm.Syntax.Range exposing
 
 See also [Basics.compare](https://package.elm-lang.org/packages/elm/core/latest/Basics#compare).
 
-@docs compareLocations, comparePositions
+@docs compare, compareLocations
 
 
 # Json
@@ -119,8 +119,8 @@ sortLocations =
 
 {-| Compare the position of two Ranges.
 -}
-comparePositions : Range -> Range -> Order
-comparePositions left right =
+compare : Range -> Range -> Order
+compare left right =
     case compareLocations left.start right.start of
         EQ ->
             compareLocations left.end right.end
@@ -140,4 +140,4 @@ compareLocations left right =
         GT
 
     else
-        compare left.column right.column
+        Basics.compare left.column right.column

--- a/src/Elm/Syntax/Range.elm
+++ b/src/Elm/Syntax/Range.elm
@@ -1,7 +1,7 @@
 module Elm.Syntax.Range exposing
     ( Range, Location
     , emptyRange, combine
-    , compareLocations
+    , compareLocations, comparePositions
     , encode, decoder
     )
 
@@ -22,7 +22,7 @@ module Elm.Syntax.Range exposing
 
 See also [Basics.compare](https://package.elm-lang.org/packages/elm/core/latest/Basics#compare).
 
-@docs compareLocations
+@docs compareLocations, comparePositions
 
 
 # Json
@@ -115,6 +115,18 @@ combine ranges =
 sortLocations : List Location -> List Location
 sortLocations =
     List.sortWith compareLocations
+
+
+{-| Compare the position of two Ranges.
+-}
+comparePositions : Range -> Range -> Order
+comparePositions left right =
+    case compareLocations left.start right.start of
+        EQ ->
+            compareLocations left.end right.end
+
+        order ->
+            order
 
 
 {-| Compare two Locations.

--- a/src/Elm/Syntax/Range.elm
+++ b/src/Elm/Syntax/Range.elm
@@ -1,6 +1,7 @@
 module Elm.Syntax.Range exposing
     ( Range, Location
     , emptyRange, combine
+    , compareLocations
     , encode, decoder
     )
 
@@ -15,6 +16,13 @@ module Elm.Syntax.Range exposing
 # Functions
 
 @docs emptyRange, combine
+
+
+# Comparison
+
+See also [Basics.compare](https://package.elm-lang.org/packages/elm/core/latest/Basics#compare).
+
+@docs compareLocations
 
 
 # Json
@@ -109,12 +117,14 @@ sortLocations =
     List.sortWith compareLocations
 
 
+{-| Compare two Locations.
+-}
 compareLocations : Location -> Location -> Order
 compareLocations left right =
     if left.row < right.row then
         LT
 
-    else if right.row < left.row then
+    else if left.row > right.row then
         GT
 
     else

--- a/tests/tests/Elm/Syntax/RangeTests.elm
+++ b/tests/tests/Elm/Syntax/RangeTests.elm
@@ -1,6 +1,6 @@
 module Elm.Syntax.RangeTests exposing (suite)
 
-import Elm.Syntax.Range as Range
+import Elm.Syntax.Range as Range exposing (Range)
 import Expect
 import Test exposing (Test, describe, test)
 
@@ -9,6 +9,7 @@ suite : Test
 suite =
     describe "Elm.Syntax.Range"
         [ describe "compareLocations" compareLocationsTests
+        , describe "comparePositions" comparePositionsTests
         ]
 
 
@@ -79,6 +80,88 @@ compareLocationsTests =
                         { left | column = 3 }
                 in
                 Range.compareLocations left right
+                    |> Expect.equal GT
+        ]
+    ]
+
+
+comparePositionsTests : List Test
+comparePositionsTests =
+    [ describe "EQ"
+        [ test "when ranges are equal" <|
+            \() ->
+                let
+                    range : Range
+                    range =
+                        { start = { row = 1, column = 2 }
+                        , end = { row = 3, column = 4 }
+                        }
+                in
+                Range.comparePositions range range
+                    |> Expect.equal EQ
+        ]
+    , describe "LT"
+        [ test "when left start < right start" <|
+            \() ->
+                let
+                    left : Range
+                    left =
+                        { start = { row = 1, column = 1 }
+                        , end = { row = 1, column = 2 }
+                        }
+
+                    right : Range
+                    right =
+                        { left | end = { row = 2, column = 2 } }
+                in
+                Range.comparePositions left right
+                    |> Expect.equal LT
+        , test "when left start == right start and left end < right end" <|
+            \() ->
+                let
+                    left : Range
+                    left =
+                        { start = { row = 2, column = 1 }
+                        , end = { row = 2, column = 3 }
+                        }
+
+                    right : Range
+                    right =
+                        { left | end = { row = 2, column = 9 } }
+                in
+                Range.comparePositions left right
+                    |> Expect.equal LT
+        ]
+    , describe "GT"
+        [ test "when left start > right start" <|
+            \() ->
+                let
+                    left : Range
+                    left =
+                        { start = { row = 5, column = 6 }
+                        , end = { row = 5, column = 7 }
+                        }
+
+                    right : Range
+                    right =
+                        { left | start = { row = 5, column = 2 } }
+                in
+                Range.comparePositions left right
+                    |> Expect.equal GT
+        , test "when left start == right start and left end > right end" <|
+            \() ->
+                let
+                    left : Range
+                    left =
+                        { start = { row = 5, column = 2 }
+                        , end = { row = 5, column = 9 }
+                        }
+
+                    right : Range
+                    right =
+                        { left | end = { row = 5, column = 4 } }
+                in
+                Range.comparePositions left right
                     |> Expect.equal GT
         ]
     ]

--- a/tests/tests/Elm/Syntax/RangeTests.elm
+++ b/tests/tests/Elm/Syntax/RangeTests.elm
@@ -8,9 +8,97 @@ import Test exposing (Test, describe, test)
 suite : Test
 suite =
     describe "Elm.Syntax.Range"
-        [ describe "compareLocations" compareLocationsTests
+        [ describe "combine" combineTests
+        , describe "compareLocations" compareLocationsTests
         , describe "comparePositions" comparePositionsTests
         ]
+
+
+combineTests : List Test
+combineTests =
+    [ test "given an empty list is an empty range" <|
+        \() ->
+            Range.combine []
+                |> Expect.equal Range.emptyRange
+    , test "given a singleton list is the same range" <|
+        \() ->
+            let
+                range : Range
+                range =
+                    { start = { row = 1, column = 1 }
+                    , end = { row = 1, column = 9 }
+                    }
+            in
+            Range.combine [ range ]
+                |> Expect.equal range
+    , test "given a list of ranges, where one covers all the others, gives that range" <|
+        \() ->
+            let
+                outerRange : Range
+                outerRange =
+                    { start = { row = 1, column = 1 }
+                    , end = { row = 5, column = 100 }
+                    }
+
+                ranges : List Range
+                ranges =
+                    [ outerRange
+                    , { start = { row = 2, column = 1 }
+                      , end = { row = 2, column = 9 }
+                      }
+                    , { start = { row = 3, column = 5 }
+                      , end = { row = 4, column = 15 }
+                      }
+                    ]
+            in
+            Range.combine ranges
+                |> Expect.equal outerRange
+    , test "given a list of distinct ranges where none overlap, gives a range over all" <|
+        \() ->
+            let
+                outerRange : Range
+                outerRange =
+                    { start = { row = 2, column = 1 }
+                    , end = { row = 10, column = 69 }
+                    }
+
+                ranges : List Range
+                ranges =
+                    [ { start = outerRange.start
+                      , end = { row = 2, column = 21 }
+                      }
+                    , { start = { row = 4, column = 6 }
+                      , end = { row = 4, column = 100 }
+                      }
+                    , { start = { row = 9, column = 5 }
+                      , end = outerRange.end
+                      }
+                    ]
+            in
+            Range.combine ranges
+                |> Expect.equal outerRange
+    , test "given overlapping ranges, gives a range over both" <|
+        \() ->
+            let
+                outerRange : Range
+                outerRange =
+                    { start = { row = 1, column = 23 }
+                    , end = { row = 32, column = 5 }
+                    }
+
+                ranges : List Range
+                ranges =
+                    [ { start = { row = 15, column = 1 }
+                      , end = outerRange.end
+                      }
+                    , { start = outerRange.start
+                      , end = { row = 16, column = 27 }
+                      }
+                    ]
+            in
+            Range.combine ranges
+                |> Expect.equal outerRange
+    ]
 
 
 compareLocationsTests : List Test

--- a/tests/tests/Elm/Syntax/RangeTests.elm
+++ b/tests/tests/Elm/Syntax/RangeTests.elm
@@ -9,8 +9,8 @@ suite : Test
 suite =
     describe "Elm.Syntax.Range"
         [ describe "combine" combineTests
+        , describe "compare" compareTests
         , describe "compareLocations" compareLocationsTests
-        , describe "comparePositions" comparePositionsTests
         ]
 
 
@@ -173,8 +173,8 @@ compareLocationsTests =
     ]
 
 
-comparePositionsTests : List Test
-comparePositionsTests =
+compareTests : List Test
+compareTests =
     [ describe "EQ"
         [ test "when ranges are equal" <|
             \() ->
@@ -185,7 +185,7 @@ comparePositionsTests =
                         , end = { row = 3, column = 4 }
                         }
                 in
-                Range.comparePositions range range
+                Range.compare range range
                     |> Expect.equal EQ
         ]
     , describe "LT"
@@ -202,7 +202,7 @@ comparePositionsTests =
                     right =
                         { left | end = { row = 2, column = 2 } }
                 in
-                Range.comparePositions left right
+                Range.compare left right
                     |> Expect.equal LT
         , test "when left start == right start and left end < right end" <|
             \() ->
@@ -217,7 +217,7 @@ comparePositionsTests =
                     right =
                         { left | end = { row = 2, column = 9 } }
                 in
-                Range.comparePositions left right
+                Range.compare left right
                     |> Expect.equal LT
         ]
     , describe "GT"
@@ -234,7 +234,7 @@ comparePositionsTests =
                     right =
                         { left | start = { row = 5, column = 2 } }
                 in
-                Range.comparePositions left right
+                Range.compare left right
                     |> Expect.equal GT
         , test "when left start == right start and left end > right end" <|
             \() ->
@@ -249,7 +249,7 @@ comparePositionsTests =
                     right =
                         { left | end = { row = 5, column = 4 } }
                 in
-                Range.comparePositions left right
+                Range.compare left right
                     |> Expect.equal GT
         ]
     ]

--- a/tests/tests/Elm/Syntax/RangeTests.elm
+++ b/tests/tests/Elm/Syntax/RangeTests.elm
@@ -1,0 +1,84 @@
+module Elm.Syntax.RangeTests exposing (suite)
+
+import Elm.Syntax.Range as Range
+import Expect
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "Elm.Syntax.Range"
+        [ describe "compareLocations" compareLocationsTests
+        ]
+
+
+compareLocationsTests : List Test
+compareLocationsTests =
+    [ describe "EQ"
+        [ test "when locations are equal" <|
+            \() ->
+                let
+                    location : Range.Location
+                    location =
+                        { row = 1, column = 3 }
+                in
+                Range.compareLocations location location
+                    |> Expect.equal EQ
+        ]
+    , describe "LT"
+        [ test "when left row < right row" <|
+            \() ->
+                let
+                    left : Range.Location
+                    left =
+                        { row = 1, column = 1 }
+
+                    right : Range.Location
+                    right =
+                        { left | row = 3 }
+                in
+                Range.compareLocations left right
+                    |> Expect.equal LT
+        , test "when left row == right row and left column < right column" <|
+            \() ->
+                let
+                    left : Range.Location
+                    left =
+                        { row = 1, column = 1 }
+
+                    right : Range.Location
+                    right =
+                        { left | column = 3 }
+                in
+                Range.compareLocations left right
+                    |> Expect.equal LT
+        ]
+    , describe "GT"
+        [ test "when left row > right row" <|
+            \() ->
+                let
+                    left : Range.Location
+                    left =
+                        { row = 3, column = 4 }
+
+                    right : Range.Location
+                    right =
+                        { left | row = 2 }
+                in
+                Range.compareLocations left right
+                    |> Expect.equal GT
+        , test "when left row == right row and left column > right column" <|
+            \() ->
+                let
+                    left : Range.Location
+                    left =
+                        { row = 2, column = 6 }
+
+                    right : Range.Location
+                    right =
+                        { left | column = 3 }
+                in
+                Range.compareLocations left right
+                    |> Expect.equal GT
+        ]
+    ]


### PR DESCRIPTION
This adds tests for `Range.combine` and adds new comparison functions:

* `Range.compare : Range -> Range -> Order`
* `Range.compareLocations : Range.Location -> Range.Location -> Order`

~~After a discussion with @stil4m we settled on `Range.comparePositions` rather than simply `Range.compare` so that there's no confusion about what dimension is being compared (i.e., position or size). There's no easy way to get the size of a range so that comparison is not provided.~~