### PR TITLE
Fix erroneous greedy lambda range parsing

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -398,12 +398,19 @@ lambdaExpression : Parser State (Node Expression)
 lambdaExpression =
     lazy
         (\() ->
-            succeed (\args expr -> Lambda args expr |> LambdaExpression)
-                |> Combine.ignore (string "\\")
-                |> Combine.ignore (maybe Layout.layout)
-                |> Combine.andMap (sepBy1 (maybe Layout.layout) functionArgument)
-                |> Combine.andMap (Layout.maybeAroundBothSides (string "->") |> Combine.continueWith expression)
-                |> Node.parser
+            Ranges.withCurrentPoint
+                (\current ->
+                    succeed
+                        (\args expr ->
+                            Lambda args expr
+                                |> LambdaExpression
+                                |> Node { start = current.start, end = (Node.range expr).end }
+                        )
+                        |> Combine.ignore (string "\\")
+                        |> Combine.ignore (maybe Layout.layout)
+                        |> Combine.andMap (sepBy1 (maybe Layout.layout) functionArgument)
+                        |> Combine.andMap (Layout.maybeAroundBothSides (string "->") |> Combine.continueWith expression)
+                )
         )
 
 

--- a/tests/Elm/Parser/LambdaExpressionTests.elm
+++ b/tests/Elm/Parser/LambdaExpressionTests.elm
@@ -1,7 +1,9 @@
 module Elm.Parser.LambdaExpressionTests exposing (all)
 
+import Combine
 import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Parser.Declarations as Parser
+import Elm.Parser.Layout as Layout
 import Elm.Parser.State exposing (emptyState)
 import Elm.Syntax.Expression exposing (..)
 import Elm.Syntax.Node as Node exposing (Node(..))
@@ -95,4 +97,9 @@ all =
                                 }
                             )
                         )
+        , test "lambda with trailing whitespace" <|
+            \() ->
+                parseFullStringState emptyState " \\a b -> a + b\n\n\n\n--some comment\n" (Layout.layout |> Combine.continueWith Parser.expression)
+                    |> Maybe.map Node.range
+                    |> Expect.equal (Just { end = { column = 15, row = 1 }, start = { column = 2, row = 1 } })
         ]


### PR DESCRIPTION
Fixes #136.  Looks like this got missed in 9d7a87a9b21f77b6ab8d76e188fa1a1c7089e4a9 which fixed it for `let` but not lambdas.  This just applies the same fix and adds a test for it.

These changes should probably be backported to `v7`, since they are currently causing `elm-review` rules to generate invalid code, e.g SiriusStarr/elm-review-no-unsorted#3.