### PR TITLE
Make sure file comments are sorted

### DIFF
--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -90,16 +90,13 @@ process _ (InternalRawFile.Raw file) =
     { moduleDefinition = file.moduleDefinition
     , imports = file.imports
     , declarations = List.reverse changes.declarations
-    , comments =
-        (changes.remainingComments :: changes.previousComments)
-            |> List.reverse
-            |> List.concat
+    , comments = List.sortWith (\(Node a _) (Node b _) -> Range.compare a b) (changes.remainingComments ++ changes.previousComments)
     }
 
 
 type alias DeclarationsAndComments =
     { declarations : List (Node Declaration)
-    , previousComments : List (List (Node Comment))
+    , previousComments : List (Node Comment)
     , remainingComments : List (Node Comment)
     }
 
@@ -158,13 +155,13 @@ addDocumentation howToUpdate declaration file =
     in
     case maybeDoc of
         Just doc ->
-            { previousComments = previous :: file.previousComments
+            { previousComments = previous ++ file.previousComments
             , remainingComments = remaining
             , declarations = Node (Range.combine [ Node.range doc, Node.range declaration ]) (howToUpdate doc) :: file.declarations
             }
 
         Nothing ->
-            { previousComments = previous :: file.previousComments
+            { previousComments = previous ++ file.previousComments
             , remainingComments = remaining
             , declarations = declaration :: file.declarations
             }

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -93,10 +93,10 @@ f =
                     |> Result.map .comments
                     |> Expect.equal
                         (Ok
-                            [ Node { start = { row = 11, column = 1 }, end = { row = 11, column = 5 } } "-- 3"
-                            , Node { start = { row = 10, column = 1 }, end = { row = 10, column = 8 } } "{- 2 -}"
+                            [ Node { start = { row = 4, column = 1 }, end = { row = 5, column = 3 } } "{-| Module documentation\n-}"
                             , Node { start = { row = 9, column = 1 }, end = { row = 9, column = 5 } } "-- 1"
-                            , Node { start = { row = 4, column = 1 }, end = { row = 5, column = 3 } } "{-| Module documentation\n-}"
+                            , Node { start = { row = 10, column = 1 }, end = { row = 10, column = 8 } } "{- 2 -}"
+                            , Node { start = { row = 11, column = 1 }, end = { row = 11, column = 5 } } "-- 3"
                             , Node { start = { row = 16, column = 5 }, end = { row = 16, column = 9 } } "-- 4"
                             , Node { start = { row = 19, column = 1 }, end = { row = 19, column = 5 } } "-- 5"
                             , Node { start = { row = 20, column = 1 }, end = { row = 20, column = 8 } } "{- 6 -}"

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -40,7 +40,7 @@ all =
         --                 |> Expect.equal (Err [ "Could not continue parsing on location (2,6)" ])
         --     ]
         , describe "FileTests - serialisation"
-            [ Samples.allSamples
+            (Samples.allSamples
                 |> List.indexedMap
                     (\n s ->
                         test ("sample " ++ String.fromInt (n + 1)) <|
@@ -57,6 +57,5 @@ all =
                                 in
                                 Expect.equal parsed roundTrip
                     )
-                |> Test.concat
-            ]
+            )
         ]

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -1,11 +1,13 @@
 module Elm.Parser.FileTests exposing (all)
 
 import Elm.Internal.RawFile as InternalRawFile
+import Elm.Parser
 import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Parser.File as Parser
 import Elm.Parser.Samples as Samples
 import Elm.Parser.State exposing (emptyState)
 import Elm.RawFile as RawFile exposing (RawFile)
+import Elm.Syntax.Node exposing (Node(..))
 import Expect
 import Json.Decode
 import Json.Encode
@@ -60,4 +62,44 @@ all =
                                 Expect.equal parsed roundTrip
                     )
             )
+        , test "Comments ordering" <|
+            \() ->
+                let
+                    input : String
+                    input =
+                        """
+module Foo exposing (..)
+
+{-| Module documentation
+-}
+
+import A
+
+-- 1
+{- 2 -}
+-- 3
+
+{-| Function declaration
+-}
+f =
+    -- 4
+    identity
+
+-- 5
+{- 6 -}
+"""
+                in
+                Elm.Parser.parseToFile input
+                    |> Result.map .comments
+                    |> Expect.equal
+                        (Ok
+                            [ Node { start = { row = 11, column = 1 }, end = { row = 11, column = 5 } } "-- 3"
+                            , Node { start = { row = 10, column = 1 }, end = { row = 10, column = 8 } } "{- 2 -}"
+                            , Node { start = { row = 9, column = 1 }, end = { row = 9, column = 5 } } "-- 1"
+                            , Node { start = { row = 4, column = 1 }, end = { row = 5, column = 3 } } "{-| Module documentation\n-}"
+                            , Node { start = { row = 16, column = 5 }, end = { row = 16, column = 9 } } "-- 4"
+                            , Node { start = { row = 19, column = 1 }, end = { row = 19, column = 5 } } "-- 5"
+                            , Node { start = { row = 20, column = 1 }, end = { row = 20, column = 8 } } "{- 6 -}"
+                            ]
+                        )
         ]

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -5,7 +5,7 @@ import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Parser.File as Parser
 import Elm.Parser.Samples as Samples
 import Elm.Parser.State exposing (emptyState)
-import Elm.RawFile as RawFile
+import Elm.RawFile as RawFile exposing (RawFile)
 import Expect
 import Json.Decode
 import Json.Encode
@@ -46,10 +46,12 @@ all =
                         test ("sample " ++ String.fromInt (n + 1)) <|
                             \() ->
                                 let
+                                    parsed : Maybe RawFile
                                     parsed =
                                         parseFullStringState emptyState s Parser.file
                                             |> Maybe.map InternalRawFile.Raw
 
+                                    roundTrip : Maybe RawFile
                                     roundTrip =
                                         parsed
                                             |> Maybe.map (RawFile.encode >> Json.Encode.encode 0)


### PR DESCRIPTION
This sorts comments from closest to furthest from the start of the file.
Previously, the order was somewhat random, as can be seen in [this temporary commit](https://github.com/stil4m/elm-syntax/commit/fe59cac6aa26051483502d861da2b9dcca38d078#diff-5695ccd7e19fe3749727cf2a0f2a627f534609a7ce87f8682997c612096b1923R96-R102)

We already do this sorting in `elm-review`, but it feels off to have to do it there. 
This will make it more consistent as well, since declarations and imports are in "normal" order but comments weren't.

Can be reviewed commit by commit.