### PR TITLE
Fix indentation in case expression

### DIFF
--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -518,8 +518,10 @@ writeExpression (Node range inner) =
                             ]
             in
             breaked
-                [ spaced [ string "case", writeExpression caseBlock.expression, string "of" ]
+                [ string ""
+                , spaced [ string "case", writeExpression caseBlock.expression, string "of" ]
                 , breaked (List.map writeCaseBranch (caseBlock.firstCase :: caseBlock.restOfCases))
+                , string ""
                 ]
 
         LambdaExpression lambda ->


### PR DESCRIPTION
This fixes https://github.com/stil4m/elm-syntax/issues/98

It has the side effect of adding some unnecessary new lines before and after case expressions*. To me this doesn't seem like a big issue since the Elm code will still compile and elm-format will tidy things up.

@jfmengels I'll go ahead and backport this one as it requires some changes before it will work with elm-syntax v7.

\* The reason adding a leading new line to case expressions is so the `case expr of` is on it's own line. Otherwise, it can get pushed too far to the right by the code preceding it. The trailing new line is to preventing closing parenthesis from ending up on the same line as the last case pattern (which will cause a compiler error).