### PR TITLE
Do not support parsing Destructuring declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Stop parsing `FloatPattern` (this is an invalid pattern in Elm 0.19)
+- Stop parsing `Destructuring` declaration (this is an invalid declaration in Elm 0.19)
 
 ## [7.3.1] - 2022-08-16
 

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -38,7 +38,6 @@ declaration =
                             Node r (Declaration.AliasDeclaration a)
                 )
         , portDeclaration
-        , destructuringDeclaration
         ]
 
 
@@ -120,16 +119,6 @@ infixDeclaration =
             Infix.infixDefinition
                 |> Combine.map (\inf -> Node (Range.combine [ current, Node.range inf.function ]) (Declaration.InfixDeclaration inf))
         )
-
-
-destructuringDeclaration : Parser State (Node Declaration)
-destructuringDeclaration =
-    succeed
-        (\x y -> Node.combine Declaration.Destructuring x y)
-        |> Combine.andMap pattern
-        |> Combine.ignore (string "=")
-        |> Combine.ignore Layout.layout
-        |> Combine.andMap expression
 
 
 portDeclaration : Parser State (Node Declaration)

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -469,16 +469,10 @@ all =
                                 }
                             )
                         )
-        , test "Destructuring declaration" <|
+        , test "should fail to parse destructuring declaration at the top-level" <|
             \() ->
-                parseFullStringWithNullState "_ = b" declaration
-                    |> Maybe.map Node.value
-                    |> Expect.equal
-                        (Just
-                            (Destructuring (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } AllPattern)
-                                (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 6 } } (FunctionOrValue [] "b"))
-                            )
-                        )
+                "_ = b"
+                    |> expectInvalid
         , test "declaration" <|
             \() ->
                 parseFullStringState emptyState "main =\n  text \"Hello, World!\"" Parser.function
@@ -666,3 +660,13 @@ all =
                 parseFullStringState emptyState "a = (+ )" Parser.function
                     |> Expect.equal Nothing
         ]
+
+
+expectInvalid : String -> Expect.Expectation
+expectInvalid source =
+    case parseFullStringWithNullState source declaration of
+        Nothing ->
+            Expect.pass
+
+        Just actual ->
+            Expect.fail ("This source code is successfully parsed but it shouldn't:\n" ++ Debug.toString actual)

--- a/tests/Elm/Parser/Samples.elm
+++ b/tests/Elm/Parser/Samples.elm
@@ -12,7 +12,6 @@ allSamples =
     , sample7
     , sample8
     , sample9
-    , sample10
     , sample11
     , sample12
     , sample13
@@ -623,13 +622,6 @@ update msg model =
 
 
       """
-
-
-sample10 : String
-sample10 =
-    """module X exposing (..)
-
-{k,v} = r"""
 
 
 sample11 : String


### PR DESCRIPTION
`Destructuring` is not valid Elm code in Elm 0.19.

We already decided to remove it from v8, but I'm turning this into a parsing error for v7 already so that it is easier to find syntax errors (after an `elm-review` fix for instance).