### PR TITLE
Extension record should have nonempty number of fields

### DIFF
--- a/src/Elm/Inspector.elm
+++ b/src/Elm/Inspector.elm
@@ -248,11 +248,14 @@ inspectTypeAnnotationInner config (Node _ typeRefence) context =
         Tuple typeAnnotations ->
             List.foldl (inspectTypeAnnotation config) context typeAnnotations
 
-        Record recordDefinition _ ->
+        Record recordDefinition ->
             List.foldl (inspectTypeAnnotation config) context (List.map (Node.value >> Tuple.second) recordDefinition)
 
         FunctionTypeAnnotation left right ->
             List.foldl (inspectTypeAnnotation config) context [ left, right ]
+
+        ExtensionRecord _ firstField restOfFields ->
+            List.foldl (inspectTypeAnnotation config) context (List.map (Node.value >> Tuple.second) (firstField :: restOfFields))
 
         Var _ ->
             context

--- a/src/Elm/Syntax/TypeAnnotation.elm
+++ b/src/Elm/Syntax/TypeAnnotation.elm
@@ -16,7 +16,7 @@ For example:
 
 ## Types
 
-@docs TypeAnnotation, RecordDefinition, RecordField
+@docs TypeAnnotation, RecordField
 
 
 ## Serialization

--- a/src/Elm/Syntax/TypeAnnotation.elm
+++ b/src/Elm/Syntax/TypeAnnotation.elm
@@ -1,5 +1,5 @@
 module Elm.Syntax.TypeAnnotation exposing
-    ( TypeAnnotation(..), RecordDefinition, RecordField
+    ( TypeAnnotation(..), RecordField
     , encode, decoder
     )
 
@@ -37,7 +37,8 @@ import Json.Encode as JE exposing (Value)
   - `Var`: `a`
   - `Type`: `Maybe (Int -> String)`
   - `Tuples`: `(a, b, c)` or Unit `()`
-  - `Record`: `{ name : String}`
+  - `Record`: `{ name : String }`
+  - `ExtensionRecord`: `{ a | name : String }`
   - `GenericRecord`: `{ a | name : String}`
   - `FunctionTypeAnnotation`: `Int -> String`
 
@@ -46,14 +47,9 @@ type TypeAnnotation
     = Var String
     | Type (Node ( ModuleName, String )) (List (Node TypeAnnotation))
     | Tuple (List (Node TypeAnnotation))
-    | Record RecordDefinition (Maybe (Node String))
+    | Record (List (Node RecordField))
+    | ExtensionRecord (Node String) (Node RecordField) (List (Node RecordField))
     | FunctionTypeAnnotation (Node TypeAnnotation) (Node TypeAnnotation)
-
-
-{-| A list of fields in-order of a record type annotation.
--}
-type alias RecordDefinition =
-    List (Node RecordField)
 
 
 {-| Single field of a record. A name and its type.
@@ -105,21 +101,19 @@ encode typeAnnotation =
                     , ( "right", Node.encode encode right )
                     ]
 
-        Record recordDefinition generic ->
+        Record recordDefinition ->
             encodeTyped "record" <|
                 JE.object
-                    [ ( "value", encodeRecordDefinition recordDefinition )
-                    , ( "generic"
-                      , generic
-                            |> Maybe.map (Node.encode JE.string)
-                            |> Maybe.withDefault JE.null
-                      )
+                    [ ( "value", JE.list (Node.encode encodeRecordField) recordDefinition )
                     ]
 
-
-encodeRecordDefinition : RecordDefinition -> Value
-encodeRecordDefinition =
-    JE.list (Node.encode encodeRecordField)
+        ExtensionRecord generic firstField restOfFields ->
+            encodeTyped "extension" <|
+                JE.object
+                    [ ( "generic", Node.encode JE.string generic )
+                    , ( "firstField", Node.encode encodeRecordField firstField )
+                    , ( "restOfFields", JE.list (Node.encode encodeRecordField) restOfFields )
+                    ]
 
 
 encodeRecordField : RecordField -> Value
@@ -157,15 +151,13 @@ decoder =
                         (JD.field "right" nestedDecoder)
                   )
                 , ( "record"
-                  , JD.map2 Record
-                        (JD.field "value" recordDefinitionDecoder)
-                        (JD.field "generic"
-                            (JD.oneOf
-                                [ JD.null Nothing
-                                , Node.decoder JD.string |> JD.map Just
-                                ]
-                            )
-                        )
+                  , JD.map Record (JD.field "value" (JD.list <| Node.decoder recordFieldDecoder))
+                  )
+                , ( "extension"
+                  , JD.map3 ExtensionRecord
+                        (JD.field "generic" (Node.decoder JD.string))
+                        (JD.field "firstField" (Node.decoder recordFieldDecoder))
+                        (JD.field "restOfFields" (JD.list <| Node.decoder recordFieldDecoder))
                   )
                 ]
         )
@@ -174,11 +166,6 @@ decoder =
 nestedDecoder : Decoder (Node TypeAnnotation)
 nestedDecoder =
     JD.lazy (\() -> Node.decoder decoder)
-
-
-recordDefinitionDecoder : Decoder RecordDefinition
-recordDefinitionDecoder =
-    JD.lazy (\() -> JD.list <| Node.decoder recordFieldDecoder)
 
 
 recordFieldDecoder : Decoder RecordField

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -358,19 +358,17 @@ writeTypeAnnotation (Node _ typeAnnotation) =
         Tuple xs ->
             parensComma False (List.map writeTypeAnnotation xs)
 
-        Record xs generic ->
-            case generic of
-                Nothing ->
-                    bracesComma False (List.map writeRecordField xs)
+        Record xs ->
+            bracesComma False (List.map writeRecordField xs)
 
-                Just genericName ->
-                    spaced
-                        [ string "{"
-                        , string <| Node.value genericName
-                        , string "|"
-                        , sepByComma False (List.map writeRecordField xs)
-                        , string "}"
-                        ]
+        ExtensionRecord generic firstField restOfFields ->
+            spaced
+                [ string "{"
+                , string <| Node.value generic
+                , string "|"
+                , sepByComma False (List.map writeRecordField (firstField :: restOfFields))
+                , string "}"
+                ]
 
         FunctionTypeAnnotation left right ->
             let

--- a/tests/tests/Elm/Parser/CombineTestUtil.elm
+++ b/tests/tests/Elm/Parser/CombineTestUtil.elm
@@ -283,11 +283,6 @@ noRangeRecordField ( a, b ) =
     ( unRange a, noRangeTypeReference b )
 
 
-noRangeRecordDefinition : RecordDefinition -> RecordDefinition
-noRangeRecordDefinition =
-    List.map (unRanged noRangeRecordField)
-
-
 noRangeTypeReference : Node TypeAnnotation -> Node TypeAnnotation
 noRangeTypeReference (Node _ typeAnnotation) =
     Node emptyRange <|
@@ -301,8 +296,14 @@ noRangeTypeReference (Node _ typeAnnotation) =
             Tuple a ->
                 Tuple (List.map noRangeTypeReference a)
 
-            Record a name ->
-                Record (List.map (unRanged noRangeRecordField) a) (Maybe.map unRange name)
+            Record a ->
+                Record (List.map (unRanged noRangeRecordField) a)
+
+            ExtensionRecord generic firstField restOfFields ->
+                ExtensionRecord
+                    (unRange generic)
+                    (unRanged noRangeRecordField firstField)
+                    (List.map (unRanged noRangeRecordField) restOfFields)
 
             FunctionTypeAnnotation a b ->
                 FunctionTypeAnnotation

--- a/tests/tests/Elm/Parser/TypeAnnotationTests.elm
+++ b/tests/tests/Elm/Parser/TypeAnnotationTests.elm
@@ -102,7 +102,7 @@ all =
                     |> Expect.equal
                         (Just <|
                             Node emptyRange <|
-                                Record [] Nothing
+                                Record []
                         )
         , test "recordTypeReference one field" <|
             \() ->
@@ -113,7 +113,6 @@ all =
                             Node emptyRange <|
                                 Record
                                     [ Node emptyRange ( Node emptyRange "color", Node emptyRange <| Type (Node emptyRange ( [], "String" )) [] ) ]
-                                    Nothing
                         )
         , test "record with generic" <|
             \() ->
@@ -122,11 +121,10 @@ all =
                     |> Expect.equal
                         (Just
                             (Node emptyRange <|
-                                Record
-                                    [ Node emptyRange ( Node emptyRange "position", Node emptyRange <| Type (Node emptyRange <| ( [], "Vec2" )) [] )
-                                    , Node emptyRange ( Node emptyRange "texture", Node emptyRange <| Type (Node emptyRange ( [], "Vec2" )) [] )
-                                    ]
-                                    (Just (Node emptyRange "attr"))
+                                ExtensionRecord
+                                    (Node emptyRange "attr")
+                                    (Node emptyRange ( Node emptyRange "position", Node emptyRange <| Type (Node emptyRange <| ( [], "Vec2" )) [] ))
+                                    [ Node emptyRange ( Node emptyRange "texture", Node emptyRange <| Type (Node emptyRange ( [], "Vec2" )) [] ) ]
                             )
                         )
         , test "recordTypeReference nested record" <|
@@ -145,10 +143,8 @@ all =
                                                 , Node emptyRange ( Node emptyRange "g", Node emptyRange <| Type (Node emptyRange ( [], "Int" )) [] )
                                                 , Node emptyRange ( Node emptyRange "b", Node emptyRange <| Type (Node emptyRange ( [], "Int" )) [] )
                                                 ]
-                                                Nothing
                                         )
                                     ]
-                                    Nothing
                             )
                         )
         , test "recordTypeReference with generic" <|
@@ -164,7 +160,6 @@ all =
                                         , Node emptyRange <| Var "s"
                                         )
                                     ]
-                                    Nothing
                             )
                         )
         , test "function type reference" <|

--- a/tests/tests/Elm/Parser/TypingsTests.elm
+++ b/tests/tests/Elm/Parser/TypingsTests.elm
@@ -53,7 +53,6 @@ all =
                                             , Node emptyRange <| Elm.Syntax.TypeAnnotation.Type (Node emptyRange <| ( [], "String" )) []
                                             )
                                         ]
-                                        Nothing
                             }
                         )
         , test "type alias with Var " <|
@@ -74,9 +73,36 @@ all =
                                             , Node emptyRange <| Var "a"
                                             )
                                         ]
-                                        Nothing
                             }
                         )
+        , test "type alias extension record" <|
+            \() ->
+                parseFullStringWithNullState "type alias Foo abc = { abc |color: String }" Parser.typeDefinition
+                    |> Maybe.andThen asTypeAlias
+                    |> Maybe.map noRangeTypeAlias
+                    |> Expect.equal
+                        (Just <|
+                            { documentation = Nothing
+                            , name = Node emptyRange "Foo"
+                            , generics = [ Node emptyRange "abc" ]
+                            , typeAnnotation =
+                                Node emptyRange <|
+                                    ExtensionRecord
+                                        (Node emptyRange "abc")
+                                        (Node emptyRange <|
+                                            ( Node emptyRange <| "color"
+                                            , Node emptyRange <| Elm.Syntax.TypeAnnotation.Type (Node emptyRange <| ( [], "String" )) []
+                                            )
+                                        )
+                                        []
+                            }
+                        )
+        , test "type alias extension record with no fields fails" <|
+            \() ->
+                parseFullStringWithNullState "type alias Foo abc = { abc |  }" Parser.typeDefinition
+                    |> Maybe.andThen asTypeAlias
+                    |> Maybe.map noRangeTypeAlias
+                    |> Expect.equal Nothing
         , test "type" <|
             \() ->
                 parseFullStringWithNullState "type Color = Blue String | Red | Green" Parser.typeDefinition

--- a/tests/tests/Elm/ProcessingTests.elm
+++ b/tests/tests/Elm/ProcessingTests.elm
@@ -195,7 +195,6 @@ type alias Foo
                                         Type (Node { end = { column = 21, row = 5 }, start = { column = 15, row = 5 } } ( [], "String" )) []
                                     )
                                 ]
-                                Nothing
                     }
             ]
       , comments = []


### PR DESCRIPTION
`Elm.Syntax.TypeAnnotation.TypeAnnotation` has a `Record` variant that used to pull double duty as both a record and an extension record. It had an impossible state where it could both be an extension record and have no fields (which the Elm compiler doesn't allow).

To fix this I added a `ExtensionRecord` variant that has a nonempty number of fields.