### PR TITLE
Add test case for field access vs application precedence

### DIFF
--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -179,7 +179,7 @@ recordAccessParser =
 
 functionCall : Pratt.Config s (Node Expression) -> ( Int, Node Expression -> Parser s (Node Expression) )
 functionCall =
-    Pratt.infixLeft 95
+    Pratt.infixLeft 90
         (Combine.succeed ())
         (\((Node leftRange leftValue) as left) right ->
             case leftValue of
@@ -466,7 +466,7 @@ ifBlockExpression config =
 
 negationOperation : Config s (Node Expression) -> Parser s (Node Expression)
 negationOperation =
-    Pratt.prefix 9
+    Pratt.prefix 95
         minusNotFollowedBySpaceOrComment
         (\((Node { start, end } _) as subExpr) ->
             Node

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -151,7 +151,7 @@ infixLeftSubtraction precedence =
 
 recordAccess : Config State (Node Expression) -> ( Int, Node Expression -> Parser State (Node Expression) )
 recordAccess =
-    Pratt.postfix 98
+    Pratt.postfix 100
         recordAccessParser
         (\((Node leftRange _) as left) ((Node rightRange _) as field) ->
             Node
@@ -179,7 +179,7 @@ recordAccessParser =
 
 functionCall : Pratt.Config s (Node Expression) -> ( Int, Node Expression -> Parser s (Node Expression) )
 functionCall =
-    Pratt.infixLeft 99
+    Pratt.infixLeft 95
         (Combine.succeed ())
         (\((Node leftRange leftValue) as left) right ->
             case leftValue of

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -548,6 +548,35 @@ all =
                                 ]
                             )
                         )
+        , test "application should be lower-priority than field access" <|
+            \() ->
+                "foo { d | b = f x y }.b"
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 24 } }
+                            (Application
+                                [ Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } (FunctionOrValue [] "foo")
+                                , Node { start = { row = 1, column = 5 }, end = { row = 1, column = 24 } }
+                                    (RecordAccess
+                                        (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 22 } }
+                                            (RecordUpdateExpression (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 8 } } "d")
+                                                [ Node { start = { row = 1, column = 11 }, end = { row = 1, column = 21 } }
+                                                    ( Node { start = { row = 1, column = 11 }, end = { row = 1, column = 12 } } "b"
+                                                    , Node { start = { row = 1, column = 15 }, end = { row = 1, column = 20 } }
+                                                        (Application
+                                                            [ Node { start = { row = 1, column = 15 }, end = { row = 1, column = 16 } } (FunctionOrValue [] "f")
+                                                            , Node { start = { row = 1, column = 17 }, end = { row = 1, column = 18 } } (FunctionOrValue [] "x")
+                                                            , Node { start = { row = 1, column = 19 }, end = { row = 1, column = 20 } } (FunctionOrValue [] "y")
+                                                            ]
+                                                        )
+                                                    )
+                                                ]
+                                            )
+                                        )
+                                        (Node { start = { row = 1, column = 23 }, end = { row = 1, column = 24 } } "b")
+                                    )
+                                ]
+                            )
+                        )
         ]
 
 

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -594,6 +594,34 @@ all =
                                 ]
                             )
                         )
+        , test "negation can be applied on record access" <|
+            \() ->
+                "1 + -{x = 10}.x"
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 16 } }
+                            (OperatorApplication "+"
+                                Left
+                                (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (Integer 1))
+                                (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 16 } }
+                                    (Negation
+                                        (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 16 } }
+                                            (RecordAccess
+                                                (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 14 } }
+                                                    (RecordExpr
+                                                        [ Node { start = { row = 1, column = 7 }, end = { row = 1, column = 13 } }
+                                                            ( Node { start = { row = 1, column = 7 }, end = { row = 1, column = 8 } } "x"
+                                                            , Node { start = { row = 1, column = 11 }, end = { row = 1, column = 13 } } (Integer 10)
+                                                            )
+                                                        ]
+                                                    )
+                                                )
+                                                (Node { start = { row = 1, column = 15 }, end = { row = 1, column = 16 } } "x")
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
         ]
 
 

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -577,6 +577,23 @@ all =
                                 ]
                             )
                         )
+        , test "should not consider a negative number parameter as the start of a new application" <|
+            \() ->
+                "Random.list -1 generator"
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 25 } }
+                            (Application
+                                [ Node { start = { row = 1, column = 1 }, end = { row = 1, column = 12 } } (FunctionOrValue [ "Random" ] "list")
+                                , Node { start = { row = 1, column = 13 }, end = { row = 1, column = 15 } }
+                                    (Negation
+                                        (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 15 } }
+                                            (Integer 1)
+                                        )
+                                    )
+                                , Node { start = { row = 1, column = 16 }, end = { row = 1, column = 25 } } (FunctionOrValue [] "generator")
+                                ]
+                            )
+                        )
         ]
 
 

--- a/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/Elm/Parser/ModuleTests.elm
@@ -6,6 +6,7 @@ import Elm.Parser.Modules as Parser
 import Elm.Syntax.Declaration exposing (Declaration(..))
 import Elm.Syntax.Exposing exposing (..)
 import Elm.Syntax.Expression exposing (Expression(..))
+import Elm.Syntax.Infix exposing (InfixDirection(..))
 import Elm.Syntax.Module exposing (..)
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern(..))
@@ -444,13 +445,22 @@ fun2 n =
                                                 { arguments = [ Node { start = { row = 3, column = 6 }, end = { row = 3, column = 7 } } (VarPattern "n") ]
                                                 , expression =
                                                     Node { start = { row = 4, column = 3 }, end = { row = 5, column = 11 } }
-                                                        (Application
-                                                            [ Node { start = { row = 4, column = 3 }, end = { row = 4, column = 7 } } (FunctionOrValue [] "fun2")
-                                                            , Node { start = { row = 4, column = 8 }, end = { row = 4, column = 9 } } (FunctionOrValue [] "n")
-                                                            , Node { start = { row = 5, column = 3 }, end = { row = 5, column = 4 } } (Operator "+")
-                                                            , Node { start = { row = 5, column = 5 }, end = { row = 5, column = 9 } } (FunctionOrValue [] "fun2")
-                                                            , Node { start = { row = 5, column = 10 }, end = { row = 5, column = 11 } } (FunctionOrValue [] "n")
-                                                            ]
+                                                        (OperatorApplication "+"
+                                                            Left
+                                                            (Node { start = { row = 4, column = 3 }, end = { row = 4, column = 9 } }
+                                                                (Application
+                                                                    [ Node { start = { row = 4, column = 3 }, end = { row = 4, column = 7 } } (FunctionOrValue [] "fun2")
+                                                                    , Node { start = { row = 4, column = 8 }, end = { row = 4, column = 9 } } (FunctionOrValue [] "n")
+                                                                    ]
+                                                                )
+                                                            )
+                                                            (Node { start = { row = 5, column = 5 }, end = { row = 5, column = 11 } }
+                                                                (Application
+                                                                    [ Node { start = { row = 5, column = 5 }, end = { row = 5, column = 9 } } (FunctionOrValue [] "fun2")
+                                                                    , Node { start = { row = 5, column = 10 }, end = { row = 5, column = 11 } } (FunctionOrValue [] "n")
+                                                                    ]
+                                                                )
+                                                            )
                                                         )
                                                 , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 5 } } "fun1"
                                                 }

--- a/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/Elm/Parser/ModuleTests.elm
@@ -8,6 +8,7 @@ import Elm.Syntax.Exposing exposing (..)
 import Elm.Syntax.Expression exposing (Expression(..))
 import Elm.Syntax.Module exposing (..)
 import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
 import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
 import Expect
 import Test exposing (..)
@@ -420,6 +421,66 @@ a : Int
 b = 2
 """
                     |> expectInvalid
+        , test "trailing comments at the end of declarations" <|
+            \() ->
+                parse """module A exposing (fun1, fun2)
+
+fun1 n =
+  fun2 n
+  + fun2 n  -- a
+
+fun2 n =
+  fun1 n    -- b
+"""
+                    File.file
+                    |> Expect.equal
+                        (Just
+                            { comments = [ Node { start = { row = 5, column = 13 }, end = { row = 5, column = 17 } } "-- a", Node { start = { row = 8, column = 13 }, end = { row = 8, column = 17 } } "-- b" ]
+                            , declarations =
+                                [ Node { start = { row = 3, column = 1 }, end = { row = 5, column = 11 } }
+                                    (FunctionDeclaration
+                                        { declaration =
+                                            Node { start = { row = 3, column = 1 }, end = { row = 5, column = 11 } }
+                                                { arguments = [ Node { start = { row = 3, column = 6 }, end = { row = 3, column = 7 } } (VarPattern "n") ]
+                                                , expression =
+                                                    Node { start = { row = 4, column = 3 }, end = { row = 5, column = 11 } }
+                                                        (Application
+                                                            [ Node { start = { row = 4, column = 3 }, end = { row = 4, column = 7 } } (FunctionOrValue [] "fun2")
+                                                            , Node { start = { row = 4, column = 8 }, end = { row = 4, column = 9 } } (FunctionOrValue [] "n")
+                                                            , Node { start = { row = 5, column = 3 }, end = { row = 5, column = 4 } } (Operator "+")
+                                                            , Node { start = { row = 5, column = 5 }, end = { row = 5, column = 9 } } (FunctionOrValue [] "fun2")
+                                                            , Node { start = { row = 5, column = 10 }, end = { row = 5, column = 11 } } (FunctionOrValue [] "n")
+                                                            ]
+                                                        )
+                                                , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 5 } } "fun1"
+                                                }
+                                        , documentation = Nothing
+                                        , signature = Nothing
+                                        }
+                                    )
+                                , Node { start = { row = 7, column = 1 }, end = { row = 8, column = 9 } }
+                                    (FunctionDeclaration
+                                        { declaration =
+                                            Node { start = { row = 7, column = 1 }, end = { row = 8, column = 9 } }
+                                                { arguments = [ Node { start = { row = 7, column = 6 }, end = { row = 7, column = 7 } } (VarPattern "n") ]
+                                                , expression =
+                                                    Node { start = { row = 8, column = 3 }, end = { row = 8, column = 9 } }
+                                                        (Application
+                                                            [ Node { start = { row = 8, column = 3 }, end = { row = 8, column = 7 } } (FunctionOrValue [] "fun1")
+                                                            , Node { start = { row = 8, column = 8 }, end = { row = 8, column = 9 } } (FunctionOrValue [] "n")
+                                                            ]
+                                                        )
+                                                , name = Node { start = { row = 7, column = 1 }, end = { row = 7, column = 5 } } "fun2"
+                                                }
+                                        , documentation = Nothing
+                                        , signature = Nothing
+                                        }
+                                    )
+                                ]
+                            , imports = []
+                            , moduleDefinition = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 31 } } (NormalModule { exposingList = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 31 } } (Explicit [ Node { start = { row = 1, column = 20 }, end = { row = 1, column = 24 } } (FunctionExpose "fun1"), Node { start = { row = 1, column = 26 }, end = { row = 1, column = 30 } } (FunctionExpose "fun2") ]), moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } [ "A" ] })
+                            }
+                        )
         ]
 
 


### PR DESCRIPTION
I found a few regressions in the `pratt-parser` branch, so I've written tests for them.

1. Trailing comments at the end of a declaration are a syntax error.
2. `f -g a` is incorrectly parsed as `f - (g a)` instead of as `f (-g) a`
3. `foo a.field` is incorrectly parsed as `(foo a).field` instead of as `foo (a.field)`

cc @jiegillet