### PR TITLE
Replace isLower and isUpper workaround with miniBill/elm-unicode

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -35,6 +35,7 @@
         "elm/json": "1.0.0 <= v < 2.0.0",
         "elm/parser": "1.0.0 <= v < 2.0.0",
         "elm-community/list-extra": "8.0.0 <= v < 9.0.0",
+        "miniBill/elm-unicode": "1.0.2 <= v < 2.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
         "stil4m/structured-writer": "1.0.1 <= v < 2.0.0"
     },

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -20,12 +20,13 @@ module Elm.Parser.Tokens exposing
     , typeName
     )
 
-import Char exposing (fromCode)
+import Char
 import Combine exposing (Parser, fail, many1, or, string, succeed)
 import Combine.Char exposing (anyChar, char, oneOf)
 import Hex
 import Parser as Core exposing ((|.), (|=), Nestable(..), Step(..))
 import Set
+import Unicode
 
 
 reservedList : List String
@@ -239,8 +240,8 @@ multiLineStringLiteral =
 functionName : Parser s String
 functionName =
     Core.variable
-        { start = isLower
-        , inner = \c -> isAlphaNum c || c == '_'
+        { start = Unicode.isLower
+        , inner = \c -> Unicode.isAlphaNum c || c == '_'
         , reserved = Set.fromList reservedList
         }
         |> Combine.fromCore
@@ -249,43 +250,11 @@ functionName =
 typeName : Parser s String
 typeName =
     Core.variable
-        { start = isUpper
-        , inner = \c -> isAlphaNum c || c == '_'
+        { start = Unicode.isUpper
+        , inner = \c -> Unicode.isAlphaNum c || c == '_'
         , reserved = Set.fromList reservedList
         }
         |> Combine.fromCore
-
-
-isAlphaNum : Char -> Bool
-isAlphaNum char =
-    isUpperOrLower char || Char.isDigit char
-
-
-isUpperOrLower : Char -> Bool
-isUpperOrLower char =
-    let
-        stringChar =
-            String.fromChar char
-    in
-    String.toUpper stringChar /= stringChar || String.toLower stringChar /= stringChar
-
-
-isLower : Char -> Bool
-isLower char =
-    let
-        stringChar =
-            String.fromChar char
-    in
-    String.toUpper stringChar /= stringChar && String.toLower stringChar == stringChar
-
-
-isUpper : Char -> Bool
-isUpper char =
-    let
-        stringChar =
-            String.fromChar char
-    in
-    String.toUpper stringChar == stringChar && String.toLower stringChar /= stringChar
 
 
 excludedOperators : List String

--- a/tests/elm.json
+++ b/tests/elm.json
@@ -4,7 +4,7 @@
         "../src",
         "tests"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/core": "1.0.0",
@@ -15,6 +15,7 @@
             "elm-community/json-extra": "3.0.0",
             "elm-community/list-extra": "8.0.0",
             "elm-explorations/test": "1.0.0",
+            "miniBill/elm-unicode": "1.0.2",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.2"
         },


### PR DESCRIPTION
Unicode aware isLower and isUpper functions were implemented using an ugly workaround involving `Char.toLower` and `Char.toUpper`. `elm-unicode` is published so we can use that instead now.