### PR TITLE
Fix incorrect range for declarations for comments

### DIFF
--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -213,7 +213,7 @@ addDocumentation howToUpdate declaration file =
         Just doc ->
             { previousComments = previous :: file.previousComments
             , remainingComments = remaining
-            , declarations = Node (Node.range declaration) (howToUpdate doc) :: file.declarations
+            , declarations = Node (Range.combine [ Node.range doc, Node.range declaration ]) (howToUpdate doc) :: file.declarations
             }
 
         Nothing ->

--- a/tests/Elm/ProcessingTests.elm
+++ b/tests/Elm/ProcessingTests.elm
@@ -35,7 +35,7 @@ bar = 1
                     }
       , imports = []
       , declarations =
-            [ Node { start = { row = 5, column = 1 }, end = { row = 5, column = 8 } } <|
+            [ Node { start = { row = 3, column = 1 }, end = { row = 5, column = 8 } } <|
                 FunctionDeclaration
                     { documentation = Just (Node { start = { row = 3, column = 1 }, end = { row = 4, column = 3 } } "{-| The docs\n-}")
                     , signature = Nothing
@@ -71,7 +71,7 @@ bar = 1
                     }
       , imports = []
       , declarations =
-            [ Node { start = { row = 5, column = 1 }, end = { row = 6, column = 8 } } <|
+            [ Node { start = { row = 3, column = 1 }, end = { row = 6, column = 8 } } <|
                 FunctionDeclaration
                     { documentation =
                         Just <| Node { start = { row = 3, column = 1 }, end = { row = 4, column = 3 } } "{-| The docs\n-}"
@@ -228,12 +228,11 @@ type alias Foo
                     }
       , imports = []
       , declarations =
-            [ Node { start = { row = 4, column = 1 }, end = { row = 5, column = 23 } } <|
+            [ Node { start = { row = 3, column = 1 }, end = { row = 5, column = 23 } } <|
                 AliasDeclaration
                     { documentation =
                         Just <|
-                            Node { start = { row = 3, column = 1 }, end = { row = 3, column = 15 } } <|
-                                "{-| The Doc -}"
+                            Node { start = { row = 3, column = 1 }, end = { row = 3, column = 15 } } "{-| The Doc -}"
                     , name = Node { end = { column = 15, row = 4 }, start = { column = 12, row = 4 } } "Foo"
                     , generics = []
                     , typeAnnotation =
@@ -265,7 +264,7 @@ type Foo
 """
     , { comments = []
       , declarations =
-            [ Node { end = { column = 10, row = 6 }, start = { column = 1, row = 4 } }
+            [ Node { end = { column = 10, row = 6 }, start = { column = 1, row = 3 } }
                 (CustomTypeDeclaration
                     { constructors =
                         [ Node { end = { column = 9, row = 5 }, start = { column = 6, row = 5 } }


### PR DESCRIPTION
After doing #144, I discovered that the ranges for declarations with documentations (`{-| ... -}`) have an incorrect range that does not contain their documentation. The attached documentation field was at the right position, but was outside the range of its parent, which was surprising.

I've only noticed this right now because `elm-review-unused` circumvented the issue a long long time ago...

I'm not merging this directly into `master` because this part of the code was refactored more in #142.
I'll then backport all the PRs, including this one, bit by bit to `v8`.