### PR TITLE
Fail to parse when exposing clause is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Stop parsing `FloatPattern` (this is an invalid pattern in Elm 0.19)
 - Stop parsing `Destructuring` declaration (this is an invalid declaration in Elm 0.19)
+- Fail to parse when doing exposing clause is empty (`exposing ()`)
 
 ## [7.3.1] - 2022-08-16
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Expose exposing (exposeDefinition)
 
-import Combine exposing (Parser, choice, maybe, or, parens, sepBy, string, succeed, while)
+import Combine exposing (Parser, choice, maybe, or, parens, sepBy1, string, succeed, while)
 import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -27,7 +27,7 @@ exposeListWith =
 exposingListInner : Parser State Exposing
 exposingListInner =
     or (withRange (succeed All |> Combine.ignore (Layout.maybeAroundBothSides (string ".."))))
-        (Combine.map Explicit (sepBy (char ',') (Layout.maybeAroundBothSides exposable)))
+        (Combine.map Explicit (sepBy1 (char ',') (Layout.maybeAroundBothSides exposable)))
 
 
 exposable : Parser State (Node TopLevelExpose)

--- a/tests/Elm/Parser/ExposeTests.elm
+++ b/tests/Elm/Parser/ExposeTests.elm
@@ -39,6 +39,10 @@ all =
             \() ->
                 "exposing (. .)"
                     |> expectInvalid
+        , test "should fail to parse empty exposing list" <|
+            \() ->
+                "exposing ()"
+                    |> expectInvalid
         , test "Explicit exposing list" <|
             \() ->
                 "exposing (Model,Msg(..),Info(..),init,(::))"

--- a/tests/Elm/Parser/LetExpressionTests.elm
+++ b/tests/Elm/Parser/LetExpressionTests.elm
@@ -211,6 +211,15 @@ all =
   in
   bar"""
                     |> expectInvalid
+
+        -- TODO Make this pass
+        --      , test "should fail to parse `as` pattern not surrounded by parentheses" <|
+        --          \() ->
+        --              """let
+        --  bar n as m = 1
+        --in
+        --bar"""
+        --                  |> expectInvalid
         , test "should not parse let destructuring with a type annotation" <|
             \() ->
                 """let

--- a/tests/Elm/Parser/Samples.elm
+++ b/tests/Elm/Parser/Samples.elm
@@ -548,7 +548,7 @@ foo = 1
 
 sample4 : String
 sample4 =
-    """module Operators exposing ()
+    """module Operators exposing ((|=), (|.))
 
 infix left 5 (|=) = keeper
 infix left 6 (|.) = ignorer

--- a/tests/Elm/Parser/TypeAnnotationTests.elm
+++ b/tests/Elm/Parser/TypeAnnotationTests.elm
@@ -33,6 +33,7 @@ all =
                         )
         , test "tupledTypeReference 2" <|
             \() ->
+                -- TODO This feels incorrect, there should be a Parenthesized type for this
                 "( () )"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } } Unit)


### PR DESCRIPTION
And add a few tests that should be done at some point in the future.