### PR TITLE
Fix let function declaration range

### DIFF
--- a/tests/tests/Elm/Parser/LetExpressionTests.elm
+++ b/tests/tests/Elm/Parser/LetExpressionTests.elm
@@ -52,7 +52,7 @@ all =
                 parseFullStringState emptyState "let\n  foo = bar\n  \n  john = doe\n in" Parser.letBlock
                     |> Expect.equal
                         (Just
-                            [ Node { end = { column = 3, row = 4 }, start = { column = 3, row = 2 } } <|
+                            [ Node { end = { column = 12, row = 2 }, start = { column = 3, row = 2 } } <|
                                 LetFunction
                                     { documentation = Nothing
                                     , signature = Nothing
@@ -63,7 +63,7 @@ all =
                                             , expression = Node { end = { column = 12, row = 2 }, start = { column = 9, row = 2 } } <| FunctionOrValue [] "bar"
                                             }
                                     }
-                            , Node { end = { column = 2, row = 5 }, start = { column = 3, row = 4 } } <|
+                            , Node { end = { column = 13, row = 4 }, start = { column = 3, row = 4 } } <|
                                 LetFunction
                                     { documentation = Nothing
                                     , signature = Nothing
@@ -84,7 +84,7 @@ all =
                         (Just
                             (LetExpression
                                 { declarations =
-                                    [ Node { end = { column = 2, row = 3 }, start = { column = 3, row = 2 } } <|
+                                    [ Node { end = { column = 10, row = 2 }, start = { column = 3, row = 2 } } <|
                                         LetFunction
                                             { documentation = Nothing
                                             , signature = Nothing
@@ -156,18 +156,17 @@ all =
         , test "some let" <|
             \() ->
                 parseFullStringState emptyState "let\n    _ = b\n in\n    z" Parser.expression
-                    |> Maybe.map noRangeExpression
                     |> Maybe.map Node.value
                     |> Expect.equal
                         (Just
                             (LetExpression
                                 { declarations =
-                                    [ Node emptyRange <|
+                                    [ Node { end = { column = 10, row = 2 }, start = { column = 5, row = 2 } } <|
                                         LetDestructuring
-                                            (Node emptyRange AllPattern)
-                                            (Node emptyRange <| FunctionOrValue [] "b")
+                                            (Node { end = { column = 6, row = 2 }, start = { column = 5, row = 2 } } AllPattern)
+                                            (Node { end = { column = 10, row = 2 }, start = { column = 9, row = 2 } } <| FunctionOrValue [] "b")
                                     ]
-                                , expression = Node emptyRange <| FunctionOrValue [] "z"
+                                , expression = Node { end = { column = 6, row = 4 }, start = { column = 5, row = 4 } } <| FunctionOrValue [] "z"
                                 }
                             )
                         )

--- a/tests/tests/Elm/Parser/LetExpressionTests.elm
+++ b/tests/tests/Elm/Parser/LetExpressionTests.elm
@@ -50,29 +50,28 @@ all =
         , test "let block" <|
             \() ->
                 parseFullStringState emptyState "let\n  foo = bar\n  \n  john = doe\n in" Parser.letBlock
-                    |> Maybe.map (List.map noRangeLetDeclaration)
                     |> Expect.equal
                         (Just
-                            [ Node emptyRange <|
+                            [ Node { end = { column = 3, row = 4 }, start = { column = 3, row = 2 } } <|
                                 LetFunction
                                     { documentation = Nothing
                                     , signature = Nothing
                                     , declaration =
-                                        Node emptyRange <|
-                                            { name = Node emptyRange "foo"
+                                        Node { end = { column = 12, row = 2 }, start = { column = 3, row = 2 } }
+                                            { name = Node { end = { column = 6, row = 2 }, start = { column = 3, row = 2 } } "foo"
                                             , arguments = []
-                                            , expression = Node emptyRange <| FunctionOrValue [] "bar"
+                                            , expression = Node { end = { column = 12, row = 2 }, start = { column = 9, row = 2 } } <| FunctionOrValue [] "bar"
                                             }
                                     }
-                            , Node emptyRange <|
+                            , Node { end = { column = 2, row = 5 }, start = { column = 3, row = 4 } } <|
                                 LetFunction
                                     { documentation = Nothing
                                     , signature = Nothing
                                     , declaration =
-                                        Node emptyRange <|
-                                            { name = Node emptyRange "john"
+                                        Node { end = { column = 13, row = 4 }, start = { column = 3, row = 4 } } <|
+                                            { name = Node { end = { column = 7, row = 4 }, start = { column = 3, row = 4 } } "john"
                                             , arguments = []
-                                            , expression = Node emptyRange <| FunctionOrValue [] "doe"
+                                            , expression = Node { end = { column = 13, row = 4 }, start = { column = 10, row = 4 } } <| FunctionOrValue [] "doe"
                                             }
                                     }
                             ]
@@ -80,25 +79,24 @@ all =
         , test "correct let with indent" <|
             \() ->
                 parseFullStringState emptyState "let\n  bar = 1\n in\n  bar" Parser.expression
-                    |> Maybe.map noRangeExpression
                     |> Maybe.map Node.value
                     |> Expect.equal
                         (Just
                             (LetExpression
                                 { declarations =
-                                    [ Node emptyRange <|
+                                    [ Node { end = { column = 2, row = 3 }, start = { column = 3, row = 2 } } <|
                                         LetFunction
                                             { documentation = Nothing
                                             , signature = Nothing
                                             , declaration =
-                                                Node emptyRange <|
-                                                    { name = Node emptyRange "bar"
+                                                Node { end = { column = 10, row = 2 }, start = { column = 3, row = 2 } } <|
+                                                    { name = Node { end = { column = 6, row = 2 }, start = { column = 3, row = 2 } } "bar"
                                                     , arguments = []
-                                                    , expression = Node emptyRange <| Integer 1
+                                                    , expression = Node { end = { column = 10, row = 2 }, start = { column = 9, row = 2 } } <| Integer 1
                                                     }
                                             }
                                     ]
-                                , expression = Node emptyRange <| FunctionOrValue [] "bar"
+                                , expression = Node { end = { column = 6, row = 4 }, start = { column = 3, row = 4 } } <| FunctionOrValue [] "bar"
                                 }
                             )
                         )


### PR DESCRIPTION
Previously, function declarations in a let expression would include all the trailing whitespace and even the `in` keyword in their range. I've fixed this so now the let function declaration's range stops at the end of their respective expressions.