### PR TITLE
rename emptyRange

### DIFF
--- a/src/Elm/Syntax/Range.elm
+++ b/src/Elm/Syntax/Range.elm
@@ -53,8 +53,8 @@ type alias Range =
 
 {-| Construct an empty range
 -}
-emptyRange : Range
-emptyRange =
+empty : Range
+empty =
     { start = { row = 0, column = 0 }
     , end = { row = 0, column = 0 }
     }


### PR DESCRIPTION
https://package.elm-lang.org/help/design-guidelines#module-names-should-not-reappear-in-function-names