### PR TITLE
Ignore node modules and intelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 elm-stuff
 parse.js
+node_modules
+.idea


### PR DESCRIPTION
I constantly have to remember to not accidentally add these in pull requests so I think it's best if they are included in .gitignore