### PR TITLE
Fix stack overflow during post-processing

### DIFF
--- a/review/suppressed/NoDeprecated.json
+++ b/review/suppressed/NoDeprecated.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "automatically created by": "elm-review suppress",
+  "learn more": "elm-review suppress --help",
+  "suppressions": [
+    { "count": 2, "filePath": "tests/Elm/ProcessingTests.elm" }
+  ]
+}

--- a/src/Elm/Processing.elm
+++ b/src/Elm/Processing.elm
@@ -409,12 +409,24 @@ visitFunctionDeclaration functionDeclaration =
 
 
 visitExpression : Node Expression -> Node Expression
-visitExpression (Node range expression) =
+visitExpression expression =
+    visitExpressionInner <|
+        case expression of
+            Node r (Application args) ->
+                Node r (fixApplication args)
+
+            _ ->
+                expression
+
+
+visitExpressionInner : Node Expression -> Node Expression
+visitExpressionInner (Node range expression) =
     Node range <|
         case expression of
             Application args ->
-                visitExpression (Node range (fixApplication args))
-                    |> Node.value
+                args
+                    |> List.map visitExpression
+                    |> Application
 
             OperatorApplication op dir left right ->
                 OperatorApplication op

--- a/tests/Elm/ProcessingTests.elm
+++ b/tests/Elm/ProcessingTests.elm
@@ -1,6 +1,7 @@
-module Elm.ProcessingTests exposing (suite)
+module Elm.ProcessingTests exposing (suite, suiteDeprecated)
 
 import Elm.Parser as Parser
+import Elm.Processing as Processing
 import Elm.Syntax.Declaration exposing (..)
 import Elm.Syntax.Exposing exposing (..)
 import Elm.Syntax.Expression exposing (..)
@@ -10,6 +11,7 @@ import Elm.Syntax.Module exposing (..)
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.TypeAnnotation exposing (..)
 import Expect
+import Parser exposing (DeadEnd)
 import Test exposing (..)
 
 
@@ -22,6 +24,28 @@ suite =
                     \() ->
                         Parser.parseToFile (String.trim input)
                             |> Expect.equal (Ok output)
+            )
+            testCases
+        )
+
+
+{-| Using the deprecated `Elm.Parser.parse`.
+-}
+suiteDeprecated : Test
+suiteDeprecated =
+    describe "Elm.Processing.parse"
+        (List.map
+            (\( name, input, output ) ->
+                test name <|
+                    \() ->
+                        case context of
+                            Ok context_ ->
+                                Parser.parse (String.trim input)
+                                    |> Result.map (Processing.process context_)
+                                    |> Expect.equal (Ok output)
+
+                            Err _ ->
+                                Expect.fail "Failed to generate context."
             )
             testCases
         )
@@ -44,6 +68,36 @@ testCases =
     , typeAliasWithDocumentation
     , typeWithDocumentation
     ]
+
+
+context : Result (List DeadEnd) Processing.ProcessContext
+context =
+    """
+module Basics exposing ((+), (-), (*), (/), (//), (^), (==), (/=), (<), (>), (<=), (>=), (&&), (||), (++), (<|), (|>), (<<), (>>))
+         
+         
+infix right 0 (<|) = apL
+infix left  0 (|>) = apR
+infix right 2 (||) = or
+infix right 3 (&&) = and
+infix non   4 (==) = eq
+infix non   4 (/=) = neq
+infix non   4 (<)  = lt
+infix non   4 (>)  = gt
+infix non   4 (<=) = le
+infix non   4 (>=) = ge
+infix right 5 (++) = append
+infix left  6 (+)  = add
+infix left  6 (-)  = sub
+infix left  7 (*)  = mul
+infix left  7 (/)  = fdiv
+infix left  7 (//) = idiv
+infix right 8 (^)  = pow
+infix left  9 (<<) = composeL
+infix right 9 (>>) = composeR"""
+        |> String.trim
+        |> Parser.parse
+        |> Result.map (\a -> Processing.addFile a Processing.init)
 
 
 functionWithDocs : ( String, String, File )

--- a/tests/Elm/ProcessingTests.elm
+++ b/tests/Elm/ProcessingTests.elm
@@ -13,6 +13,39 @@ import Expect
 import Test exposing (..)
 
 
+suite : Test
+suite =
+    describe "Elm.Processing"
+        (List.map
+            (\( name, input, output ) ->
+                test name <|
+                    \() ->
+                        Parser.parseToFile (String.trim input)
+                            |> Expect.equal (Ok output)
+            )
+            testCases
+        )
+
+
+testCases : List ( String, String, File )
+testCases =
+    [ functionWithDocs
+    , functionWithDocsAndSignature
+    , functionWithSingleLineCommentAsDoc
+    , fileWithMultipleComments
+    , functionWithMultiLineCommentAsDoc
+    , postProcessInfixOperators
+    , postProcessInfixOperators2
+    , postProcessInfixOperators3
+    , postProcessInfixOperatorsInNegation
+    , postProcessInfixOperatorsInRecordAccess
+    , postProcessInfixOperatorsRegressionTest
+    , postProcessInfixOperatorsAssociativityTest
+    , typeAliasWithDocumentation
+    , typeWithDocumentation
+    ]
+
+
 functionWithDocs : ( String, String, File )
 functionWithDocs =
     ( "functionWithDocs"
@@ -748,31 +781,3 @@ pipeline1 = 1 |> 2 |> 3
                 )
       }
     )
-
-
-suite : Test
-suite =
-    describe "Elm.Processing"
-        (List.map
-            (\( name, input, output ) ->
-                test name <|
-                    \() ->
-                        Parser.parseToFile (String.trim input)
-                            |> Expect.equal (Ok output)
-            )
-            [ functionWithDocs
-            , functionWithDocsAndSignature
-            , functionWithSingleLineCommentAsDoc
-            , fileWithMultipleComments
-            , functionWithMultiLineCommentAsDoc
-            , postProcessInfixOperators
-            , postProcessInfixOperators2
-            , postProcessInfixOperators3
-            , postProcessInfixOperatorsInNegation
-            , postProcessInfixOperatorsInRecordAccess
-            , postProcessInfixOperatorsRegressionTest
-            , postProcessInfixOperatorsAssociativityTest
-            , typeAliasWithDocumentation
-            , typeWithDocumentation
-            ]
-        )

--- a/tests/Elm/ProcessingTests.elm
+++ b/tests/Elm/ProcessingTests.elm
@@ -9,6 +9,7 @@ import Elm.Syntax.File exposing (..)
 import Elm.Syntax.Infix exposing (..)
 import Elm.Syntax.Module exposing (..)
 import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
 import Elm.Syntax.TypeAnnotation exposing (..)
 import Expect
 import Parser exposing (DeadEnd)
@@ -67,6 +68,7 @@ testCases =
     , postProcessInfixOperatorsAssociativityTest
     , typeAliasWithDocumentation
     , typeWithDocumentation
+    , maxCallStackSizeFailure
     ]
 
 
@@ -332,6 +334,43 @@ type alias Foo
                     }
             ]
       , comments = []
+      }
+    )
+
+
+maxCallStackSizeFailure : ( String, String, File )
+maxCallStackSizeFailure =
+    ( "maxCallStackSizeFailure"
+    , """module Simplify.AstHelpers exposing (log)
+
+
+log : Int -> Int
+log a =
+    Debug.log "ok" a
+"""
+    , { comments = []
+      , declarations =
+            [ Node { end = { column = 21, row = 6 }, start = { column = 1, row = 4 } }
+                (FunctionDeclaration
+                    { declaration = Node { end = { column = 21, row = 6 }, start = { column = 1, row = 5 } } { arguments = [ Node { end = { column = 6, row = 5 }, start = { column = 5, row = 5 } } (VarPattern "a") ], expression = Node { end = { column = 21, row = 6 }, start = { column = 5, row = 6 } } (Application [ Node { end = { column = 14, row = 6 }, start = { column = 5, row = 6 } } (FunctionOrValue [ "Debug" ] "log"), Node { end = { column = 19, row = 6 }, start = { column = 15, row = 6 } } (Literal "ok"), Node { end = { column = 21, row = 6 }, start = { column = 20, row = 6 } } (FunctionOrValue [] "a") ]), name = Node { end = { column = 4, row = 5 }, start = { column = 1, row = 5 } } "log" }
+                    , documentation = Nothing
+                    , signature = Just (Node { end = { column = 17, row = 4 }, start = { column = 1, row = 4 } } { name = Node { end = { column = 4, row = 4 }, start = { column = 1, row = 4 } } "log", typeAnnotation = Node { end = { column = 17, row = 4 }, start = { column = 7, row = 4 } } (FunctionTypeAnnotation (Node { end = { column = 10, row = 4 }, start = { column = 7, row = 4 } } (Typed (Node { end = { column = 10, row = 4 }, start = { column = 7, row = 4 } } ( [], "Int" )) [])) (Node { end = { column = 17, row = 4 }, start = { column = 14, row = 4 } } (Typed (Node { end = { column = 17, row = 4 }, start = { column = 14, row = 4 } } ( [], "Int" )) []))) })
+                    }
+                )
+            ]
+      , imports = []
+      , moduleDefinition =
+            Node { end = { column = 42, row = 1 }, start = { column = 1, row = 1 } }
+                (NormalModule
+                    { exposingList =
+                        Node { end = { column = 42, row = 1 }, start = { column = 28, row = 1 } }
+                            (Explicit
+                                [ Node { end = { column = 41, row = 1 }, start = { column = 38, row = 1 } } (FunctionExpose "log")
+                                ]
+                            )
+                    , moduleName = Node { end = { column = 27, row = 1 }, start = { column = 8, row = 1 } } [ "Simplify", "AstHelpers" ]
+                    }
+                )
       }
     )
 


### PR DESCRIPTION
I introduced an infinite recursion in 03ce4ff14672b7d4f5e49a9a978ddc2df51b01c, which wasn't caught because we have few parser tests that do post-processing, and none of them had a single function call.

I would very much like to go back to the previous version of the `visitExpression` that wasn't split in 2 (to reduce the size of the call stack and improve performance), but I can't seem to wrap my around it in a way that doesn't break the re-balancing of the tree or result in a infinite recursion again.