### PR TITLE
Add a simple elm-review rule for formatting ranges

### DIFF
--- a/review/src/OrderedRanges.elm
+++ b/review/src/OrderedRanges.elm
@@ -1,0 +1,57 @@
+module OrderedRanges exposing (rule)
+
+import Elm.Syntax.Expression as Expression exposing (Expression, RecordSetter)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Range exposing (Range)
+import Elm.Writer
+import Review.Fix exposing (Fix)
+import Review.Rule as Rule exposing (Error, Rule)
+
+
+rule : Rule
+rule =
+    Rule.newModuleRuleSchema "OrderedRanges" ()
+        |> Rule.withSimpleExpressionVisitor expressionVisitor
+        |> Rule.fromModuleRuleSchema
+
+
+expressionVisitor : Node Expression -> List (Error {})
+expressionVisitor node =
+    case Node.value node of
+        Expression.RecordExpr recordSetters ->
+            case recordSetters of
+                [ Node _ ( Node _ "end", _ ), Node _ ( Node _ "start", _ ) ] ->
+                    [ Rule.errorWithFix
+                        { message = "Writing a node range is more readable from the start"
+                        , details =
+                            [ "If like me you have the bad habit of copying nodes from test outputs, this rule will cover for you." ]
+                        }
+                        (Node.range node)
+                        [ fixWithFlippedOrder (Node.range node) recordSetters ]
+                    ]
+
+                [ Node _ ( Node _ "column", _ ), Node _ ( Node _ "row", _ ) ] ->
+                    [ Rule.errorWithFix
+                        { message = "Writing a Location is more readable with the row first"
+                        , details =
+                            [ "If like me you have the bad habit of copying locations from test outputs, this rule will cover for you." ]
+                        }
+                        (Node.range node)
+                        [ fixWithFlippedOrder (Node.range node) recordSetters ]
+                    ]
+
+                _ ->
+                    []
+
+        _ ->
+            []
+
+
+fixWithFlippedOrder : Range -> List (Node RecordSetter) -> Fix
+fixWithFlippedOrder range =
+    List.reverse
+        >> Expression.RecordExpr
+        >> Node.empty
+        >> Elm.Writer.writeExpression
+        >> Elm.Writer.write
+        >> Review.Fix.replaceRangeBy range

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -33,6 +33,7 @@ import NoUnused.Exports exposing (annotatedBy)
 import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
+import OrderedRanges
 import Review.Rule as Rule exposing (Rule)
 import Simplify
 
@@ -72,4 +73,5 @@ config =
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule
     , Simplify.rule Simplify.defaults
+    , OrderedRanges.rule
     ]

--- a/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/Elm/Parser/ModuleTests.elm
@@ -139,11 +139,11 @@ b = 3
                                                             )
                                                             (Node { start = { row = 5, column = 9 }, end = { row = 5, column = 10 } } (Integer 1))
                                                             (Node
-                                                                { end = { column = 10, row = 7 }
-                                                                , start =
-                                                                    { column = 9
-                                                                    , row = 7
+                                                                { start =
+                                                                    { row = 7
+                                                                    , column = 9
                                                                     }
+                                                                , end = { row = 7, column = 10 }
                                                                 }
                                                                 (Integer 2)
                                                             )
@@ -158,12 +158,11 @@ b = 3
                                     (FunctionDeclaration
                                         { declaration =
                                             Node
-                                                { end =
-                                                    { column = 6
-                                                    , row =
-                                                        13
+                                                { start = { row = 13, column = 1 }
+                                                , end =
+                                                    { row = 13
+                                                    , column = 6
                                                     }
-                                                , start = { column = 1, row = 13 }
                                                 }
                                                 { arguments = []
                                                 , expression = Node { start = { row = 13, column = 5 }, end = { row = 13, column = 6 } } (Integer 3)
@@ -180,19 +179,17 @@ b = 3
                                     (NormalModule
                                         { exposingList =
                                             Node
-                                                { end =
-                                                    { column =
-                                                        32
-                                                    , row = 1
+                                                { start = { row = 1, column = 19 }
+                                                , end =
+                                                    { row = 1
+                                                    , column = 32
                                                     }
-                                                , start = { column = 19, row = 1 }
                                                 }
                                                 (All { start = { row = 1, column = 29 }, end = { row = 1, column = 31 } })
                                         , moduleName =
                                             Node
-                                                { end =
-                                                    { column = 18, row = 1 }
-                                                , start = { column = 8, row = 1 }
+                                                { start = { row = 1, column = 8 }
+                                                , end = { row = 1, column = 18 }
                                                 }
                                                 [ "TestModule" ]
                                         }
@@ -219,8 +216,8 @@ b = 3
                             { comments = [ Node { start = { row = 8, column = 1 }, end = { row = 9, column = 3 } } "{-| doc\n-}" ]
                             , declarations =
                                 [ Node
-                                    { end = { column = 6, row = 4 }
-                                    , start = { column = 1, row = 3 }
+                                    { start = { row = 3, column = 1 }
+                                    , end = { row = 4, column = 6 }
                                     }
                                     (FunctionDeclaration
                                         { declaration =
@@ -228,9 +225,8 @@ b = 3
                                                 { arguments = []
                                                 , expression =
                                                     Node
-                                                        { end =
-                                                            { column = 6, row = 4 }
-                                                        , start = { column = 5, row = 4 }
+                                                        { start = { row = 4, column = 5 }
+                                                        , end = { row = 4, column = 6 }
                                                         }
                                                         (Integer 2)
                                                 , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 2 } } "a"
@@ -240,9 +236,8 @@ b = 3
                                         }
                                     )
                                 , Node
-                                    { end =
-                                        { column = 6, row = 10 }
-                                    , start = { column = 1, row = 10 }
+                                    { start = { row = 10, column = 1 }
+                                    , end = { row = 10, column = 6 }
                                     }
                                     (FunctionDeclaration
                                         { declaration =
@@ -250,9 +245,8 @@ b = 3
                                                 { arguments = []
                                                 , expression =
                                                     Node
-                                                        { end =
-                                                            { column = 6, row = 10 }
-                                                        , start = { column = 5, row = 10 }
+                                                        { start = { row = 10, column = 5 }
+                                                        , end = { row = 10, column = 6 }
                                                         }
                                                         (Integer 3)
                                                 , name = Node { start = { row = 10, column = 1 }, end = { row = 10, column = 2 } } "b"
@@ -269,9 +263,8 @@ b = 3
                                         { exposingList =
                                             Node { start = { row = 1, column = 19 }, end = { row = 1, column = 32 } }
                                                 (All
-                                                    { end =
-                                                        { column = 31, row = 1 }
-                                                    , start = { column = 29, row = 1 }
+                                                    { start = { row = 1, column = 29 }
+                                                    , end = { row = 1, column = 31 }
                                                     }
                                                 )
                                         , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 18 } } [ "TestModule" ]

--- a/tests/Elm/Parser/TypeAnnotationTests.elm
+++ b/tests/Elm/Parser/TypeAnnotationTests.elm
@@ -175,22 +175,22 @@ all =
             \() ->
                 "{ foo : Int, bar : Int, baz : Int }"
                     |> expectAst
-                        (Node { start = { column = 1, row = 1 }, end = { column = 36, row = 1 } } <|
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 36 } } <|
                             Record
-                                [ Node { start = { column = 3, row = 1 }, end = { column = 12, row = 1 } }
-                                    ( Node { start = { column = 3, row = 1 }, end = { column = 6, row = 1 } } "foo"
-                                    , Node { start = { column = 9, row = 1 }, end = { column = 12, row = 1 } } <|
-                                        Typed (Node { start = { column = 9, row = 1 }, end = { column = 12, row = 1 } } ( [], "Int" )) []
+                                [ Node { start = { row = 1, column = 3 }, end = { row = 1, column = 12 } }
+                                    ( Node { start = { row = 1, column = 3 }, end = { row = 1, column = 6 } } "foo"
+                                    , Node { start = { row = 1, column = 9 }, end = { row = 1, column = 12 } } <|
+                                        Typed (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 12 } } ( [], "Int" )) []
                                     )
-                                , Node { start = { column = 14, row = 1 }, end = { column = 23, row = 1 } }
-                                    ( Node { start = { column = 14, row = 1 }, end = { column = 17, row = 1 } } "bar"
-                                    , Node { start = { column = 20, row = 1 }, end = { column = 23, row = 1 } } <|
-                                        Typed (Node { start = { column = 20, row = 1 }, end = { column = 23, row = 1 } } ( [], "Int" )) []
+                                , Node { start = { row = 1, column = 14 }, end = { row = 1, column = 23 } }
+                                    ( Node { start = { row = 1, column = 14 }, end = { row = 1, column = 17 } } "bar"
+                                    , Node { start = { row = 1, column = 20 }, end = { row = 1, column = 23 } } <|
+                                        Typed (Node { start = { row = 1, column = 20 }, end = { row = 1, column = 23 } } ( [], "Int" )) []
                                     )
-                                , Node { start = { column = 25, row = 1 }, end = { column = 35, row = 1 } }
-                                    ( Node { start = { column = 25, row = 1 }, end = { column = 28, row = 1 } } "baz"
-                                    , Node { start = { column = 31, row = 1 }, end = { column = 34, row = 1 } } <|
-                                        Typed (Node { start = { column = 31, row = 1 }, end = { column = 34, row = 1 } } ( [], "Int" )) []
+                                , Node { start = { row = 1, column = 25 }, end = { row = 1, column = 35 } }
+                                    ( Node { start = { row = 1, column = 25 }, end = { row = 1, column = 28 } } "baz"
+                                    , Node { start = { row = 1, column = 31 }, end = { row = 1, column = 34 } } <|
+                                        Typed (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 34 } } ( [], "Int" )) []
                                     )
                                 ]
                         )


### PR DESCRIPTION
As I was playing around in the codebase, I was often copy/pasting the output of tests into actual tests, and I realized that the ranges/locations are shown in alphabetical order, which is the least readable order possible.

Instead of changing it by hand, I thought I would write a simple `elm-review` rule, so here it is.