### PR TITLE
Do not support parsing FloatPattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Stop parsing `FloatPattern` (this is an invalid pattern in Elm 0.19)
+
 ## [7.3.1] - 2022-08-16
 
 - Fixed an infinite recursion during parsing of a file.

--- a/src/Elm/Parser/Numbers.elm
+++ b/src/Elm/Parser/Numbers.elm
@@ -5,14 +5,14 @@ import Elm.Parser.State exposing (State)
 import Parser as Core
 
 
-raw : (Float -> a) -> (Int -> a) -> (Int -> a) -> Core.Parser a
+raw : Maybe (Float -> a) -> (Int -> a) -> (Int -> a) -> Core.Parser a
 raw floatf intf hexf =
     Core.number
         { int = Just intf
         , hex = Just hexf
         , octal = Nothing
         , binary = Nothing
-        , float = Just floatf
+        , float = floatf
         }
 
 
@@ -20,11 +20,11 @@ raw floatf intf hexf =
 -}
 forgivingNumber : (Float -> a) -> (Int -> a) -> (Int -> a) -> Parser State a
 forgivingNumber floatf intf hexf =
-    Core.backtrackable (raw floatf intf hexf)
+    Core.backtrackable (raw (Just floatf) intf hexf)
         |> Combine.fromCore
 
 
-number : (Float -> a) -> (Int -> a) -> (Int -> a) -> Parser State a
-number floatf intf hexf =
-    raw floatf intf hexf
+number : (Int -> a) -> (Int -> a) -> Parser State a
+number intf hexf =
+    raw Nothing intf hexf
         |> Combine.fromCore

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -62,7 +62,7 @@ variablePart =
 
 numberPart : Parser State Pattern
 numberPart =
-    Elm.Parser.Numbers.number FloatPattern IntPattern HexPattern
+    Elm.Parser.Numbers.number IntPattern HexPattern
 
 
 listPattern : Parser State (Node Pattern)

--- a/tests/Elm/Parser/NumbersTests.elm
+++ b/tests/Elm/Parser/NumbersTests.elm
@@ -11,12 +11,12 @@ all =
     describe "NumbersTests"
         [ test "hex" <|
             \() ->
-                parseFullStringWithNullState "0x03FFFFFF" (Parser.number (always Nothing) (always Nothing) Just)
+                parseFullStringWithNullState "0x03FFFFFF" (Parser.number (always Nothing) Just)
                     |> Expect.equal
                         (Just (Just 67108863))
         , test "hex - 2" <|
             \() ->
-                parseFullStringWithNullState "0xFF" (Parser.number (always Nothing) (always Nothing) Just)
+                parseFullStringWithNullState "0xFF" (Parser.number (always Nothing) Just)
                     |> Expect.equal
                         (Just (Just 255))
         ]

--- a/tests/Elm/Parser/PatternTests.elm
+++ b/tests/Elm/Parser/PatternTests.elm
@@ -45,6 +45,8 @@ all =
             \() ->
                 "0x1"
                     |> expectAst (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } <| HexPattern 1)
+        , test "Float should not be valid" <|
+            \() -> expectInvalid "1.0"
         , test "Uncons" <|
             \() ->
                 "n :: tail"


### PR DESCRIPTION
`FloatPattern` is not valid Elm code (reproduction: https://ellie-app.com/nKH4nP3gH2Va1)

We already decided to remove it from v8 (see eeed6b2f52003c74576a3139ad05743c8ef28aa1), but I'm turning this into a parsing error for v7 already so that it is easier to find syntax errors (after an `elm-review` fix for instance).