### PR TITLE
Fix parsing error when there are no parens around `=` in a type alias declaration

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -516,7 +516,7 @@ letDestructuringDeclarationWithPattern p =
             succeed (LetDestructuring p)
                 |> Combine.ignore (maybe Layout.layout)
                 |> Combine.ignore (string "=")
-                |> Combine.ignore Layout.layout
+                |> Combine.ignore (maybe Layout.layout)
                 |> Combine.andMap expression
         )
 

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -31,7 +31,7 @@ typeDefinition =
                             |> Combine.andMap (Node.parser typeName |> Combine.ignore Layout.layout)
                             |> Combine.andMap genericList
                             |> Combine.ignore (string "=")
-                            |> Combine.ignore Layout.layout
+                            |> Combine.ignore (maybe Layout.layout)
                             |> Combine.andMap typeAnnotation
                             |> Combine.map
                                 (\typeAlias ->

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -28,7 +28,7 @@ typeDefinition =
                     (Combine.choice
                         [ succeed (TypeAlias Nothing)
                             |> Combine.ignore (string "alias" |> Combine.continueWith Layout.layout)
-                            |> Combine.andMap (Node.parser typeName |> Combine.ignore Layout.layout)
+                            |> Combine.andMap (Node.parser typeName |> Combine.ignore (maybe Layout.layout))
                             |> Combine.andMap genericList
                             |> Combine.ignore (string "=")
                             |> Combine.ignore (maybe Layout.layout)

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -150,7 +150,7 @@ type alias LetBlock =
     }
 
 
-{-| Union type for all possible declations in a let block
+{-| Union type for all possible declarations in a let block
 -}
 type LetDeclaration
     = LetFunction Function

--- a/tests/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/tests/Elm/Parser/DeclarationsTests.elm
@@ -272,6 +272,46 @@ all =
                                         }
                                 }
                         )
+        , test "let destructuring with no spaces around '='" <|
+            \() ->
+                parseFullStringWithNullState "foo =\n let\n  (b, c)=(1, 2)\n in\n  b" Parser.function
+                    |> Maybe.map Node.value
+                    |> Maybe.map noRangeDeclaration
+                    |> Expect.equal
+                        (Just <|
+                            FunctionDeclaration
+                                { signature = Nothing
+                                , documentation = Nothing
+                                , declaration =
+                                    Node emptyRange <|
+                                        { name = Node emptyRange "foo"
+                                        , arguments = []
+                                        , expression =
+                                            Node emptyRange <|
+                                                LetExpression
+                                                    { declarations =
+                                                        [ Node emptyRange <|
+                                                            LetDestructuring
+                                                                (Node emptyRange
+                                                                    (TuplePattern
+                                                                        [ Node emptyRange (VarPattern "b")
+                                                                        , Node emptyRange (VarPattern "c")
+                                                                        ]
+                                                                    )
+                                                                )
+                                                                (Node emptyRange
+                                                                    (TupledExpression
+                                                                        [ Node emptyRange (Integer 1)
+                                                                        , Node emptyRange (Integer 2)
+                                                                        ]
+                                                                    )
+                                                                )
+                                                        ]
+                                                    , expression = Node emptyRange <| FunctionOrValue [] "b"
+                                                    }
+                                        }
+                                }
+                        )
         , test "declaration with record" <|
             \() ->
                 parseFullStringWithNullState "main =\n  beginnerProgram { model = 0, view = view, update = update }" Parser.function

--- a/tests/tests/Elm/Parser/TypingsTests.elm
+++ b/tests/tests/Elm/Parser/TypingsTests.elm
@@ -57,7 +57,7 @@ all =
                         )
         , test "type alias without spacings around '='" <|
             \() ->
-                parseFullStringWithNullState "type alias Foo={color: String }" Parser.typeDefinition
+                parseFullStringWithNullState "type alias Foo ={color: String }" Parser.typeDefinition
                     |> Maybe.andThen asTypeAlias
                     |> Maybe.map noRangeTypeAlias
                     |> Expect.equal

--- a/tests/tests/Elm/Parser/TypingsTests.elm
+++ b/tests/tests/Elm/Parser/TypingsTests.elm
@@ -57,7 +57,7 @@ all =
                         )
         , test "type alias without spacings around '='" <|
             \() ->
-                parseFullStringWithNullState "type alias Foo ={color: String }" Parser.typeDefinition
+                parseFullStringWithNullState "type alias Foo={color: String }" Parser.typeDefinition
                     |> Maybe.andThen asTypeAlias
                     |> Maybe.map noRangeTypeAlias
                     |> Expect.equal

--- a/tests/tests/Elm/Parser/TypingsTests.elm
+++ b/tests/tests/Elm/Parser/TypingsTests.elm
@@ -55,6 +55,26 @@ all =
                                         ]
                             }
                         )
+        , test "type alias without spacings around '='" <|
+            \() ->
+                parseFullStringWithNullState "type alias Foo={color: String }" Parser.typeDefinition
+                    |> Maybe.andThen asTypeAlias
+                    |> Maybe.map noRangeTypeAlias
+                    |> Expect.equal
+                        (Just <|
+                            { documentation = Nothing
+                            , name = Node emptyRange "Foo"
+                            , generics = []
+                            , typeAnnotation =
+                                Node emptyRange <|
+                                    Record
+                                        [ Node emptyRange <|
+                                            ( Node emptyRange <| "color"
+                                            , Node emptyRange <| Typed (Node emptyRange <| ( [], "String" )) []
+                                            )
+                                        ]
+                            }
+                        )
         , test "type alias with GenericType " <|
             \() ->
                 parseFullStringWithNullState "type alias Foo a = {some : a }" Parser.typeDefinition


### PR DESCRIPTION
There was an issue with parsing type alias declarations when there was no spacing on either side of the `=` sign.

```elm
-- Succeed to parse
type alias A = ()
-- Fail to parse
type alias A= ()
type alias A =()
```

Example of this happening in an Ellie: https://ellie-app.com/cJJBxZd4gkga1

This is also the case in v8, so we'll need to backport this to `master`.