### PR TITLE
Add test failing on master

### DIFF
--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -388,6 +388,17 @@ all =
                                 ]
                             )
                         )
+        , test "subtraction without spaces" <|
+            \() ->
+                "2-1"
+                    |> expectAst
+                        (Node { end = { column = 4, row = 1 }, start = { column = 1, row = 1 } }
+                            (OperatorApplication "-"
+                                Left
+                                (Node { end = { column = 2, row = 1 }, start = { column = 1, row = 1 } } (Integer 2))
+                                (Node { end = { column = 4, row = 1 }, start = { column = 3, row = 1 } } (Integer 1))
+                            )
+                        )
         , test "negated expression for value" <|
             \() ->
                 "-x"

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -392,11 +392,11 @@ all =
             \() ->
                 "2-1"
                     |> expectAst
-                        (Node { end = { column = 4, row = 1 }, start = { column = 1, row = 1 } }
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } }
                             (OperatorApplication "-"
                                 Left
-                                (Node { end = { column = 2, row = 1 }, start = { column = 1, row = 1 } } (Integer 2))
-                                (Node { end = { column = 4, row = 1 }, start = { column = 3, row = 1 } } (Integer 1))
+                                (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (Integer 2))
+                                (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (Integer 1))
                             )
                         )
         , test "negated expression for value" <|


### PR DESCRIPTION
After I ran my dirty script on all elm files in `~/.elm/0.19.1/packages/elm` and `~/.elm/0.19.1/packages/jfmengels` and some other files, I only found one regression, and it's pretty funny that it turns out to be a bug on master :)

I'm sure that it was not found before because `elm-format` changes `a-b` to `a - b`, and hardly anyone doesn't use `elm-format`.