### PR TITLE
spelling corrections

### DIFF
--- a/src/Elm/Syntax/Exposing.elm
+++ b/src/Elm/Syntax/Exposing.elm
@@ -34,7 +34,7 @@ import Json.Decode as JD exposing (Decoder)
 import Json.Encode as JE exposing (Value)
 
 
-{-| Diffent kind of exposing declarations
+{-| Different kind of exposing declarations
 -}
 type Exposing
     = All Range

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -228,7 +228,7 @@ isCase e =
             False
 
 
-{-| Check whether an expression is an operator appliation expression
+{-| Check whether an expression is an operator application expression
 -}
 isOperatorApplication : Expression -> Bool
 isOperatorApplication e =

--- a/src/Elm/Syntax/Infix.elm
+++ b/src/Elm/Syntax/Infix.elm
@@ -96,5 +96,5 @@ decodeDirection =
                         JD.succeed Non
 
                     _ ->
-                        JD.fail "Invlalid direction"
+                        JD.fail "Invalid direction"
             )

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -43,17 +43,17 @@ all =
                 parseFullStringWithNullState "\"\"\"Bar foo \n a\"\"\"" expression
                     |> Maybe.map Node.value
                     |> Expect.equal (Just (Literal "Bar foo \n a"))
-        , test "Regression test for muliline strings with backslashes" <|
+        , test "Regression test for multiline strings with backslashes" <|
             \() ->
                 parseFullStringWithNullState "\"\"\"\\{\\}\"\"\"" expression
                     |> Maybe.map Node.value
                     |> Expect.equal Nothing
-        , test "Regression test 2 for muliline strings with backslashes" <|
+        , test "Regression test 2 for multiline strings with backslashes" <|
             \() ->
                 parseFullStringWithNullState "\"\"\"\\\\{\\\\}\"\"\"" expression
                     |> Maybe.map Node.value
                     |> Expect.equal (Just (Literal "\\{\\}"))
-        , test "Regression test 3 for muliline strings with backslashes" <|
+        , test "Regression test 3 for multiline strings with backslashes" <|
             \() ->
                 parseFullStringWithNullState "\"\"\"\\\\a-blablabla-\\\\b\"\"\"" expression
                     |> Maybe.map Node.value


### PR DESCRIPTION
Mini corrections in public docs and test descriptions:
```diff
-Diffent
+Different

-appliation
+application

-Invlalid
+Invalid

-muliline
+multiline
```

On another note: `Pattern`s are serialized with
```elm
encodeTyped "parenthesized"
( "parentisized", JD.map ParenthesizedPattern ... )
```
which, correctly spelled, should be `"parenthesized"` just like the variant name.
This is a breaking change for users of the format, so I just left this notice for the next major version.