### PR TITLE
Fix if expression range

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -565,22 +565,32 @@ numberExpression =
 
 ifBlockExpression : Parser State (Node Expression)
 ifBlockExpression =
-    Node.parser
-        (ifToken
-            |> Combine.continueWith
-                (lazy
-                    (\() ->
-                        succeed IfBlock
-                            |> Combine.ignore (maybe Layout.layout)
-                            |> Combine.andMap expression
-                            |> Combine.ignore (maybe Layout.layout)
-                            |> Combine.ignore thenToken
-                            |> Combine.ignore (maybe Layout.layout)
-                            |> Combine.andMap expression
-                            |> Combine.ignore (maybe Layout.layout)
-                            |> Combine.andMap (elseToken |> Combine.continueWith Layout.layout |> Combine.continueWith expression)
+    Ranges.withCurrentPoint
+        (\current ->
+            ifToken
+                |> Combine.continueWith
+                    (lazy
+                        (\() ->
+                            succeed
+                                (\condition ifTrue ifFalse ->
+                                    Node
+                                        { start = current.start, end = (Node.range ifFalse).end }
+                                        (IfBlock condition ifTrue ifFalse)
+                                )
+                                |> Combine.ignore (maybe Layout.layout)
+                                |> Combine.andMap expression
+                                |> Combine.ignore (maybe Layout.layout)
+                                |> Combine.ignore thenToken
+                                |> Combine.ignore (maybe Layout.layout)
+                                |> Combine.andMap expression
+                                |> Combine.ignore (maybe Layout.layout)
+                                |> Combine.andMap
+                                    (elseToken
+                                        |> Combine.continueWith Layout.layout
+                                        |> Combine.continueWith expression
+                                    )
+                        )
                     )
-                )
         )
 
 

--- a/tests/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/tests/Elm/Parser/ModuleTests.elm
@@ -71,7 +71,7 @@ all =
                 parseFullStringWithNullState "module I_en_gb exposing (..)" Parser.moduleDefinition
                     |> Maybe.map noRangeModule
                     |> Expect.equal (Just (NormalModule { moduleName = Node emptyRange <| [ "I_en_gb" ], exposingList = Node emptyRange <| All emptyRange }))
-        , test "Incorrect range in if expression regression test" <|
+        , test "Regression test for Incorrect range in if expression" <|
             \() ->
                 parseFullStringWithNullState
                     """module TestModule exposing (..)
@@ -93,7 +93,7 @@ b = 3
                         (Just
                             { comments = [ Node { end = { column = 3, row = 12 }, start = { column = 1, row = 11 } } "{-| doc\u{000D}\n-}" ]
                             , declarations =
-                                [ Node { end = { column = 1, row = 13 }, start = { column = 1, row = 3 } }
+                                [ Node { end = { column = 10, row = 7 }, start = { column = 1, row = 3 } }
                                     (FunctionDeclaration
                                         { declaration =
                                             Node { end = { column = 10, row = 7 }, start = { column = 1, row = 3 } }

--- a/tests/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/tests/Elm/Parser/ModuleTests.elm
@@ -74,7 +74,7 @@ all =
         , test "Regression test for Incorrect range in if expression" <|
             \() ->
                 parseFullStringWithNullState
-                    """module TestModule exposing (..)
+                    (String.filter ((/=) '\u{000D}') """module TestModule exposing (..)
 
 a =
     if cond then
@@ -87,11 +87,11 @@ a =
 {-| doc
 -}
 b = 3
-"""
+""")
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = [ Node { end = { column = 3, row = 12 }, start = { column = 1, row = 11 } } "{-| doc\u{000D}\n-}" ]
+                            { comments = [ Node { end = { column = 3, row = 12 }, start = { column = 1, row = 11 } } "{-| doc\n-}" ]
                             , declarations =
                                 [ Node { end = { column = 10, row = 7 }, start = { column = 1, row = 3 } }
                                     (FunctionDeclaration
@@ -166,7 +166,7 @@ b = 3
         , test "Simple module range test" <|
             \() ->
                 parseFullStringWithNullState
-                    """module TestModule exposing (..)
+                    (String.filter ((/=) '\u{000D}') """module TestModule exposing (..)
 
 a =
     2
@@ -176,11 +176,11 @@ a =
 {-| doc
 -}
 b = 3
-"""
+""")
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = [ Node { end = { column = 3, row = 9 }, start = { column = 1, row = 8 } } "{-| doc\u{000D}\n-}" ]
+                            { comments = [ Node { end = { column = 3, row = 9 }, start = { column = 1, row = 8 } } "{-| doc\n-}" ]
                             , declarations =
                                 [ Node
                                     { end = { column = 6, row = 4 }

--- a/tests/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/tests/Elm/Parser/ModuleTests.elm
@@ -1,8 +1,11 @@
 module Elm.Parser.ModuleTests exposing (all)
 
 import Elm.Parser.CombineTestUtil exposing (..)
+import Elm.Parser.File as File
 import Elm.Parser.Modules as Parser
+import Elm.Syntax.Declaration exposing (Declaration(..))
 import Elm.Syntax.Exposing exposing (..)
+import Elm.Syntax.Expression exposing (Expression(..))
 import Elm.Syntax.Module exposing (..)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range exposing (emptyRange)
@@ -68,4 +71,176 @@ all =
                 parseFullStringWithNullState "module I_en_gb exposing (..)" Parser.moduleDefinition
                     |> Maybe.map noRangeModule
                     |> Expect.equal (Just (NormalModule { moduleName = Node emptyRange <| [ "I_en_gb" ], exposingList = Node emptyRange <| All emptyRange }))
+        , test "Incorrect range in if expression regression test" <|
+            \() ->
+                parseFullStringWithNullState
+                    """module TestModule exposing (..)
+
+a =
+    if cond then
+        1
+    else
+        2
+
+-- hello
+
+{-| doc
+-}
+b = 3
+"""
+                    File.file
+                    |> Expect.equal
+                        (Just
+                            { comments = [ Node { end = { column = 3, row = 12 }, start = { column = 1, row = 11 } } "{-| doc\u{000D}\n-}", Node { end = { column = 9, row = 9 }, start = { column = 1, row = 9 } } "-- hello" ]
+                            , declarations =
+                                [ Node { end = { column = 1, row = 13 }, start = { column = 1, row = 3 } }
+                                    (FunctionDeclaration
+                                        { declaration =
+                                            Node { end = { column = 10, row = 7 }, start = { column = 1, row = 3 } }
+                                                { arguments = []
+                                                , expression =
+                                                    Node { end = { column = 10, row = 7 }, start = { column = 5, row = 4 } }
+                                                        (IfBlock
+                                                            (Node { end = { column = 12, row = 4 }, start = { column = 8, row = 4 } }
+                                                                (FunctionOrValue [] "cond")
+                                                            )
+                                                            (Node { end = { column = 10, row = 5 }, start = { column = 9, row = 5 } } (Integer 1))
+                                                            (Node
+                                                                { end = { column = 10, row = 7 }
+                                                                , start =
+                                                                    { column = 9
+                                                                    , row = 7
+                                                                    }
+                                                                }
+                                                                (Integer 2)
+                                                            )
+                                                        )
+                                                , name = Node { end = { column = 2, row = 3 }, start = { column = 1, row = 3 } } "a"
+                                                }
+                                        , documentation = Nothing
+                                        , signature = Nothing
+                                        }
+                                    )
+                                , Node { end = { column = 6, row = 13 }, start = { column = 1, row = 13 } }
+                                    (FunctionDeclaration
+                                        { declaration =
+                                            Node
+                                                { end =
+                                                    { column = 6
+                                                    , row =
+                                                        13
+                                                    }
+                                                , start = { column = 1, row = 13 }
+                                                }
+                                                { arguments = [], expression = Node { end = { column = 6, row = 13 }, start = { column = 5, row = 13 } } (Integer 3), name = Node { end = { column = 2, row = 13 }, start = { column = 1, row = 13 } } "b" }
+                                        , documentation = Nothing
+                                        , signature = Nothing
+                                        }
+                                    )
+                                ]
+                            , imports = []
+                            , moduleDefinition =
+                                Node { end = { column = 32, row = 1 }, start = { column = 1, row = 1 } }
+                                    (NormalModule
+                                        { exposingList =
+                                            Node
+                                                { end =
+                                                    { column =
+                                                        32
+                                                    , row = 1
+                                                    }
+                                                , start = { column = 19, row = 1 }
+                                                }
+                                                (All { end = { column = 31, row = 1 }, start = { column = 29, row = 1 } })
+                                        , moduleName =
+                                            Node
+                                                { end =
+                                                    { column = 18, row = 1 }
+                                                , start = { column = 8, row = 1 }
+                                                }
+                                                [ "TestModule" ]
+                                        }
+                                    )
+                            }
+                        )
+        , test "Simple module range test" <|
+            \() ->
+                parseFullStringWithNullState
+                    """module TestModule exposing (..)
+
+a =
+    2
+
+-- hello
+
+{-| doc
+-}
+b = 3
+"""
+                    File.file
+                    |> Expect.equal
+                        (Just
+                            { comments = [ Node { end = { column = 3, row = 9 }, start = { column = 1, row = 8 } } "{-| doc\u{000D}\n-}", Node { end = { column = 9, row = 6 }, start = { column = 1, row = 6 } } "-- hello" ]
+                            , declarations =
+                                [ Node
+                                    { end = { column = 6, row = 4 }
+                                    , start = { column = 1, row = 3 }
+                                    }
+                                    (FunctionDeclaration
+                                        { declaration =
+                                            Node { end = { column = 6, row = 4 }, start = { column = 1, row = 3 } }
+                                                { arguments = []
+                                                , expression =
+                                                    Node
+                                                        { end =
+                                                            { column = 6, row = 4 }
+                                                        , start = { column = 5, row = 4 }
+                                                        }
+                                                        (Integer 2)
+                                                , name = Node { end = { column = 2, row = 3 }, start = { column = 1, row = 3 } } "a"
+                                                }
+                                        , documentation = Nothing
+                                        , signature = Nothing
+                                        }
+                                    )
+                                , Node
+                                    { end =
+                                        { column = 6, row = 10 }
+                                    , start = { column = 1, row = 10 }
+                                    }
+                                    (FunctionDeclaration
+                                        { declaration =
+                                            Node { end = { column = 6, row = 10 }, start = { column = 1, row = 10 } }
+                                                { arguments = []
+                                                , expression =
+                                                    Node
+                                                        { end =
+                                                            { column = 6, row = 10 }
+                                                        , start = { column = 5, row = 10 }
+                                                        }
+                                                        (Integer 3)
+                                                , name = Node { end = { column = 2, row = 10 }, start = { column = 1, row = 10 } } "b"
+                                                }
+                                        , documentation = Nothing
+                                        , signature = Nothing
+                                        }
+                                    )
+                                ]
+                            , imports = []
+                            , moduleDefinition =
+                                Node { end = { column = 32, row = 1 }, start = { column = 1, row = 1 } }
+                                    (NormalModule
+                                        { exposingList =
+                                            Node { end = { column = 32, row = 1 }, start = { column = 19, row = 1 } }
+                                                (All
+                                                    { end =
+                                                        { column = 31, row = 1 }
+                                                    , start = { column = 29, row = 1 }
+                                                    }
+                                                )
+                                        , moduleName = Node { end = { column = 18, row = 1 }, start = { column = 8, row = 1 } } [ "TestModule" ]
+                                        }
+                                    )
+                            }
+                        )
         ]

--- a/tests/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/tests/Elm/Parser/ModuleTests.elm
@@ -82,7 +82,7 @@ a =
     else
         2
 
--- hello
+
 
 {-| doc
 -}
@@ -91,7 +91,7 @@ b = 3
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = [ Node { end = { column = 3, row = 12 }, start = { column = 1, row = 11 } } "{-| doc\u{000D}\n-}", Node { end = { column = 9, row = 9 }, start = { column = 1, row = 9 } } "-- hello" ]
+                            { comments = [ Node { end = { column = 3, row = 12 }, start = { column = 1, row = 11 } } "{-| doc\u{000D}\n-}" ]
                             , declarations =
                                 [ Node { end = { column = 1, row = 13 }, start = { column = 1, row = 3 } }
                                     (FunctionDeclaration
@@ -171,7 +171,7 @@ b = 3
 a =
     2
 
--- hello
+
 
 {-| doc
 -}
@@ -180,7 +180,7 @@ b = 3
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = [ Node { end = { column = 3, row = 9 }, start = { column = 1, row = 8 } } "{-| doc\u{000D}\n-}", Node { end = { column = 9, row = 6 }, start = { column = 1, row = 6 } } "-- hello" ]
+                            { comments = [ Node { end = { column = 3, row = 9 }, start = { column = 1, row = 8 } } "{-| doc\u{000D}\n-}" ]
                             , declarations =
                                 [ Node
                                     { end = { column = 6, row = 4 }


### PR DESCRIPTION
This fixes https://github.com/stil4m/elm-syntax/issues/92. 

As @jfmengels mentioned, this is indeed related to an earlier `let...in` range miscalculation. I think there might be more bugs like this (though I didn't find anymore right now) as it's caused by `Node.parser` which uses the current parser position as the end position of a range rather than using the end position of the child expression. For many cases, the current parser position and the end position of the expression are the same. But in `let`, `case`, and `if` expressions, this isn't true.