### PR TITLE
Optimize Range.combine

### DIFF
--- a/review/suppressed/NoMissingTypeAnnotationInLetIn.json
+++ b/review/suppressed/NoMissingTypeAnnotationInLetIn.json
@@ -7,7 +7,6 @@
     { "count": 9, "filePath": "src/Elm/Writer.elm" },
     { "count": 7, "filePath": "src/Elm/Parser/Declarations.elm" },
     { "count": 3, "filePath": "src/Elm/Parser/Imports.elm" },
-    { "count": 2, "filePath": "src/Elm/Syntax/Range.elm" },
     { "count": 2, "filePath": "tests/Elm/Parser/PatternTests.elm" },
     { "count": 2, "filePath": "tests/Elm/Parser/TypeAnnotationTests.elm" },
     { "count": 1, "filePath": "src/Combine.elm" },

--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -157,7 +157,7 @@ addDocumentation howToUpdate declaration file =
         Just doc ->
             { previousComments = previous ++ file.previousComments
             , remainingComments = remaining
-            , declarations = Node (Range.combine [ Node.range doc, Node.range declaration ]) (howToUpdate doc) :: file.declarations
+            , declarations = Node { start = (Node.range doc).start, end = (Node.range declaration).end } (howToUpdate doc) :: file.declarations
             }
 
         Nothing ->

--- a/src/Elm/Syntax/Range.elm
+++ b/src/Elm/Syntax/Range.elm
@@ -97,22 +97,41 @@ fromList input =
 -}
 combine : List Range -> Range
 combine ranges =
-    let
-        starts =
-            List.map .start ranges |> sortLocations
+    case ranges of
+        [] ->
+            emptyRange
 
-        ends =
-            List.map .end ranges |> sortLocations |> List.reverse
-    in
-    Maybe.map2 Range (List.head starts) (List.head ends)
-        |> Maybe.withDefault emptyRange
+        head :: tail ->
+            combineHelp tail head.start head.end
 
 
-{-| Could be faster via single fold
--}
-sortLocations : List Location -> List Location
-sortLocations =
-    List.sortWith compareLocations
+combineHelp : List Range -> Location -> Location -> Range
+combineHelp ranges previousStart previousEnd =
+    case ranges of
+        [] ->
+            { start = previousStart, end = previousEnd }
+
+        { start, end } :: rest ->
+            let
+                newStart : Location
+                newStart =
+                    case compareLocations start previousStart of
+                        LT ->
+                            start
+
+                        _ ->
+                            previousStart
+
+                newEnd : Location
+                newEnd =
+                    case compareLocations end previousEnd of
+                        GT ->
+                            end
+
+                        _ ->
+                            previousEnd
+            in
+            combineHelp rest newStart newEnd
 
 
 {-| Compare the position of two Ranges.

--- a/src/Elm/Syntax/Range.elm
+++ b/src/Elm/Syntax/Range.elm
@@ -77,31 +77,20 @@ encode { start, end } =
 decoder : Decoder Range
 decoder =
     JD.list JD.int
-        |> JD.andThen
-            (fromList >> fromResult)
+        |> JD.andThen fromList
 
 
-fromList : List Int -> Result String Range
+fromList : List Int -> Decoder Range
 fromList input =
     case input of
         [ a, b, c, d ] ->
-            Ok
+            JD.succeed
                 { start = { row = a, column = b }
                 , end = { row = c, column = d }
                 }
 
         _ ->
-            Err "Invalid input list"
-
-
-fromResult : Result String a -> Decoder a
-fromResult result =
-    case result of
-        Ok successValue ->
-            JD.succeed successValue
-
-        Err errorMessage ->
-            JD.fail errorMessage
+            JD.fail "Invalid input list"
 
 
 {-| Compute the largest area of a list of ranges.


### PR DESCRIPTION
- Avoid using `Range.combine` in a situation where we know which location is the start and which one is the end.
- Make `Range.combine` much faster (haven't done a benchmark but we do a LOT less list operations)