### PR TITLE
Require at least one exposed item in an explicit exposing list

### DIFF
--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -231,12 +231,12 @@ many1 p =
 
 sepBy : Parser s x -> Parser s a -> Parser s (List a)
 sepBy sep p =
-    or (sepBy1 sep p) (succeed [])
+    or (sepBy1 sep p |> map (\( head, rest ) -> head :: rest)) (succeed [])
 
 
-sepBy1 : Parser s x -> Parser s a -> Parser s (List a)
+sepBy1 : Parser s x -> Parser s a -> Parser s ( a, List a )
 sepBy1 sep p =
-    succeed (::)
+    succeed Tuple.pair
         |> andMap p
         |> andMap (many (sep |> continueWith p))
 

--- a/src/Elm/DefaultImports.elm
+++ b/src/Elm/DefaultImports.elm
@@ -17,9 +17,8 @@ defaults =
             Just <|
                 Node Range.emptyRange <|
                     Explicit
-                        [ Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "List") Nothing)
-                        , Node Range.emptyRange <| InfixExpose "::"
-                        ]
+                        (Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "List") Nothing))
+                        [ Node Range.emptyRange <| InfixExpose "::" ]
       , moduleAlias = Nothing
       }
     , { moduleName = Node Range.emptyRange <| [ "Maybe" ]
@@ -27,10 +26,11 @@ defaults =
             Just <|
                 Node Range.emptyRange <|
                     Explicit
-                        [ Node Range.emptyRange <|
+                        (Node Range.emptyRange <|
                             TypeExpose
                                 (ExposedType (Node Range.emptyRange "Maybe") (Just Range.emptyRange))
-                        ]
+                        )
+                        []
       , moduleAlias = Nothing
       }
     , { moduleName = Node Range.emptyRange <| [ "Result" ]
@@ -38,10 +38,11 @@ defaults =
             Just <|
                 Node Range.emptyRange <|
                     Explicit
-                        [ Node Range.emptyRange <|
+                        (Node Range.emptyRange <|
                             TypeExpose
                                 (ExposedType (Node Range.emptyRange "Result") (Just Range.emptyRange))
-                        ]
+                        )
+                        []
       , moduleAlias = Nothing
       }
     , { moduleName = Node Range.emptyRange <| [ "String" ], exposingList = Nothing, moduleAlias = Nothing }
@@ -52,8 +53,8 @@ defaults =
             Just <|
                 Node Range.emptyRange <|
                     Explicit
-                        [ Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "Program") Nothing)
-                        ]
+                        (Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "Program") Nothing))
+                        []
       , moduleAlias = Nothing
       }
     , { moduleName = Node Range.emptyRange <| [ "Platform", "Cmd" ]
@@ -61,13 +62,17 @@ defaults =
             Just <|
                 Node Range.emptyRange <|
                     Explicit
-                        [ Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "Cmd") Nothing)
-                        , Node Range.emptyRange <| InfixExpose "!"
-                        ]
+                        (Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "Cmd") Nothing))
+                        [ Node Range.emptyRange <| InfixExpose "!" ]
       , moduleAlias = Nothing
       }
     , { moduleName = Node Range.emptyRange <| [ "Platform", "Sub" ]
-      , exposingList = Just <| Node Range.emptyRange <| Explicit [ Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "Sub") Nothing) ]
+      , exposingList =
+            Just <|
+                Node Range.emptyRange <|
+                    Explicit
+                        (Node Range.emptyRange <| TypeExpose (ExposedType (Node Range.emptyRange "Sub") Nothing))
+                        []
       , moduleAlias = Nothing
       }
     ]

--- a/src/Elm/Interface.elm
+++ b/src/Elm/Interface.elm
@@ -123,8 +123,8 @@ build (Raw file) =
             fileToDefinitions file
     in
     case Module.exposingList (Node.value file.moduleDefinition) of
-        Explicit x ->
-            buildInterfaceFromExplicit x fileDefinitionList
+        Explicit head rest ->
+            buildInterfaceFromExplicit (head :: rest) fileDefinitionList
 
         All _ ->
             List.map Tuple.second fileDefinitionList

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -7,7 +7,7 @@ import Elm.Syntax.ModuleName exposing (ModuleName)
 
 moduleName : Parser s ModuleName
 moduleName =
-    sepBy1 (string ".") Tokens.typeName
+    sepBy1 (string ".") Tokens.typeName |> Combine.map (\( head, rest ) -> head :: rest)
 
 
 typeIndicator : Parser s ( ModuleName, String )

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -386,7 +386,10 @@ lambdaExpression =
             succeed (\args expr -> Lambda args expr |> LambdaExpression)
                 |> Combine.ignore (string "\\")
                 |> Combine.ignore (maybe Layout.layout)
-                |> Combine.andMap (sepBy1 (maybe Layout.layout) functionArgument)
+                |> Combine.andMap
+                    (sepBy1 (maybe Layout.layout) functionArgument
+                        |> Combine.map (\( head, rest ) -> head :: rest)
+                    )
                 |> Combine.andMap (Layout.maybeAroundBothSides (string "->") |> Combine.continueWith expression)
                 |> Node.parser
         )

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Expose exposing (exposable, exposeDefinition, exposingListInner, infixExpose, typeExpose)
 
-import Combine exposing (Parser, choice, maybe, or, parens, sepBy, string, succeed, while)
+import Combine exposing (Parser, choice, maybe, or, parens, sepBy1, string, succeed, while)
 import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -27,7 +27,10 @@ exposeListWith =
 exposingListInner : Parser State Exposing
 exposingListInner =
     or (withRange (succeed All |> Combine.ignore (Layout.maybeAroundBothSides (string ".."))))
-        (Combine.map Explicit (sepBy (char ',') (Layout.maybeAroundBothSides exposable)))
+        (Combine.map
+            (\( head, rest ) -> Explicit head rest)
+            (sepBy1 (char ',') (Layout.maybeAroundBothSides exposable))
+        )
 
 
 exposable : Parser State (Node TopLevelExpose)

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -34,6 +34,7 @@ whereBlock =
         (string "}")
         (sepBy1 (string ",")
             (Layout.maybeAroundBothSides effectWhereClause)
+            |> Combine.map (\( head, rest ) -> head :: rest)
         )
         |> Combine.map
             (\pairs ->

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -58,6 +58,7 @@ typeDefinition =
 valueConstructors : Parser State (List (Node ValueConstructor))
 valueConstructors =
     Combine.sepBy1 (Combine.ignore (maybe Layout.layout) (string "|")) valueConstructor
+        |> Combine.map (\( head, rest ) -> head :: rest)
 
 
 valueConstructor : Parser State (Node ValueConstructor)

--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -105,10 +105,10 @@ buildSingle imp moduleIndex =
                 |> Interface.operators
                 |> List.map (\x -> ( Node.value x.operator, x ))
 
-        Just (Node _ (Explicit l)) ->
+        Just (Node _ (Explicit head rest)) ->
             let
                 selectedOperators =
-                    Exposing.operators <| List.map Node.value l
+                    Exposing.operators <| List.map Node.value (head :: rest)
             in
             moduleIndex
                 |> Dict.get (Node.value imp.moduleName)

--- a/src/Elm/Syntax/Exposing.elm
+++ b/src/Elm/Syntax/Exposing.elm
@@ -43,7 +43,7 @@ import Json.Encode as JE exposing (Value)
 -}
 type Exposing
     = All Range
-    | Explicit (List (Node TopLevelExpose))
+    | Explicit (Node TopLevelExpose) (List (Node TopLevelExpose))
 
 
 {-| An exposed entity
@@ -82,7 +82,7 @@ exposesFunction s exposure =
         All _ ->
             True
 
-        Explicit l ->
+        Explicit head rest ->
             List.any
                 (\(Node _ value) ->
                     case value of
@@ -92,7 +92,7 @@ exposesFunction s exposure =
                         _ ->
                             False
                 )
-                l
+                (head :: rest)
 
 
 {-| Collect all operator names from a list of TopLevelExposes
@@ -124,8 +124,8 @@ encode exp =
         All r ->
             encodeTyped "all" <| Range.encode r
 
-        Explicit l ->
-            encodeTyped "explicit" (JE.list encodeTopLevelExpose l)
+        Explicit head rest ->
+            encodeTyped "explicit" (JE.list encodeTopLevelExpose (head :: rest))
 
 
 {-| JSON decoder for an `Exposing` syntax element.
@@ -134,8 +134,22 @@ decoder : Decoder Exposing
 decoder =
     decodeTyped
         [ ( "all", Range.decoder |> JD.map All )
-        , ( "explicit", JD.list topLevelExposeDecoder |> JD.map Explicit )
+        , ( "explicit", decodeNonemptyList topLevelExposeDecoder |> JD.map (\( head, rest ) -> Explicit head rest) )
         ]
+
+
+decodeNonemptyList : Decoder a -> Decoder ( a, List a )
+decodeNonemptyList decodeA =
+    JD.list decodeA
+        |> JD.andThen
+            (\list ->
+                case list of
+                    head :: rest ->
+                        JD.succeed ( head, rest )
+
+                    [] ->
+                        JD.fail "List must have at least one element."
+            )
 
 
 encodeTopLevelExpose : Node TopLevelExpose -> Value

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -127,8 +127,11 @@ writeExposureExpose x =
         All _ ->
             string "exposing (..)"
 
-        Explicit exposeList ->
+        Explicit head rest ->
             let
+                exposeList =
+                    head :: rest
+
                 diffLines =
                     List.map Node.range exposeList
                         |> startOnDifferentLines

--- a/tests/tests/Elm/Parser/CombineTestUtil.elm
+++ b/tests/tests/Elm/Parser/CombineTestUtil.elm
@@ -143,10 +143,8 @@ noRangeExposingList x =
         All r ->
             All emptyRange
 
-        Explicit list ->
-            list
-                |> List.map noRangeExpose
-                |> Explicit
+        Explicit head rest ->
+            Explicit (noRangeExpose head) (List.map noRangeExpose rest)
 
 
 noRangePattern : Node Pattern -> Node Pattern

--- a/tests/tests/Elm/Parser/ExposeTests.elm
+++ b/tests/tests/Elm/Parser/ExposeTests.elm
@@ -34,8 +34,8 @@ all =
                     |> Expect.equal
                         (Just
                             (Explicit
-                                [ Node emptyRange <| TypeOrAliasExpose "Model"
-                                , Node emptyRange <| TypeExpose (ExposedType (Node emptyRange "Msg") (Just emptyRange))
+                                (Node emptyRange <| TypeOrAliasExpose "Model")
+                                [ Node emptyRange <| TypeExpose (ExposedType (Node emptyRange "Msg") (Just emptyRange))
                                 , Node emptyRange <| TypeExpose (ExposedType (Node emptyRange "Info") (Just emptyRange))
                                 , Node emptyRange <| FunctionExpose "init"
                                 , Node emptyRange <| InfixExpose "::"
@@ -46,24 +46,12 @@ all =
             \() ->
                 parseFullStringWithNullState "foo\n --bar\n " exposingListInner
                     |> Maybe.map noRangeExposingList
-                    |> Expect.equal
-                        (Just
-                            (Explicit
-                                [ Node emptyRange <| FunctionExpose "foo"
-                                ]
-                            )
-                        )
+                    |> Expect.equal (Just (Explicit (Node emptyRange <| FunctionExpose "foo") []))
         , test "exposingList with comment 2" <|
             \() ->
                 parseFullStringWithNullState "exposing (foo\n --bar\n )" exposeDefinition
                     |> Maybe.map noRangeExposingList
-                    |> Expect.equal
-                        (Just
-                            (Explicit
-                                [ Node emptyRange <| FunctionExpose "foo"
-                                ]
-                            )
-                        )
+                    |> Expect.equal (Just (Explicit (Node emptyRange <| FunctionExpose "foo") []))
         , test "exposingList with spacing" <|
             \() ->
                 parseFullStringWithNullState "exposing (Model, Msg, Info   (..)   ,init,(::) )" exposeDefinition
@@ -71,8 +59,8 @@ all =
                     |> Expect.equal
                         (Just
                             (Explicit
-                                [ Node emptyRange <| TypeOrAliasExpose "Model"
-                                , Node emptyRange <| TypeOrAliasExpose "Msg"
+                                (Node emptyRange <| TypeOrAliasExpose "Model")
+                                [ Node emptyRange <| TypeOrAliasExpose "Msg"
                                 , Node emptyRange <| TypeExpose (ExposedType (Node emptyRange "Info") (Just emptyRange))
                                 , Node emptyRange <| FunctionExpose "init"
                                 , Node emptyRange <| InfixExpose "::"
@@ -93,9 +81,10 @@ all =
                         |> Expect.equal
                             (Just
                                 (Explicit
-                                    [ Node { end = { column = 11, row = 2 }, start = { column = 7, row = 2 } }
+                                    (Node { end = { column = 11, row = 2 }, start = { column = 7, row = 2 } }
                                         (TypeOrAliasExpose "Link")
-                                    , Node { end = { column = 11, row = 3 }, start = { column = 7, row = 3 } }
+                                    )
+                                    [ Node { end = { column = 11, row = 3 }, start = { column = 7, row = 3 } }
                                         (FunctionExpose "init")
                                     ]
                                 )

--- a/tests/tests/Elm/Parser/ImportsTests.elm
+++ b/tests/tests/Elm/Parser/ImportsTests.elm
@@ -27,8 +27,8 @@ all =
                                     Just <|
                                         Node emptyRange <|
                                             Explicit
-                                                [ Node emptyRange <| TypeOrAliasExpose "Model"
-                                                , Node emptyRange <| TypeExpose (ExposedType (Node emptyRange "Msg") (Just emptyRange))
+                                                (Node emptyRange <| TypeOrAliasExpose "Model")
+                                                [ Node emptyRange <| TypeExpose (ExposedType (Node emptyRange "Msg") (Just emptyRange))
                                                 ]
                                 }
                         )
@@ -41,7 +41,7 @@ all =
                             Node emptyRange <|
                                 { moduleName = Node emptyRange <| [ "Html" ]
                                 , moduleAlias = Nothing
-                                , exposingList = Just <| Node emptyRange <| Explicit [ Node emptyRange <| FunctionExpose "text" ]
+                                , exposingList = Just <| Node emptyRange <| Explicit (Node emptyRange <| FunctionExpose "text") []
                                 }
                         )
         , test "import minimal" <|

--- a/tests/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/tests/Elm/Parser/ModuleTests.elm
@@ -21,7 +21,7 @@ all =
                         (Just
                             (NormalModule
                                 { moduleName = Node emptyRange <| [ "Foo" ]
-                                , exposingList = Node emptyRange <| Explicit [ Node emptyRange <| TypeOrAliasExpose "Bar" ]
+                                , exposingList = Node emptyRange <| Explicit (Node emptyRange <| TypeOrAliasExpose "Bar") []
                                 }
                             )
                         )
@@ -29,12 +29,12 @@ all =
             \() ->
                 parseFullStringWithNullState "port module Foo exposing (Bar)" Parser.moduleDefinition
                     |> Maybe.map noRangeModule
-                    |> Expect.equal (Just (PortModule { moduleName = Node emptyRange <| [ "Foo" ], exposingList = Node emptyRange <| Explicit [ Node emptyRange <| TypeOrAliasExpose "Bar" ] }))
+                    |> Expect.equal (Just (PortModule { moduleName = Node emptyRange <| [ "Foo" ], exposingList = Node emptyRange <| Explicit (Node emptyRange <| TypeOrAliasExpose "Bar") [] }))
         , test "port moduleDefinition with spacing" <|
             \() ->
                 parseFullStringWithNullState "port module Foo exposing ( Bar )" Parser.moduleDefinition
                     |> Maybe.map noRangeModule
-                    |> Expect.equal (Just (PortModule { moduleName = Node emptyRange <| [ "Foo" ], exposingList = Node emptyRange <| Explicit [ Node emptyRange <| TypeOrAliasExpose "Bar" ] }))
+                    |> Expect.equal (Just (PortModule { moduleName = Node emptyRange <| [ "Foo" ], exposingList = Node emptyRange <| Explicit (Node emptyRange <| TypeOrAliasExpose "Bar") [] }))
         , test "effect moduleDefinition" <|
             \() ->
                 parseFullStringWithNullState "effect module Foo where {command = MyCmd, subscription = MySub } exposing (Bar)" Parser.moduleDefinition
@@ -43,7 +43,7 @@ all =
                         (Just
                             (EffectModule
                                 { moduleName = Node emptyRange <| [ "Foo" ]
-                                , exposingList = Node emptyRange <| Explicit [ Node emptyRange <| TypeOrAliasExpose "Bar" ]
+                                , exposingList = Node emptyRange <| Explicit (Node emptyRange <| TypeOrAliasExpose "Bar") []
                                 , command = Just <| Node emptyRange <| "MyCmd"
                                 , subscription = Just <| Node emptyRange <| "MySub"
                                 }

--- a/tests/tests/Elm/Parser/Samples.elm
+++ b/tests/tests/Elm/Parser/Samples.elm
@@ -422,7 +422,7 @@ foo = 1
 
 sample4 : String
 sample4 =
-    """module Operators exposing ()
+    """module Operators exposing (..)
 
 infix left 5 (|=) = keeper
 infix left 6 (|.) = ignorer

--- a/tests/tests/Elm/Syntax/ExposingTests.elm
+++ b/tests/tests/Elm/Syntax/ExposingTests.elm
@@ -30,8 +30,8 @@ suite =
                 \() ->
                     symmetric
                         (Explicit
-                            [ Node emptyRange (FunctionExpose "beginnerProgram")
-                            , Node emptyRange (FunctionExpose "div")
+                            (Node emptyRange (FunctionExpose "beginnerProgram"))
+                            [ Node emptyRange (FunctionExpose "div")
                             , Node emptyRange (FunctionExpose "button")
                             , Node emptyRange (FunctionExpose "text")
                             ]

--- a/tests/tests/Elm/Syntax/ImportTests.elm
+++ b/tests/tests/Elm/Syntax/ImportTests.elm
@@ -39,8 +39,8 @@ suite =
                             (Just <|
                                 Node emptyRange <|
                                     Explicit
-                                        [ Node emptyRange (FunctionExpose "beginnerProgram")
-                                        , Node emptyRange (FunctionExpose "div")
+                                        (Node emptyRange (FunctionExpose "beginnerProgram"))
+                                        [ Node emptyRange (FunctionExpose "div")
                                         , Node emptyRange (FunctionExpose "button")
                                         , Node emptyRange (FunctionExpose "text")
                                         ]


### PR DESCRIPTION
This prevents another impossible state