### PR TITLE
Add regression tests for (+ ) bug

### DIFF
--- a/tests/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/tests/Elm/Parser/DeclarationsTests.elm
@@ -565,4 +565,12 @@ all =
                                         )
                                 }
                         )
+        , test "regression test for disallowing ( +)" <|
+            \() ->
+                parseFullStringState emptyState "a = ( +)" Parser.function
+                    |> Expect.equal Nothing
+        , test "regression test for disallowing (+ )" <|
+            \() ->
+                parseFullStringState emptyState "a = (+ )" Parser.function
+                    |> Expect.equal Nothing
         ]


### PR DESCRIPTION
This fixes https://github.com/stil4m/elm-syntax/issues/75.

Or rather, that bug appears to already be fixed but I'm not sure when it happened. I've just added some regression tests.