### PR TITLE
Remove unnecessary lazy calls

### DIFF
--- a/src/Elm/Parser/Comments.elm
+++ b/src/Elm/Parser/Comments.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Comments exposing (multilineComment, singleLineComment)
 
-import Combine exposing (Parser, lazy, modifyState, string, succeed)
+import Combine exposing (Parser, modifyState, string, succeed)
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State, addComment)
 import Elm.Parser.Whitespace exposing (untilNewlineToken)
@@ -35,4 +35,4 @@ multilineCommentInner =
 
 multilineComment : Parser State ()
 multilineComment =
-    lazy (\() -> parseComment multilineCommentInner)
+    parseComment multilineCommentInner

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -32,22 +32,16 @@ exposingListInner =
 
 exposable : Parser State (Node TopLevelExpose)
 exposable =
-    Combine.lazy
-        (\() ->
-            choice
-                [ typeExpose
-                , infixExpose
-                , functionExpose
-                ]
-        )
+    choice
+        [ typeExpose
+        , infixExpose
+        , functionExpose
+        ]
 
 
 infixExpose : Parser State (Node TopLevelExpose)
 infixExpose =
-    Combine.lazy
-        (\() ->
-            Node.parser (Combine.map InfixExpose (parens (while ((/=) ')'))))
-        )
+    Node.parser (Combine.map InfixExpose (parens (while ((/=) ')'))))
 
 
 typeExpose : Parser State (Node TopLevelExpose)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -18,25 +18,22 @@ type Mode
 
 typeAnnotation : Parser State (Node TypeAnnotation)
 typeAnnotation =
-    lazy
-        (\() ->
-            typeAnnotationNoFn Eager
-                |> Combine.andThen
-                    (\typeRef ->
-                        Layout.optimisticLayoutWith
-                            (\() -> succeed typeRef)
-                            (\() ->
-                                or
-                                    (Combine.map (\ta -> Node.combine FunctionTypeAnnotation typeRef ta)
-                                        (string "->"
-                                            |> Combine.ignore (maybe Layout.layout)
-                                            |> Combine.continueWith typeAnnotation
-                                        )
-                                    )
-                                    (succeed typeRef)
+    typeAnnotationNoFn Eager
+        |> Combine.andThen
+            (\typeRef ->
+                Layout.optimisticLayoutWith
+                    (\() -> succeed typeRef)
+                    (\() ->
+                        or
+                            (Combine.map (\ta -> Node.combine FunctionTypeAnnotation typeRef ta)
+                                (string "->"
+                                    |> Combine.ignore (maybe Layout.layout)
+                                    |> Combine.continueWith typeAnnotation
+                                )
                             )
+                            (succeed typeRef)
                     )
-        )
+            )
 
 
 typeAnnotationNonGreedy : Parser State (Node TypeAnnotation)
@@ -64,34 +61,31 @@ typeAnnotationNoFn mode =
 
 parensTypeAnnotation : Parser State (Node TypeAnnotation)
 parensTypeAnnotation =
-    lazy
-        (\() ->
-            let
-                commaSep : Parser State (List (Node TypeAnnotation))
-                commaSep =
-                    many
-                        (string ","
-                            |> Combine.ignore (maybe Layout.layout)
-                            |> Combine.continueWith typeAnnotation
-                            |> Combine.ignore (maybe Layout.layout)
-                        )
+    let
+        commaSep : Parser State (List (Node TypeAnnotation))
+        commaSep =
+            many
+                (string ","
+                    |> Combine.ignore (maybe Layout.layout)
+                    |> Combine.continueWith typeAnnotation
+                    |> Combine.ignore (maybe Layout.layout)
+                )
 
-                nested : Parser State TypeAnnotation
-                nested =
-                    Combine.succeed asTypeAnnotation
-                        |> Combine.ignore (maybe Layout.layout)
-                        |> Combine.andMap typeAnnotation
-                        |> Combine.ignore (maybe Layout.layout)
-                        |> Combine.andMap commaSep
-            in
-            Node.parser
-                (Combine.string "("
-                    |> Combine.continueWith
-                        (Combine.choice
-                            [ Combine.string ")" |> Combine.map (always Unit)
-                            , nested |> Combine.ignore (Combine.string ")")
-                            ]
-                        )
+        nested : Parser State TypeAnnotation
+        nested =
+            Combine.succeed asTypeAnnotation
+                |> Combine.ignore (maybe Layout.layout)
+                |> Combine.andMap typeAnnotation
+                |> Combine.ignore (maybe Layout.layout)
+                |> Combine.andMap commaSep
+    in
+    Node.parser
+        (Combine.string "("
+            |> Combine.continueWith
+                (Combine.choice
+                    [ Combine.string ")" |> Combine.map (always Unit)
+                    , nested |> Combine.ignore (Combine.string ")")
+                    ]
                 )
         )
 
@@ -108,115 +102,103 @@ asTypeAnnotation ((Node _ value) as x) xs =
 
 genericTypeAnnotation : Parser State (Node TypeAnnotation)
 genericTypeAnnotation =
-    lazy
-        (\() ->
-            Node.parser (Combine.map GenericType functionName)
-        )
+    Node.parser (Combine.map GenericType functionName)
 
 
 recordFieldsTypeAnnotation : Parser State RecordDefinition
 recordFieldsTypeAnnotation =
-    lazy (\() -> sepBy1 (string ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition))
+    sepBy1 (string ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition)
 
 
 recordTypeAnnotation : Parser State (Node TypeAnnotation)
 recordTypeAnnotation =
-    lazy
-        (\() ->
-            Node.parser
-                (string "{"
-                    |> Combine.ignore (maybe Layout.layout)
-                    |> Combine.continueWith
-                        (Combine.choice
-                            [ Combine.string "}" |> Combine.continueWith (Combine.succeed (Record []))
-                            , Node.parser functionName
-                                |> Combine.ignore (maybe Layout.layout)
-                                |> Combine.andThen
-                                    (\fname ->
-                                        Combine.choice
-                                            [ Combine.succeed (GenericRecord fname)
-                                                |> Combine.ignore (Combine.string "|")
-                                                |> Combine.andMap (Node.parser recordFieldsTypeAnnotation)
-                                                |> Combine.ignore (Combine.string "}")
-                                            , Combine.string ":"
-                                                |> Combine.ignore (maybe Layout.layout)
-                                                |> Combine.continueWith typeAnnotation
-                                                |> Combine.ignore (maybe Layout.layout)
-                                                |> Combine.andThen
-                                                    (\ta ->
-                                                        Combine.choice
-                                                            [ -- Skip a comma and then look for at least 1 more field
-                                                              string ","
-                                                                |> Combine.continueWith recordFieldsTypeAnnotation
-                                                            , -- Single field record, so just end with no additional fields
-                                                              Combine.succeed []
-                                                            ]
-                                                            |> Combine.ignore (Combine.string "}")
-                                                            |> Combine.map (\rest -> Record <| Node.combine Tuple.pair fname ta :: rest)
-                                                    )
-                                            ]
-                                    )
-                            ]
-                        )
+    Node.parser
+        (string "{"
+            |> Combine.ignore (maybe Layout.layout)
+            |> Combine.continueWith
+                (Combine.choice
+                    [ Combine.string "}" |> Combine.continueWith (Combine.succeed (Record []))
+                    , Node.parser functionName
+                        |> Combine.ignore (maybe Layout.layout)
+                        |> Combine.andThen
+                            (\fname ->
+                                Combine.choice
+                                    [ Combine.succeed (GenericRecord fname)
+                                        |> Combine.ignore (Combine.string "|")
+                                        |> Combine.andMap (Node.parser recordFieldsTypeAnnotation)
+                                        |> Combine.ignore (Combine.string "}")
+                                    , Combine.string ":"
+                                        |> Combine.ignore (maybe Layout.layout)
+                                        |> Combine.continueWith typeAnnotation
+                                        |> Combine.ignore (maybe Layout.layout)
+                                        |> Combine.andThen
+                                            (\ta ->
+                                                Combine.choice
+                                                    [ -- Skip a comma and then look for at least 1 more field
+                                                      string ","
+                                                        |> Combine.continueWith recordFieldsTypeAnnotation
+                                                    , -- Single field record, so just end with no additional fields
+                                                      Combine.succeed []
+                                                    ]
+                                                    |> Combine.ignore (Combine.string "}")
+                                                    |> Combine.map (\rest -> Record <| Node.combine Tuple.pair fname ta :: rest)
+                                            )
+                                    ]
+                            )
+                    ]
                 )
         )
 
 
 recordFieldDefinition : Parser State RecordField
 recordFieldDefinition =
-    lazy
-        (\() ->
-            succeed Tuple.pair
-                |> Combine.andMap (maybe Layout.layout |> Combine.continueWith (Node.parser functionName))
-                |> Combine.andMap
-                    (maybe Layout.layout
-                        |> Combine.continueWith (string ":")
-                        |> Combine.continueWith (maybe Layout.layout)
-                        |> Combine.continueWith typeAnnotation
-                    )
-        )
+    succeed Tuple.pair
+        |> Combine.andMap (maybe Layout.layout |> Combine.continueWith (Node.parser functionName))
+        |> Combine.andMap
+            (maybe Layout.layout
+                |> Combine.continueWith (string ":")
+                |> Combine.continueWith (maybe Layout.layout)
+                |> Combine.continueWith typeAnnotation
+            )
 
 
 typedTypeAnnotation : Mode -> Parser State (Node TypeAnnotation)
 typedTypeAnnotation mode =
-    lazy
-        (\() ->
-            let
-                genericHelper : List (Node TypeAnnotation) -> Parser State (List (Node TypeAnnotation))
-                genericHelper items =
-                    or
-                        (typeAnnotationNoFn Lazy
-                            |> Combine.andThen
-                                (\next ->
-                                    Layout.optimisticLayoutWith
-                                        (\() -> Combine.succeed (List.reverse (next :: items)))
-                                        (\() -> genericHelper (next :: items))
-                                        |> Combine.ignore (maybe Layout.layout)
-                                )
+    let
+        genericHelper : List (Node TypeAnnotation) -> Parser State (List (Node TypeAnnotation))
+        genericHelper items =
+            or
+                (typeAnnotationNoFn Lazy
+                    |> Combine.andThen
+                        (\next ->
+                            Layout.optimisticLayoutWith
+                                (\() -> Combine.succeed (List.reverse (next :: items)))
+                                (\() -> genericHelper (next :: items))
+                                |> Combine.ignore (maybe Layout.layout)
                         )
-                        (Combine.succeed (List.reverse items))
+                )
+                (Combine.succeed (List.reverse items))
 
-                nodeRanges =
-                    List.map (\(Node r _) -> r)
-            in
-            Node.parser typeIndicator
-                |> Combine.andThen
-                    (\((Node tir _) as original) ->
-                        Layout.optimisticLayoutWith
-                            (\() -> Combine.succeed (Node tir (Typed original [])))
-                            (\() ->
-                                case mode of
-                                    Eager ->
-                                        Combine.map
-                                            (\args ->
-                                                Node
-                                                    (Range.combine (tir :: nodeRanges args))
-                                                    (Typed original args)
-                                            )
-                                            (genericHelper [])
+        nodeRanges =
+            List.map (\(Node r _) -> r)
+    in
+    Node.parser typeIndicator
+        |> Combine.andThen
+            (\((Node tir _) as original) ->
+                Layout.optimisticLayoutWith
+                    (\() -> Combine.succeed (Node tir (Typed original [])))
+                    (\() ->
+                        case mode of
+                            Eager ->
+                                Combine.map
+                                    (\args ->
+                                        Node
+                                            (Range.combine (tir :: nodeRanges args))
+                                            (Typed original args)
+                                    )
+                                    (genericHelper [])
 
-                                    Lazy ->
-                                        Combine.succeed (Node tir (Typed original []))
-                            )
+                            Lazy ->
+                                Combine.succeed (Node tir (Typed original []))
                     )
-        )
+            )


### PR DESCRIPTION
There were a large number of unnecessary `lazy` calls. Hopefully this will make parsers slightly faster. If not, then they'll at least be a bit cleaner.

EDIT: I forgot we have like 2 main branches on this project. I'll backport this to v8 afterwards.