### PR TITLE
Require at least one case statement to appear in case block

### DIFF
--- a/src/Elm/Inspector.elm
+++ b/src/Elm/Inspector.elm
@@ -346,7 +346,7 @@ inspectInnerExpression config expression context =
                     inspectExpression config caseBlock.expression context
 
                 context3 =
-                    List.foldl (\a b -> inspectCase config a b) context2 caseBlock.cases
+                    List.foldl (\a b -> inspectCase config a b) context2 (caseBlock.firstCase :: caseBlock.restOfCases)
             in
             context3
 

--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -357,7 +357,8 @@ visitExpressionInner visitor context (Node range expression) =
             CaseExpression caseBlock ->
                 CaseExpression
                     { expression = subVisit caseBlock.expression
-                    , cases = List.map (Tuple.mapSecond subVisit) caseBlock.cases
+                    , firstCase = Tuple.mapSecond subVisit caseBlock.firstCase
+                    , restOfCases = List.map (Tuple.mapSecond subVisit) caseBlock.restOfCases
                     }
 
             LambdaExpression lambda ->

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -1,5 +1,5 @@
 module Elm.Syntax.Expression exposing
-    ( Expression(..), Lambda, LetBlock, LetDeclaration(..), RecordSetter, CaseBlock, Cases, Case, Function, FunctionImplementation
+    ( Expression(..), Lambda, LetBlock, LetDeclaration(..), RecordSetter, CaseBlock, Case, Function, FunctionImplementation
     , functionRange, isLambda, isLet, isIfElse, isCase, isOperatorApplication
     , encode, encodeFunction, decoder, functionDecoder
     )
@@ -15,7 +15,7 @@ Although it is a easy and simple language, you can express a lot! See the `Expre
 
 ## Types
 
-@docs Expression, Lambda, LetBlock, LetDeclaration, RecordSetter, CaseBlock, Cases, Case, Function, FunctionImplementation
+@docs Expression, Lambda, LetBlock, LetDeclaration, RecordSetter, CaseBlock, Case, Function, FunctionImplementation
 
 
 ## Functions
@@ -143,7 +143,8 @@ type alias Lambda =
 -}
 type alias CaseBlock =
     { expression : Node Expression
-    , cases : Cases
+    , firstCase : Case
+    , restOfCases : List Case
     }
 
 
@@ -151,12 +152,6 @@ type alias CaseBlock =
 -}
 type alias Case =
     ( Node Pattern, Node Expression )
-
-
-{-| Type alias for a list of cases
--}
-type alias Cases =
-    List Case
 
 
 {-| Check whether an expression is a lambda-expression
@@ -389,9 +384,10 @@ encodeDestructuring pattern expression =
 
 
 encodeCaseBlock : CaseBlock -> Value
-encodeCaseBlock { cases, expression } =
+encodeCaseBlock { firstCase, restOfCases, expression } =
     JE.object
-        [ ( "cases", JE.list encodeCase cases )
+        [ ( "restOfCases", JE.list encodeCase restOfCases )
+        , ( "firstCase", encodeCase firstCase )
         , ( "expression", Node.encode encode expression )
         ]
 
@@ -497,9 +493,10 @@ decodeCaseBlock : Decoder CaseBlock
 decodeCaseBlock =
     JD.lazy
         (\() ->
-            JD.map2 CaseBlock
+            JD.map3 CaseBlock
                 (JD.field "expression" decodeNested)
-                (JD.field "cases" (JD.list decodeCase))
+                (JD.field "firstCase" decodeCase)
+                (JD.field "restOfCases" (JD.list decodeCase))
         )
 
 

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -501,6 +501,7 @@ writeExpression (Node range inner) =
 
         CaseExpression caseBlock ->
             let
+                writeCaseBranch : ( Node Pattern, Node Expression ) -> Writer
                 writeCaseBranch ( pattern, expression ) =
                     indent 2 <|
                         breaked
@@ -510,7 +511,7 @@ writeExpression (Node range inner) =
             in
             breaked
                 [ spaced [ string "case", writeExpression caseBlock.expression, string "of" ]
-                , breaked (List.map writeCaseBranch caseBlock.cases)
+                , breaked (List.map writeCaseBranch (caseBlock.firstCase :: caseBlock.restOfCases))
                 ]
 
         LambdaExpression lambda ->

--- a/tests/tests/Elm/Parser/CombineTestUtil.elm
+++ b/tests/tests/Elm/Parser/CombineTestUtil.elm
@@ -382,12 +382,10 @@ noRangeInnerExpression inner =
                 (unRanged noRangeRecordSetter firstUpdate)
                 (List.map (unRanged noRangeRecordSetter) updates)
 
-        CaseExpression { cases, expression } ->
+        CaseExpression { firstCase, restOfCases, expression } ->
             CaseExpression
-                { cases =
-                    cases
-                        |> List.map (Tuple.mapFirst noRangePattern)
-                        |> List.map (Tuple.mapSecond noRangeExpression)
+                { firstCase = Tuple.mapBoth noRangePattern noRangeExpression firstCase
+                , restOfCases = List.map (Tuple.mapBoth noRangePattern noRangeExpression) restOfCases
                 , expression = noRangeExpression expression
                 }
 

--- a/tests/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/tests/Elm/Parser/DeclarationsTests.elm
@@ -161,11 +161,11 @@ all =
                                                                         , expression =
                                                                             Node emptyRange <|
                                                                                 CaseExpression
-                                                                                    { cases =
-                                                                                        [ ( Node emptyRange <| NamedPattern { moduleName = [], name = "True" } []
-                                                                                          , Node emptyRange <| FunctionOrValue [] "z"
-                                                                                          )
-                                                                                        ]
+                                                                                    { firstCase =
+                                                                                        ( Node emptyRange <| NamedPattern { moduleName = [], name = "True" } []
+                                                                                        , Node emptyRange <| FunctionOrValue [] "z"
+                                                                                        )
+                                                                                    , restOfCases = []
                                                                                     , expression = Node emptyRange <| FunctionOrValue [] "x"
                                                                                     }
                                                                         , name = Node emptyRange "y"
@@ -318,16 +318,17 @@ all =
                                             Node emptyRange <|
                                                 CaseExpression
                                                     { expression = Node emptyRange <| FunctionOrValue [] "msg"
-                                                    , cases =
-                                                        [ ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Increment") []
-                                                          , Node emptyRange <|
-                                                                Application
-                                                                    (Node emptyRange <| FunctionOrValue [] "model")
-                                                                    [ Node emptyRange <| Operator "+"
-                                                                    , Node emptyRange <| Integer 1
-                                                                    ]
-                                                          )
-                                                        , ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Decrement") []
+                                                    , firstCase =
+                                                        ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Increment") []
+                                                        , Node emptyRange <|
+                                                            Application
+                                                                (Node emptyRange <| FunctionOrValue [] "model")
+                                                                [ Node emptyRange <| Operator "+"
+                                                                , Node emptyRange <| Integer 1
+                                                                ]
+                                                        )
+                                                    , restOfCases =
+                                                        [ ( Node emptyRange <| NamedPattern (QualifiedNameRef [] "Decrement") []
                                                           , Node emptyRange <|
                                                                 Application
                                                                     (Node emptyRange <| FunctionOrValue [] "model")
@@ -495,16 +496,17 @@ all =
                                         , expression =
                                             Node emptyRange <|
                                                 CaseExpression
-                                                    { cases =
-                                                        [ ( Node emptyRange <| NamedPattern { moduleName = [], name = "Increment" } []
-                                                          , Node emptyRange <|
-                                                                Application
-                                                                    (Node emptyRange <| FunctionOrValue [] "model")
-                                                                    [ Node emptyRange <| Operator "+"
-                                                                    , Node emptyRange <| Integer 1
-                                                                    ]
-                                                          )
-                                                        , ( Node emptyRange <| NamedPattern { moduleName = [], name = "Decrement" } []
+                                                    { firstCase =
+                                                        ( Node emptyRange <| NamedPattern { moduleName = [], name = "Increment" } []
+                                                        , Node emptyRange <|
+                                                            Application
+                                                                (Node emptyRange <| FunctionOrValue [] "model")
+                                                                [ Node emptyRange <| Operator "+"
+                                                                , Node emptyRange <| Integer 1
+                                                                ]
+                                                        )
+                                                    , restOfCases =
+                                                        [ ( Node emptyRange <| NamedPattern { moduleName = [], name = "Decrement" } []
                                                           , Node emptyRange <|
                                                                 Application
                                                                     (Node emptyRange <| FunctionOrValue [] "model")

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -135,9 +135,8 @@ suite =
                         body =
                             CaseExpression
                                 (CaseBlock (Node emptyRange <| FunctionOrValue [] "someCase")
-                                    [ ( Node emptyRange <| IntPattern 1, Node emptyRange <| FunctionOrValue [] "doSomething" )
-                                    , ( Node emptyRange <| IntPattern 2, Node emptyRange <| FunctionOrValue [] "doSomethingElse" )
-                                    ]
+                                    ( Node emptyRange <| IntPattern 1, Node emptyRange <| FunctionOrValue [] "doSomething" )
+                                    [ ( Node emptyRange <| IntPattern 2, Node emptyRange <| FunctionOrValue [] "doSomethingElse" ) ]
                                 )
 
                         function =


### PR DESCRIPTION
This prevents a case block from having 0 cases which should be impossible.