### PR TITLE
Fix case..of parser by fixing indentation stack

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -39,6 +39,6 @@
         "stil4m/structured-writer": "1.0.1 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.0.0 <= v < 2.0.0"
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
     }
 }

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -428,7 +428,7 @@ caseStatementWithCorrectIndentation config =
         (\s ->
             Combine.withLocation
                 (\l ->
-                    if Debug.log "condition" <| State.expectedColumn (Debug.log "ok" <| s) == Debug.log "column" l.column then
+                    if State.expectedColumn s == l.column then
                         caseStatement config
 
                     else

--- a/src/Elm/Parser/State.elm
+++ b/src/Elm/Parser/State.elm
@@ -35,7 +35,7 @@ expectedColumn (State { indents }) =
 
 pushIndent : Int -> State -> State
 pushIndent col (State s) =
-    State { s | indents = (col + 1) :: s.indents }
+    State { s | indents = (col - 1) :: s.indents }
 
 
 popIndent : State -> State


### PR DESCRIPTION
Only the first commit 3ae7c81 deals with the bug mentioned [here](https://github.com/stil4m/elm-syntax/pull/207#issuecomment-2053762106)

The rest are just some general cleanup. Feel free to cherry-pick whatever you want!