### PR TITLE
Indent Types correctly

### DIFF
--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -274,10 +274,10 @@ writeType type_ =
                     |> startOnDifferentLines
           in
           indent 4
-          ( sepBy ( "=", "|", "" )
-            diffLines
-            (List.map (Node.value >> writeValueConstructor) type_.constructors)
-          )
+            (sepBy ( "=", "|", "" )
+                diffLines
+                (List.map (Node.value >> writeValueConstructor) type_.constructors)
+            )
         ]
 
 

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -273,9 +273,11 @@ writeType type_ =
                 List.map Node.range type_.constructors
                     |> startOnDifferentLines
           in
-          sepBy ( "=", "|", "" )
+          indent 4
+          ( sepBy ( "=", "|", "" )
             diffLines
             (List.map (Node.value >> writeValueConstructor) type_.constructors)
+          )
         ]
 
 

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -144,7 +144,7 @@ suite =
                         |> Writer.write
                         |> Expect.equal
                             ("type Sample \n"
-                                ++ "=Foo |Bar "
+                                ++ "    =Foo |Bar "
                             )
             , test "write function with case expression using the right indentations" <|
                 \() ->


### PR DESCRIPTION
This change is already in the main branch.

Without it Types are output like this

```
Type Cedd
= Cedd String
```

And with it they look like this

```
Type Cedd
    = Cedd String
```