### PR TITLE
Fix record type annotation parsing

### DIFF
--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -116,7 +116,7 @@ genericTypeAnnotation =
 
 recordFieldsTypeAnnotation : Parser State RecordDefinition
 recordFieldsTypeAnnotation =
-    lazy (\() -> sepBy (string ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition))
+    lazy (\() -> sepBy1 (string ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition))
 
 
 recordTypeAnnotation : Parser State (Node TypeAnnotation)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -123,27 +123,6 @@ recordTypeAnnotation : Parser State (Node TypeAnnotation)
 recordTypeAnnotation =
     lazy
         (\() ->
-            let
-                nextField : Parser State RecordField
-                nextField =
-                    Combine.succeed (\a b -> ( a, b ))
-                        |> Combine.ignore (Combine.string ",")
-                        |> Combine.ignore (maybe Layout.layout)
-                        |> Combine.andMap (Node.parser functionName)
-                        |> Combine.ignore (maybe Layout.layout)
-                        |> Combine.ignore (string ":")
-                        |> Combine.ignore (maybe Layout.layout)
-                        |> Combine.andMap typeAnnotation
-                        |> Combine.ignore Layout.optimisticLayout
-
-                additionalRecordFields : RecordDefinition -> Parser State RecordDefinition
-                additionalRecordFields items =
-                    Combine.choice
-                        [ Node.parser nextField
-                            |> Combine.andThen (\next -> additionalRecordFields (next :: items))
-                        , Combine.succeed (List.reverse items)
-                        ]
-            in
             Node.parser
                 (string "{"
                     |> Combine.ignore (maybe Layout.layout)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -165,10 +165,16 @@ recordTypeAnnotation =
                                                 |> Combine.ignore (maybe Layout.layout)
                                                 |> Combine.andThen
                                                     (\ta ->
-                                                        additionalRecordFields [ Node.combine Tuple.pair fname ta ]
-                                                            |> Combine.map Record
+                                                        Combine.choice
+                                                            [ -- Skip a comma and then look for at least 1 more field
+                                                              string ","
+                                                                |> Combine.continueWith recordFieldsTypeAnnotation
+                                                            , -- Single field record, so just end with no additional fields
+                                                              Combine.succeed []
+                                                            ]
+                                                            |> Combine.ignore (Combine.string "}")
+                                                            |> Combine.map (\rest -> Record <| Node.combine Tuple.pair fname ta :: rest)
                                                     )
-                                                |> Combine.ignore (Combine.string "}")
                                             ]
                                     )
                             ]

--- a/tests/Elm/Parser/TypeAnnotationTests.elm
+++ b/tests/Elm/Parser/TypeAnnotationTests.elm
@@ -153,6 +153,31 @@ all =
                                     ]
                             )
                         )
+        , test "record field ranges" <|
+            \() ->
+                parseFullStringWithNullState "{ foo : Int, bar : Int, baz : Int }" Parser.typeAnnotation
+                    |> Expect.equal
+                        (Just <|
+                            (Node { start = { column = 1, row = 1 }, end = { column = 36, row = 1 } } <|
+                                Record
+                                    [ Node { start = { column = 3, row = 1 }, end = { column = 12, row = 1 } }
+                                        ( Node { start = { column = 3, row = 1 }, end = { column = 6, row = 1 } } "foo"
+                                        , Node { start = { column = 9, row = 1 }, end = { column = 12, row = 1 } } <|
+                                            Typed (Node { start = { column = 9, row = 1 }, end = { column = 12, row = 1 } } ( [], "Int" )) []
+                                        )
+                                    , Node { start = { column = 14, row = 1 }, end = { column = 23, row = 1 } }
+                                        ( Node { start = { column = 14, row = 1 }, end = { column = 17, row = 1 } } "bar"
+                                        , Node { start = { column = 20, row = 1 }, end = { column = 23, row = 1 } } <|
+                                            Typed (Node { start = { column = 20, row = 1 }, end = { column = 23, row = 1 } } ( [], "Int" )) []
+                                        )
+                                    , Node { start = { column = 25, row = 1 }, end = { column = 35, row = 1 } }
+                                        ( Node { start = { column = 25, row = 1 }, end = { column = 28, row = 1 } } "baz"
+                                        , Node { start = { column = 31, row = 1 }, end = { column = 34, row = 1 } } <|
+                                            Typed (Node { start = { column = 31, row = 1 }, end = { column = 34, row = 1 } } ( [], "Int" )) []
+                                        )
+                                    ]
+                            )
+                        )
         , test "recordTypeReference with generic" <|
             \() ->
                 parseFullStringWithNullState "{color: s }" Parser.typeAnnotation

--- a/tests/Elm/Parser/TypeAnnotationTests.elm
+++ b/tests/Elm/Parser/TypeAnnotationTests.elm
@@ -128,6 +128,11 @@ all =
                                     )
                             )
                         )
+        , test "generic record with no fields" <|
+            \() ->
+                parseFullStringWithNullState "{ attr |}" Parser.typeAnnotation
+                    |> Maybe.map noRangeTypeReference
+                    |> Expect.equal Nothing
         , test "recordTypeReference nested record" <|
             \() ->
                 parseFullStringWithNullState "{color: {r : Int, g :Int, b: Int } }" Parser.typeAnnotation


### PR DESCRIPTION
Closes #154 and #156   (will need to manually close the latter if this gets merged, since it seems Github doesn't want to link the PR to both)

Use `sepBy1` for `recordFieldsTypeAnnotation`, make non-generic records also use `recordFieldsTypeAnnotation`, remove now-unnecessary let decs, and add tests for both generic record annotation with no fields and for erroneous ranges on record fields.

(If there is a non-manual way of writing tests including ranges, let me know so I can update this, but I don't think there is at the moment?)