### PR TITLE
Fix CharLiteral not escaping

### DIFF
--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -490,7 +490,16 @@ writeExpression (Node range inner) =
             string ("\"" ++ s ++ "\"")
 
         CharLiteral c ->
-            string ("'" ++ String.fromList [ c ] ++ "'")
+            let
+                escape : String
+                escape =
+                    if c == '\t' || c == '\'' || c == '\\' then
+                        "\\"
+
+                    else
+                        ""
+            in
+            string ("'" ++ escape ++ String.fromList [ c ] ++ "'")
 
         TupledExpression t ->
             join [ string "(", sepHelper sepByComma (List.map recurRangeHelper t), string ")" ]

--- a/src/Elm/Writer.elm
+++ b/src/Elm/Writer.elm
@@ -490,16 +490,7 @@ writeExpression (Node range inner) =
             string ("\"" ++ s ++ "\"")
 
         CharLiteral c ->
-            let
-                escape : String
-                escape =
-                    if c == '\t' || c == '\'' || c == '\\' then
-                        "\\"
-
-                    else
-                        ""
-            in
-            string ("'" ++ escape ++ String.fromList [ c ] ++ "'")
+            writeChar c
 
         TupledExpression t ->
             join [ string "(", sepHelper sepByComma (List.map recurRangeHelper t), string ")" ]
@@ -575,6 +566,20 @@ escapeString =
     String.replace "\"" "\\\""
 
 
+writeChar : Char -> Writer
+writeChar c =
+    let
+        escape : String
+        escape =
+            if c == '\t' || c == '\'' || c == '\\' then
+                "\\"
+
+            else
+                ""
+    in
+    string ("'" ++ escape ++ String.fromChar c ++ "'")
+
+
 {-| Write a pattern
 -}
 writePattern : Node Pattern -> Writer
@@ -587,7 +592,7 @@ writePattern (Node _ p) =
             string "()"
 
         CharPattern c ->
-            string ("'" ++ String.fromList [ c ] ++ "'")
+            writeChar c
 
         StringPattern s ->
             string ("\"" ++ escapeString s ++ "\"")

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -267,6 +267,20 @@ suite =
                                 ++ "        doSomethingElse\n"
                                 ++ "    )"
                             )
+            , test "regression test for char literals not being escaped" <|
+                \() ->
+                    ListExpr
+                        [ Node emptyRange (CharLiteral '\\')
+                        , Node emptyRange (CharLiteral '"')
+                        , Node emptyRange (CharLiteral '\'')
+                        , Node emptyRange (CharLiteral '\t')
+                        , Node emptyRange (CharLiteral '→')
+                        , Node emptyRange (CharLiteral '\u{00A0}')
+                        ]
+                        |> Node emptyRange
+                        |> Writer.writeExpression
+                        |> Writer.write
+                        |> Expect.equal "['\\\\', '\"', '\\'', '\\\t', '→', '\u{00A0}']"
             , test "nested case expressions" <|
                 \() ->
                     let

--- a/tests/tests/Elm/WriterTests.elm
+++ b/tests/tests/Elm/WriterTests.elm
@@ -281,6 +281,20 @@ suite =
                         |> Writer.writeExpression
                         |> Writer.write
                         |> Expect.equal "['\\\\', '\"', '\\'', '\\\t', '→', '\u{00A0}']"
+            , test "regression test for char pattern not being escaped" <|
+                \() ->
+                    ListPattern
+                        [ Node emptyRange (CharPattern '\\')
+                        , Node emptyRange (CharPattern '"')
+                        , Node emptyRange (CharPattern '\'')
+                        , Node emptyRange (CharPattern '\t')
+                        , Node emptyRange (CharPattern '→')
+                        , Node emptyRange (CharPattern '\u{00A0}')
+                        ]
+                        |> Node emptyRange
+                        |> Writer.writePattern
+                        |> Writer.write
+                        |> Expect.equal "['\\\\', '\"', '\\'', '\\\t', '→', '\u{00A0}']"
             , test "nested case expressions" <|
                 \() ->
                     let


### PR DESCRIPTION
Fixes https://github.com/stil4m/elm-syntax/issues/124.

The issue mentioned that `→` should be converted to `\u{2192}` in the generated code. I don't think this should be done. Whether a unicode code point should be represented directly or with the \u{} notation is a choice the programmer (or elm-format) can make. As far as I can tell, both should work. For that reason, Elm.Writer will always write the actual unicode character as it's easier to do.