### PR TITLE
Make value constructors for custom type nonempty

### DIFF
--- a/src/Elm/Inspector.elm
+++ b/src/Elm/Inspector.elm
@@ -168,7 +168,9 @@ inspectType config tipe context =
 
 inspectTypeInner : Config context -> Type -> context -> context
 inspectTypeInner config typeDecl context =
-    List.foldl (inspectValueConstructor config) context typeDecl.constructors
+    List.foldl (inspectValueConstructor config)
+        context
+        (typeDecl.firstConstructor :: typeDecl.restOfConstructors)
 
 
 inspectValueConstructor : Config context -> Node ValueConstructor -> context -> context

--- a/src/Elm/Interface.elm
+++ b/src/Elm/Interface.elm
@@ -190,7 +190,13 @@ fileToDefinitions file =
                     (\(Node _ decl) ->
                         case decl of
                             CustomTypeDeclaration t ->
-                                Just ( Node.value t.name, CustomType ( Node.value t.name, t.constructors |> List.map (Node.value >> .name >> Node.value) ) )
+                                Just
+                                    ( Node.value t.name
+                                    , CustomType
+                                        ( Node.value t.name
+                                        , t.firstConstructor :: t.restOfConstructors |> List.map (Node.value >> .name >> Node.value)
+                                        )
+                                    )
 
                             AliasDeclaration a ->
                                 Just ( Node.value a.name, Alias <| Node.value a.name )

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -43,11 +43,16 @@ typeDefinition =
                             |> Combine.andMap genericList
                             |> Combine.ignore (maybe Layout.layout)
                             |> Combine.ignore (string "=" |> Combine.ignore (maybe Layout.layout))
-                            |> Combine.andMap valueConstructors
+                            |> Combine.andThen (\tipe -> Combine.map (\( head, rest ) -> tipe head rest) valueConstructors)
                             |> Combine.map
                                 (\tipe ->
                                     DefinedType
-                                        (Range.combine (start :: List.map (\(Node r _) -> r) tipe.constructors))
+                                        (Range.combine
+                                            (start
+                                                :: List.map (\(Node r _) -> r)
+                                                    (tipe.firstConstructor :: tipe.restOfConstructors)
+                                            )
+                                        )
                                         tipe
                                 )
                         ]
@@ -55,10 +60,9 @@ typeDefinition =
         )
 
 
-valueConstructors : Parser State (List (Node ValueConstructor))
+valueConstructors : Parser State ( Node ValueConstructor, List (Node ValueConstructor) )
 valueConstructors =
     Combine.sepBy1 (Combine.ignore (maybe Layout.layout) (string "|")) valueConstructor
-        |> Combine.map (\( head, rest ) -> head :: rest)
 
 
 valueConstructor : Parser State (Node ValueConstructor)

--- a/src/Elm/Syntax/Type.elm
+++ b/src/Elm/Syntax/Type.elm
@@ -43,7 +43,8 @@ type alias Type =
     { documentation : Maybe (Node Documentation)
     , name : Node String
     , generics : List (Node String)
-    , constructors : List (Node ValueConstructor)
+    , firstConstructor : Node ValueConstructor
+    , restOfConstructors : List (Node ValueConstructor)
     }
 
 
@@ -62,12 +63,13 @@ type alias ValueConstructor =
 {-| Encode a `Type` syntax element to JSON.
 -}
 encode : Type -> Value
-encode { documentation, name, generics, constructors } =
+encode { documentation, name, generics, firstConstructor, restOfConstructors } =
     JE.object
         [ ( "documentation", Maybe.map (Node.encode Documentation.encode) documentation |> Maybe.withDefault JE.null )
         , ( "name", Node.encode JE.string name )
         , ( "generics", JE.list (Node.encode JE.string) generics )
-        , ( "constructors", JE.list (Node.encode encodeValueConstructor) constructors )
+        , ( "firstConstructor", Node.encode encodeValueConstructor firstConstructor )
+        , ( "restOfConstructors", JE.list (Node.encode encodeValueConstructor) restOfConstructors )
         ]
 
 
@@ -83,11 +85,12 @@ encodeValueConstructor { name, arguments } =
 -}
 decoder : Decoder Type
 decoder =
-    JD.map4 Type
+    JD.map5 Type
         (JD.field "documentation" <| JD.nullable <| Node.decoder JD.string)
         (JD.field "name" <| Node.decoder JD.string)
         (JD.field "generics" (JD.list (Node.decoder JD.string)))
-        (JD.field "constructors" (JD.list (Node.decoder valueConstructorDecoder)))
+        (JD.field "firstConstructor" (Node.decoder valueConstructorDecoder))
+        (JD.field "restOfConstructors" (JD.list (Node.decoder valueConstructorDecoder)))
 
 
 valueConstructorDecoder : Decoder ValueConstructor

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -270,14 +270,17 @@ writeType type_ =
             , spaced (List.map (Node.value >> string) type_.generics)
             ]
         , let
+            constructors =
+                type_.firstConstructor :: type_.restOfConstructors
+
             diffLines =
-                List.map Node.range type_.constructors
+                List.map Node.range constructors
                     |> startOnDifferentLines
           in
           indent 4
             (sepBy ( "= ", " | ", "" )
                 diffLines
-                (List.map (Node.value >> writeValueConstructor) type_.constructors)
+                (List.map (Node.value >> writeValueConstructor) constructors)
             )
         ]
 

--- a/tests/tests/Elm/Parser/CombineTestUtil.elm
+++ b/tests/tests/Elm/Parser/CombineTestUtil.elm
@@ -316,7 +316,8 @@ noRangeTypeReference (Node _ typeAnnotation) =
 noRangeTypeDeclaration : Type -> Type
 noRangeTypeDeclaration x =
     { x
-        | constructors = List.map (unRanged noRangeValueConstructor) x.constructors
+        | firstConstructor = unRanged noRangeValueConstructor x.firstConstructor
+        , restOfConstructors = List.map (unRanged noRangeValueConstructor) x.restOfConstructors
         , generics = List.map unRange x.generics
         , name = unRange x.name
     }

--- a/tests/tests/Elm/Parser/TypingsTests.elm
+++ b/tests/tests/Elm/Parser/TypingsTests.elm
@@ -87,12 +87,13 @@ all =
                             { documentation = Nothing
                             , name = Node emptyRange <| "Color"
                             , generics = []
-                            , constructors =
-                                [ Node emptyRange
+                            , firstConstructor =
+                                Node emptyRange
                                     { name = Node emptyRange <| "Blue"
                                     , arguments = [ Node emptyRange <| Elm.Syntax.TypeAnnotation.Type (Node emptyRange <| ( [], "String" )) [] ]
                                     }
-                                , Node emptyRange
+                            , restOfConstructors =
+                                [ Node emptyRange
                                     { name = Node emptyRange <| "Red"
                                     , arguments = []
                                     }
@@ -111,15 +112,15 @@ all =
                     |> Expect.equal
                         (Just
                             { documentation = Nothing
-                            , constructors =
-                                [ Node emptyRange
+                            , firstConstructor =
+                                Node emptyRange
                                     { arguments =
                                         [ Node emptyRange <| Var "a"
                                         , Node emptyRange <| Elm.Syntax.TypeAnnotation.Type (Node emptyRange <| ( [], "B" )) []
                                         ]
                                     , name = Node emptyRange <| "C"
                                     }
-                                ]
+                            , restOfConstructors = []
                             , generics = []
                             , name = Node emptyRange <| "D"
                             }
@@ -132,15 +133,15 @@ all =
                     |> Expect.equal
                         (Just
                             { documentation = Nothing
-                            , constructors =
-                                [ Node emptyRange
+                            , firstConstructor =
+                                Node emptyRange
                                     { arguments =
                                         [ Node emptyRange <| Elm.Syntax.TypeAnnotation.Type (Node emptyRange <| ( [], "B" )) []
                                         , Node emptyRange <| Var "a"
                                         ]
                                     , name = Node emptyRange <| "C"
                                     }
-                                ]
+                            , restOfConstructors = []
                             , generics = []
                             , name = Node emptyRange <| "D"
                             }
@@ -153,14 +154,14 @@ all =
                     |> Expect.equal
                         (Just
                             { documentation = Nothing
-                            , constructors =
-                                [ Node emptyRange
+                            , firstConstructor =
+                                Node emptyRange
                                     { arguments =
                                         [ Node emptyRange <| Elm.Syntax.TypeAnnotation.Type (Node emptyRange <| ( [], "B" )) []
                                         ]
                                     , name = Node emptyRange <| "C"
                                     }
-                                ]
+                            , restOfConstructors = []
                             , generics = []
                             , name = Node emptyRange <| "D"
                             }
@@ -173,12 +174,12 @@ all =
                     |> Expect.equal
                         (Just
                             { documentation = Nothing
-                            , constructors =
-                                [ Node emptyRange
+                            , firstConstructor =
+                                Node emptyRange
                                     { arguments = []
                                     , name = Node emptyRange <| "Blue"
                                     }
-                                ]
+                            , restOfConstructors = []
                             , generics = []
                             , name = Node emptyRange <| "Color"
                             }
@@ -193,12 +194,13 @@ all =
                             { documentation = Nothing
                             , name = Node emptyRange <| "Maybe"
                             , generics = [ Node emptyRange <| "a" ]
-                            , constructors =
-                                [ Node emptyRange
+                            , firstConstructor =
+                                Node emptyRange
                                     { name = Node emptyRange <| "Just"
                                     , arguments = [ Node emptyRange <| Var "a" ]
                                     }
-                                , Node emptyRange
+                            , restOfConstructors =
+                                [ Node emptyRange
                                     { name = Node emptyRange <| "Nothing"
                                     , arguments = []
                                     }
@@ -216,10 +218,10 @@ all =
                     |> Expect.equal
                         (Just
                             (DefinedType { end = { column = 11, row = 1 }, start = { column = 1, row = 1 } }
-                                { constructors =
-                                    [ Node { end = { column = 11, row = 1 }, start = { column = 10, row = 1 } }
+                                { firstConstructor =
+                                    Node { end = { column = 11, row = 1 }, start = { column = 10, row = 1 } }
                                         { arguments = [], name = Node { end = { column = 11, row = 1 }, start = { column = 10, row = 1 } } "B" }
-                                    ]
+                                , restOfConstructors = []
                                 , documentation = Nothing
                                 , generics = []
                                 , name = Node { end = { column = 7, row = 1 }, start = { column = 6, row = 1 } } "A"

--- a/tests/tests/Elm/ProcessingTests.elm
+++ b/tests/tests/Elm/ProcessingTests.elm
@@ -218,10 +218,11 @@ type Foo
       , declarations =
             [ Node { end = { column = 10, row = 6 }, start = { column = 1, row = 4 } }
                 (CustomTypeDeclaration
-                    { constructors =
-                        [ Node { end = { column = 9, row = 5 }, start = { column = 6, row = 5 } }
+                    { firstConstructor =
+                        Node { end = { column = 9, row = 5 }, start = { column = 6, row = 5 } }
                             { arguments = [], name = Node { end = { column = 9, row = 5 }, start = { column = 6, row = 5 } } "Red" }
-                        , Node { end = { column = 10, row = 6 }, start = { column = 6, row = 6 } }
+                    , restOfConstructors =
+                        [ Node { end = { column = 10, row = 6 }, start = { column = 6, row = 6 } }
                             { arguments = [], name = Node { end = { column = 10, row = 6 }, start = { column = 6, row = 6 } } "Blue" }
                         ]
                     , documentation =

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -118,9 +118,8 @@ suite =
                                 Nothing
                                 (Node emptyRange "Sample")
                                 []
-                                [ Node emptyRange <| ValueConstructor (Node emptyRange "Foo") []
-                                , Node emptyRange <| ValueConstructor (Node emptyRange "Bar") []
-                                ]
+                                (Node emptyRange <| ValueConstructor (Node emptyRange "Foo") [])
+                                [ Node emptyRange <| ValueConstructor (Node emptyRange "Bar") [] ]
                             )
                     )
                         |> Writer.writeDeclaration


### PR DESCRIPTION
Having no constructors for a custom type is impossible so I've changed `Elm.Syntax.Type.Type` to reflect this.