### PR TITLE
Bugs from elm review bot

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -456,7 +456,10 @@ caseStatements =
                             Combine.withLocation
                                 (\l ->
                                     if State.expectedColumn s == l.column then
-                                        Combine.map (\c -> Combine.Loop (c :: last)) caseStatement
+                                        Combine.choice
+                                            [ Combine.map (\c -> Combine.Loop (c :: last)) caseStatement
+                                            , Combine.succeed (Combine.Done (List.reverse last))
+                                            ]
 
                                     else
                                         Combine.succeed (Combine.Done (List.reverse last))

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -71,7 +71,7 @@ listPattern =
         (\() ->
             Node.parser <|
                 between
-                    (string "[")
+                    (string "[" |> Combine.ignore (maybe Layout.layout))
                     (string "]")
                     (Combine.map ListPattern (sepBy (string ",") (Layout.maybeAroundBothSides pattern)))
         )

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -42,8 +42,9 @@ reservedList =
     , "case"
     , "of"
     , "port"
-    , "infixr"
-    , "infixl"
+
+    --, "infixr"
+    --, "infixl"
     , "type"
 
     --, "infix" Apparently this is not a reserved keyword

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -29,6 +29,7 @@ typeDefinition =
                         [ succeed (TypeAlias Nothing)
                             |> Combine.ignore (string "alias" |> Combine.continueWith Layout.layout)
                             |> Combine.andMap (Node.parser typeName |> Combine.ignore (maybe Layout.layout))
+                            |> Combine.ignore (maybe Layout.layout)
                             |> Combine.andMap genericList
                             |> Combine.ignore (string "=")
                             |> Combine.ignore (maybe Layout.layout)
@@ -41,8 +42,8 @@ typeDefinition =
                             |> Combine.andMap (Node.parser typeName)
                             |> Combine.ignore (maybe Layout.layout)
                             |> Combine.andMap genericList
+                            |> Combine.ignore (string "=")
                             |> Combine.ignore (maybe Layout.layout)
-                            |> Combine.ignore (string "=" |> Combine.ignore (maybe Layout.layout))
                             |> Combine.andThen (\tipe -> Combine.map (\( head, rest ) -> tipe head rest) valueConstructors)
                             |> Combine.map
                                 (\tipe ->
@@ -103,7 +104,7 @@ valueConstructor =
 
 genericList : Parser State (List (Node String))
 genericList =
-    many (Node.parser functionName |> Combine.ignore Layout.layout)
+    many (Node.parser functionName |> Combine.ignore (maybe Layout.layout))
 
 
 typePrefix : Parser State ()

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -17,15 +17,14 @@ import Test exposing (..)
 all : Test
 all =
     Test.concat
-        [ only <|
-            describe "FileTests" <|
-                List.indexedMap
-                    (\n s ->
-                        test ("sample " ++ String.fromInt (n + 1)) <|
-                            \() ->
-                                parseFullStringState emptyState s Parser.file |> Expect.notEqual Nothing
-                    )
-                    Samples.allSamples
+        [ describe "FileTests" <|
+            List.indexedMap
+                (\n s ->
+                    test ("sample " ++ String.fromInt (n + 1)) <|
+                        \() ->
+                            parseFullStringState emptyState s Parser.file |> Expect.notEqual Nothing
+                )
+                Samples.allSamples
 
         -- , describe "Error messages" <|
         --     [ test "failure on module name" <|

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -17,14 +17,15 @@ import Test exposing (..)
 all : Test
 all =
     Test.concat
-        [ describe "FileTests" <|
-            List.indexedMap
-                (\n s ->
-                    test ("sample " ++ String.fromInt (n + 1)) <|
-                        \() ->
-                            parseFullStringState emptyState s Parser.file |> Expect.notEqual Nothing
-                )
-                Samples.allSamples
+        [ only <|
+            describe "FileTests" <|
+                List.indexedMap
+                    (\n s ->
+                        test ("sample " ++ String.fromInt (n + 1)) <|
+                            \() ->
+                                parseFullStringState emptyState s Parser.file |> Expect.notEqual Nothing
+                    )
+                    Samples.allSamples
 
         -- , describe "Error messages" <|
         --     [ test "failure on module name" <|

--- a/tests/Elm/Parser/Samples.elm
+++ b/tests/Elm/Parser/Samples.elm
@@ -49,10 +49,73 @@ allSamples =
     , sample44
     , sample45
     , sample46
+    , sample47
+    , sample48
+    , sample49
+    , sample50
+    , sample51
     ]
 
 
+sample51 =
+    """module A exposing (..)
+
+f =
+    [case a of
+                _ -> ""]
+"""
+
+
+sample50 =
+    """module A exposing (..)
+
+f =
+    [case a of
+                _ -> ""
+               ]
+"""
+
+
+sample49 =
+    """module A exposing (..)
+
+f =
+    [case a of
+                _ -> ""
+                ]
+"""
+
+
+sample48 =
+    """module A exposing (..)
+
+f =
+    (\\a -> case a of
+                _ -> "")
+"""
+
+
+sample47 =
+    """module A exposing (..)
+
+f =
+    (\\a -> case a of
+                _ -> ""
+               )
+"""
+
+
 sample46 =
+    """module A exposing (..)
+
+f =
+    (\\a -> case a of
+                _ -> ""
+                )
+"""
+
+
+sample45 =
     """module A exposing (..)
 
 a =
@@ -63,7 +126,7 @@ a =
 """
 
 
-sample45 =
+sample44 =
     """module A exposing (..)
 
 type B a= B
@@ -71,7 +134,7 @@ type B a= B
 """
 
 
-sample44 =
+sample43 =
     """module A exposing (..)
 
 a =
@@ -81,7 +144,7 @@ a =
 """
 
 
-sample43 =
+sample42 =
     """module PegTest exposing (..)
 
 a =
@@ -89,32 +152,25 @@ a =
 
 b =
     infixl
-"""
 
-
-sample42 =
-    """module A exposing ( infixl , infixr )
-
-a = 0
+c =
+    infix
 """
 
 
 sample41 =
-    """module A exposing (..)
+    """module A exposing ( infixl , infixr, infix )
 
-type alias A msg=
-    { a : Int
-    }
+a = 0
 """
 
 
 sample40 =
     """module A exposing (..)
 
-f =
-    (\\a -> case a of
-                _ -> ""
-                )
+type alias A msg=
+    { a : Int
+    }
 """
 
 

--- a/tests/Elm/Parser/Samples.elm
+++ b/tests/Elm/Parser/Samples.elm
@@ -48,7 +48,19 @@ allSamples =
     , sample43
     , sample44
     , sample45
+    , sample46
     ]
+
+
+sample46 =
+    """module A exposing (..)
+
+a =
+    case b of
+        [
+         ] ->
+            ""
+"""
 
 
 sample45 =

--- a/tests/Elm/Parser/Samples.elm
+++ b/tests/Elm/Parser/Samples.elm
@@ -1,7 +1,5 @@
 module Elm.Parser.Samples exposing (allSamples, sample1, sample10, sample11, sample12, sample13, sample14, sample15, sample16, sample17, sample18, sample19, sample2, sample20, sample21, sample22, sample23, sample24, sample25, sample26, sample27, sample28, sample29, sample3, sample30, sample31, sample32, sample33, sample34, sample4, sample5, sample6, sample7, sample8, sample9)
 
-import Bitwise
-
 
 allSamples : List String
 allSamples =
@@ -44,7 +42,68 @@ allSamples =
     , sample37
     , sample38
     , sample39
+    , sample40
+    , sample41
+    , sample42
+    , sample43
+    , sample44
+    , sample45
     ]
+
+
+sample45 =
+    """module A exposing (..)
+
+type B a= B
+
+"""
+
+
+sample44 =
+    """module A exposing (..)
+
+a =
+    case b of
+        [  ] ->
+            ""
+"""
+
+
+sample43 =
+    """module PegTest exposing (..)
+
+a =
+    infixr
+
+b =
+    infixl
+"""
+
+
+sample42 =
+    """module A exposing ( infixl , infixr )
+
+a = 0
+"""
+
+
+sample41 =
+    """module A exposing (..)
+
+type alias A msg=
+    { a : Int
+    }
+"""
+
+
+sample40 =
+    """module A exposing (..)
+
+f =
+    (\\a -> case a of
+                _ -> ""
+                )
+"""
 
 
 sample39 =


### PR DESCRIPTION
This fixes some bugs I found while running the elm-review-bot. This included 
```elm
let b = 
    (case a of 
         _ -> ""
         )
```
, code containing infixl and infixr, and missing spaces in between the = sign and type parameters incorrectly failing to parse.