### PR TITLE
Handle unicode in tokens

### DIFF
--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -239,8 +239,8 @@ multiLineStringLiteral =
 functionName : Parser s String
 functionName =
     Core.variable
-        { start = Char.isLower
-        , inner = \c -> Char.isAlphaNum c || c == '_'
+        { start = isLower
+        , inner = \c -> isAlphaNum c || c == '_'
         , reserved = Set.fromList reservedList
         }
         |> Combine.fromCore
@@ -249,11 +249,43 @@ functionName =
 typeName : Parser s String
 typeName =
     Core.variable
-        { start = Char.isUpper
-        , inner = \c -> Char.isAlphaNum c || c == '_'
+        { start = isUpper
+        , inner = \c -> isAlphaNum c || c == '_'
         , reserved = Set.fromList reservedList
         }
         |> Combine.fromCore
+
+
+isAlphaNum : Char -> Bool
+isAlphaNum char =
+    isUpperOrLower char || Char.isDigit char
+
+
+isUpperOrLower : Char -> Bool
+isUpperOrLower char =
+    let
+        stringChar =
+            String.fromChar char
+    in
+    String.toUpper stringChar /= stringChar || String.toLower stringChar /= stringChar
+
+
+isLower : Char -> Bool
+isLower char =
+    let
+        stringChar =
+            String.fromChar char
+    in
+    String.toUpper stringChar /= stringChar && String.toLower stringChar == stringChar
+
+
+isUpper : Char -> Bool
+isUpper char =
+    let
+        stringChar =
+            String.fromChar char
+    in
+    String.toUpper stringChar == stringChar && String.toLower stringChar /= stringChar
 
 
 excludedOperators : List String

--- a/tests/tests/Elm/Parser/TokenTests.elm
+++ b/tests/tests/Elm/Parser/TokenTests.elm
@@ -187,4 +187,44 @@ all =
             \() ->
                 parseFullString longMultiLineString Parser.multiLineStringLiteral
                     |> Expect.notEqual Nothing
+        , test "ρ function" <|
+            \() ->
+                parseFullString "ρ" Parser.functionName
+                    |> Expect.notEqual Nothing
+        , test "ε2 function" <|
+            \() ->
+                parseFullString "ε2" Parser.functionName
+                    |> Expect.notEqual Nothing
+        , test "εε function" <|
+            \() ->
+                parseFullString "εε" Parser.functionName
+                    |> Expect.notEqual Nothing
+        , test "ρ uppercase function" <|
+            \() ->
+                parseFullString (String.toUpper "ρ") Parser.functionName
+                    |> Expect.equal Nothing
+        , test "ε uppercase function" <|
+            \() ->
+                parseFullString (String.toUpper "ε") Parser.functionName
+                    |> Expect.equal Nothing
+        , test "ρ type name" <|
+            \() ->
+                parseFullString "ρ" Parser.typeName
+                    |> Expect.equal Nothing
+        , test "ε2 type name" <|
+            \() ->
+                parseFullString "ε2" Parser.typeName
+                    |> Expect.equal Nothing
+        , test "εε type name" <|
+            \() ->
+                parseFullString "εε" Parser.typeName
+                    |> Expect.equal Nothing
+        , test "ρ uppercase type name" <|
+            \() ->
+                parseFullString (String.toUpper "ρ") Parser.typeName
+                    |> Expect.notEqual Nothing
+        , test "ε uppercase type name" <|
+            \() ->
+                parseFullString (String.toUpper "ε") Parser.typeName
+                    |> Expect.notEqual Nothing
         ]


### PR DESCRIPTION
This fixes https://github.com/stil4m/elm-syntax/issues/47

As I mention here https://github.com/stil4m/elm-syntax/issues/47#issuecomment-766186582 this solution is pretty hacky and might allow for situations where you can use some exotic unicode character in a type name or function that the Elm compiler wouldn't allow. Still, I think this is better than nothing.