### PR TITLE
Speed up how comments are matched with declarations

### DIFF
--- a/src/Elm/Processing/Documentation.elm
+++ b/src/Elm/Processing/Documentation.elm
@@ -26,11 +26,7 @@ postProcess file =
 
 onType : Node Type -> File -> File
 onType (Node r customType) file =
-    let
-        docs =
-            List.filter (isDocumentationForRange r) file.comments
-    in
-    case List.head docs of
+    case findDocumentationForRange r file.comments of
         Just ((Node docRange docString) as doc) ->
             { file
                 | comments =
@@ -50,11 +46,7 @@ onType (Node r customType) file =
 
 onTypeAlias : Node TypeAlias -> File -> File
 onTypeAlias (Node r typeAlias) file =
-    let
-        docs =
-            List.filter (isDocumentationForRange r) file.comments
-    in
-    case List.head docs of
+    case findDocumentationForRange r file.comments of
         Just ((Node docRange docString) as doc) ->
             { file
                 | comments =
@@ -81,11 +73,7 @@ onTypeAlias (Node r typeAlias) file =
 
 onPort : Node Port -> File -> File
 onPort (Node portRange portDeclaration) file =
-    let
-        docs =
-            List.filter (isDocumentationForRange portRange) file.comments
-    in
-    case List.head docs of
+    case findDocumentationForRange portRange file.comments of
         Just ((Node docRange _) as doc) ->
             { file
                 | comments =
@@ -111,11 +99,7 @@ onPort (Node portRange portDeclaration) file =
 
 onFunction : Node Function -> File -> File
 onFunction (Node functionRange function) file =
-    let
-        docs =
-            List.filter (isDocumentationForRange functionRange) file.comments
-    in
-    case List.head docs of
+    case findDocumentationForRange functionRange file.comments of
         Just ((Node docRange docString) as doc) ->
             { file
                 | comments =

--- a/src/Elm/Processing/Documentation.elm
+++ b/src/Elm/Processing/Documentation.elm
@@ -2,7 +2,6 @@ module Elm.Processing.Documentation exposing (postProcess)
 
 import Elm.Inspector as Inspector exposing (Order(..), defaultConfig)
 import Elm.Syntax.Declaration exposing (Declaration(..))
-import Elm.Syntax.Documentation exposing (..)
 import Elm.Syntax.Expression exposing (..)
 import Elm.Syntax.File exposing (File)
 import Elm.Syntax.Node exposing (Node(..))
@@ -152,6 +151,20 @@ replaceDeclaration (Node r1 new) (Node r2 old) =
          else
             old
         )
+
+
+findDocumentationForRange : Range -> List (Node String) -> Maybe (Node String)
+findDocumentationForRange range comments =
+    case comments of
+        [] ->
+            Nothing
+
+        comment :: restOfComments ->
+            if isDocumentationForRange range comment then
+                Just comment
+
+            else
+                findDocumentationForRange range restOfComments
 
 
 isDocumentationForRange : Range -> Node String -> Bool


### PR DESCRIPTION
Instead of filtering through all the comments that matched then taking the head, we go through the list and stop once we find one that matches.

This relies on comments already being ordered (otherwise it still works, but it won't be as fast), which was added in #102.

I don't have any benchmarks for this though. We don't need this for the 7.1.4 patch release.