### PR TITLE
Remove elm-community/json-extra dependency

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -34,7 +34,6 @@
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
         "elm/parser": "1.0.0 <= v < 2.0.0",
-        "elm-community/json-extra": "4.0.0 <= v < 5.0.0",
         "elm-community/list-extra": "8.0.0 <= v < 9.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
         "stil4m/structured-writer": "1.0.1 <= v < 2.0.0"

--- a/src/Elm/Syntax/Range.elm
+++ b/src/Elm/Syntax/Range.elm
@@ -32,7 +32,6 @@ See also [Basics.compare](https://package.elm-lang.org/packages/elm/core/latest/
 -}
 
 import Json.Decode as JD exposing (Decoder)
-import Json.Decode.Extra exposing (fromResult)
 import Json.Encode as JE exposing (Value)
 
 
@@ -93,6 +92,16 @@ fromList input =
 
         _ ->
             Err "Invalid input list"
+
+
+fromResult : Result String a -> Decoder a
+fromResult result =
+    case result of
+        Ok successValue ->
+            JD.succeed successValue
+
+        Err errorMessage ->
+            JD.fail errorMessage
 
 
 {-| Compute the largest area of a list of ranges.


### PR DESCRIPTION
Removes `elm-community/json-extra`. We barely use it but it adds a lot of indirect dependencies.

I'd also like to remove `list-extra`, but it has no indirect dependencies and we use it a lot more.