### PR TITLE
Performance improvements to the Parser

### DIFF
--- a/review/suppressed/NoImportingEverything.json
+++ b/review/suppressed/NoImportingEverything.json
@@ -3,7 +3,6 @@
   "automatically created by": "elm-review suppress",
   "learn more": "elm-review suppress --help",
   "suppressions": [
-    { "count": 13, "filePath": "src/Elm/Writer.elm" },
-    { "count": 1, "filePath": "src/Elm/Parser/TypeAnnotation.elm" }
+    { "count": 13, "filePath": "src/Elm/Writer.elm" }
   ]
 }

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -382,10 +382,13 @@ sepBy1WithoutReverse sep p =
 
 
 between : String -> String -> Parser state a -> Parser state a
-between lp rp p =
-    symbol lp
-        |> andThen (\() -> p)
-        |> ignore (symbol rp)
+between lp rp (Parser p) =
+    Parser <|
+        \state ->
+            Core.succeed identity
+                |. Core.symbol lp
+                |= p state
+                |. Core.symbol rp
 
 
 parens : Parser state a -> Parser state a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -7,6 +7,7 @@ module Combine exposing
     , end
     , fromCore
     , ignore
+    , ignoreEntirely
     , keep
     , lazy
     , location
@@ -389,6 +390,14 @@ ignore dropped target =
     target
         |> map (\a -> \() -> a)
         |> keep dropped
+
+
+ignoreEntirely : Core.Parser () -> Parser state a -> Parser state a
+ignoreEntirely dropped (Parser target) =
+    Parser <|
+        \state ->
+            target state
+                |. dropped
 
 
 continueWith : Parser state a -> Parser state () -> Parser state a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -9,6 +9,7 @@ module Combine exposing
     , fromCore
     , ignore
     , ignoreEntirely
+    , ignoreFromCore
     , keep
     , lazy
     , location
@@ -406,6 +407,18 @@ ignore (Parser dropped) (Parser target) =
                     (\( newState, a ) ->
                         dropped newState
                             |> Core.map (\( finalState, () ) -> ( finalState, a ))
+                    )
+
+
+ignoreFromCore : Parser state () -> Core.Parser a -> Parser state a
+ignoreFromCore (Parser dropped) target =
+    Parser <|
+        \state ->
+            target
+                |> Core.andThen
+                    (\a ->
+                        dropped state
+                            |> Core.map (\( newState, () ) -> ( newState, a ))
                     )
 
 

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -397,10 +397,15 @@ parens p =
 
 
 ignore : Parser state () -> Parser state a -> Parser state a
-ignore dropped target =
-    target
-        |> map (\a -> \() -> a)
-        |> keep dropped
+ignore (Parser dropped) (Parser target) =
+    Parser <|
+        \state ->
+            target state
+                |> Core.andThen
+                    (\( newState, a ) ->
+                        dropped newState
+                            |> Core.map (\( finalState, () ) -> ( finalState, a ))
+                    )
 
 
 ignoreEntirely : Core.Parser () -> Parser state a -> Parser state a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -3,6 +3,7 @@ module Combine exposing
     , Step(..)
     , andThen
     , between
+    , continueFromCore
     , continueWith
     , end
     , fromCore
@@ -420,6 +421,17 @@ continueWith : Parser state a -> Parser state () -> Parser state a
 continueWith target dropped =
     dropped
         |> andThen (\_ -> target)
+
+
+continueFromCore : Parser state a -> Core.Parser () -> Parser state a
+continueFromCore (Parser target) dropped =
+    Parser <|
+        \state ->
+            dropped
+                |> Core.andThen
+                    (\() ->
+                        target state
+                    )
 
 
 cons : a -> List a -> List a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -29,6 +29,7 @@ module Combine exposing
     , sepBy
     , sepBy1
     , sepBy1Core
+    , sepBy1WithState
     , sepBy1WithoutReverse
     , succeed
     , symbol
@@ -338,7 +339,7 @@ many1 p =
         |> keep (many p)
 
 
-sepBy : Parser state () -> Parser state a -> Parser state (List a)
+sepBy : String -> Parser state a -> Parser state (List a)
 sepBy sep p =
     oneOf
         [ sepBy1 sep p
@@ -346,20 +347,27 @@ sepBy sep p =
         ]
 
 
-sepBy1 : Parser state () -> Parser state a -> Parser state (List a)
+sepBy1 : String -> Parser state a -> Parser state (List a)
 sepBy1 sep p =
+    succeed cons
+        |> keep p
+        |> keep (many (symbol sep |> continueWith p))
+
+
+sepBy1WithState : Parser state () -> Parser state a -> Parser state (List a)
+sepBy1WithState sep p =
     succeed cons
         |> keep p
         |> keep (many (sep |> continueWith p))
 
 
-sepBy1Core : Core.Parser () -> Core.Parser a -> Core.Parser (List a)
+sepBy1Core : String -> Core.Parser a -> Core.Parser (List a)
 sepBy1Core sep p =
     Core.succeed cons
         |= p
         |= manyCore
             (Core.succeed identity
-                |. sep
+                |. Core.symbol sep
                 |= p
             )
 

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -220,14 +220,14 @@ manyWithoutReverse initList (Parser p) =
             Core.loop ( state, initList ) helper
 
 
-manyIgnore : Parser state a -> Parser state ()
+manyIgnore : Parser state () -> Parser state ()
 manyIgnore (Parser p) =
     let
         helper : state -> Core.Parser (Core.Step state ( state, () ))
         helper state =
             Core.oneOf
                 [ p state
-                    |> Core.map (\( newState, _ ) -> Core.Loop newState)
+                    |> Core.map (\( newState, () ) -> Core.Loop newState)
                 , Core.succeed (Core.Done ( state, () ))
                 ]
     in
@@ -256,7 +256,7 @@ manyWithoutReverseCore initList p =
     Core.loop initList helper
 
 
-many1Ignore : Parser state a -> Parser state ()
+many1Ignore : Parser state () -> Parser state ()
 many1Ignore p =
     p
         |> continueWith (manyIgnore p)
@@ -366,13 +366,13 @@ sepBy1Core sep p =
 {-| Same as [`sepBy1`](#sepBy1), except that it doesn't reverse the list.
 This can be useful if you need to access the range of the last item.
 -}
-sepBy1WithoutReverse : Parser state x -> Parser state a -> Parser state (List a)
+sepBy1WithoutReverse : Parser state () -> Parser state a -> Parser state (List a)
 sepBy1WithoutReverse sep p =
     p
         |> andThen (\first -> manyWithoutReverse [ first ] (sep |> continueWith p))
 
 
-between : Parser state l -> Parser state r -> Parser state a -> Parser state a
+between : Parser state () -> Parser state () -> Parser state a -> Parser state a
 between lp rp p =
     lp
         |> continueWith p
@@ -384,7 +384,7 @@ parens =
     between (symbol "(") (symbol ")")
 
 
-ignore : Parser state x -> Parser state a -> Parser state a
+ignore : Parser state () -> Parser state a -> Parser state a
 ignore dropped target =
     target
         |> map always

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -109,15 +109,13 @@ withLocation f =
                     )
 
 
-location : Parser state Location
+location : Core.Parser Location
 location =
-    Parser <|
-        \state ->
-            Core.getPosition
-                |> Core.map
-                    (\( row, col ) ->
-                        ( state, { row = row, column = col } )
-                    )
+    Core.getPosition
+        |> Core.map
+            (\( row, col ) ->
+                { row = row, column = col }
+            )
 
 
 map : (a -> b) -> Parser state a -> Parser state b

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -337,7 +337,7 @@ many1 p =
         |> keep (many p)
 
 
-sepBy : Parser state x -> Parser state a -> Parser state (List a)
+sepBy : Parser state () -> Parser state a -> Parser state (List a)
 sepBy sep p =
     oneOf
         [ sepBy1 sep p
@@ -345,7 +345,7 @@ sepBy sep p =
         ]
 
 
-sepBy1 : Parser state x -> Parser state a -> Parser state (List a)
+sepBy1 : Parser state () -> Parser state a -> Parser state (List a)
 sepBy1 sep p =
     succeed cons
         |> keep p
@@ -391,7 +391,7 @@ ignore dropped target =
         |> keep dropped
 
 
-continueWith : Parser state a -> Parser state x -> Parser state a
+continueWith : Parser state a -> Parser state () -> Parser state a
 continueWith target dropped =
     dropped
         |> map (\_ -> \a -> a)

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -381,16 +381,16 @@ sepBy1WithoutReverse sep p =
         |> andThen (\first -> manyWithoutReverse [ first ] (sep |> continueWith p))
 
 
-between : Parser state () -> String -> Parser state a -> Parser state a
+between : String -> String -> Parser state a -> Parser state a
 between lp rp p =
-    lp
+    symbol lp
         |> andThen (\() -> p)
         |> ignore (symbol rp)
 
 
 parens : Parser state a -> Parser state a
-parens =
-    between (symbol "(") ")"
+parens p =
+    between "(" ")" p
 
 
 ignore : Parser state () -> Parser state a -> Parser state a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -14,7 +14,6 @@ module Combine exposing
     , keep
     , keepFromCore
     , lazy
-    , location
     , loop
     , many
     , many1
@@ -107,15 +106,6 @@ withLocation f =
                         in
                         p state
                     )
-
-
-location : Core.Parser Location
-location =
-    Core.getPosition
-        |> Core.map
-            (\( row, col ) ->
-                { row = row, column = col }
-            )
 
 
 map : (a -> b) -> Parser state a -> Parser state b

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -387,14 +387,14 @@ parens =
 ignore : Parser state () -> Parser state a -> Parser state a
 ignore dropped target =
     target
-        |> map always
+        |> map (\a -> \() -> a)
         |> keep dropped
 
 
 continueWith : Parser state a -> Parser state x -> Parser state a
 continueWith target dropped =
     dropped
-        |> map (\_ a -> a)
+        |> map (\_ -> \a -> a)
         |> keep target
 
 

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -384,7 +384,7 @@ sepBy1WithoutReverse sep p =
 between : Parser state () -> String -> Parser state a -> Parser state a
 between lp rp p =
     lp
-        |> continueWith p
+        |> andThen (\() -> p)
         |> ignore (symbol rp)
 
 

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -114,9 +114,9 @@ location =
     Parser <|
         \state ->
             Core.getPosition
-                |> Core.andThen
+                |> Core.map
                     (\( row, col ) ->
-                        Core.succeed ( state, { row = row, column = col } )
+                        ( state, { row = row, column = col } )
                     )
 
 

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -19,6 +19,7 @@ module Combine exposing
     , manyWithEndLocationForLastElement
     , map
     , maybe
+    , maybeIgnore
     , modifyState
     , oneOf
     , parens
@@ -189,6 +190,16 @@ maybe (Parser p) =
             Core.oneOf
                 [ p state |> Core.map (\( c, v ) -> ( c, Just v ))
                 , Core.succeed ( state, Nothing )
+                ]
+
+
+maybeIgnore : Parser state () -> Parser state ()
+maybeIgnore (Parser p) =
+    Parser <|
+        \state ->
+            Core.oneOf
+                [ p state
+                , Core.succeed ( state, () )
                 ]
 
 

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -394,8 +394,7 @@ ignore dropped target =
 continueWith : Parser state a -> Parser state () -> Parser state a
 continueWith target dropped =
     dropped
-        |> map (\_ -> \a -> a)
-        |> keep target
+        |> andThen (\_ -> target)
 
 
 cons : a -> List a -> List a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -381,16 +381,16 @@ sepBy1WithoutReverse sep p =
         |> andThen (\first -> manyWithoutReverse [ first ] (sep |> continueWith p))
 
 
-between : Parser state () -> Parser state () -> Parser state a -> Parser state a
+between : Parser state () -> String -> Parser state a -> Parser state a
 between lp rp p =
     lp
         |> continueWith p
-        |> ignore rp
+        |> ignore (symbol rp)
 
 
 parens : Parser state a -> Parser state a
 parens =
-    between (symbol "(") (symbol ")")
+    between (symbol "(") ")"
 
 
 ignore : Parser state () -> Parser state a -> Parser state a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -29,7 +29,6 @@ module Combine exposing
     , sepBy1
     , sepBy1Core
     , sepBy1WithoutReverse
-    , string
     , succeed
     , symbol
     , withLocation
@@ -156,13 +155,6 @@ problem m =
 succeed : a -> Parser state a
 succeed res =
     Parser <| \state -> Core.succeed ( state, res )
-
-
-string : String -> Parser state String
-string s =
-    Parser <|
-        \state ->
-            Core.mapChompedString (\x _ -> ( state, x )) (Core.token s)
 
 
 symbol : String -> Parser state ()
@@ -389,7 +381,7 @@ between lp rp p =
 
 parens : Parser state a -> Parser state a
 parens =
-    between (string "(") (string ")")
+    between (symbol "(") (symbol ")")
 
 
 ignore : Parser state x -> Parser state a -> Parser state a

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -353,7 +353,7 @@ sepBy1 sep p =
         |> keep (many (sep |> continueWith p))
 
 
-sepBy1Core : Core.Parser x -> Core.Parser a -> Core.Parser (List a)
+sepBy1Core : Core.Parser () -> Core.Parser a -> Core.Parser (List a)
 sepBy1Core sep p =
     Core.succeed cons
         |= p

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -31,7 +31,6 @@ module Combine exposing
     , runParser
     , sepBy
     , sepBy1
-    , sepBy1Core
     , sepBy1WithState
     , sepBy1WithoutReverse
     , succeed
@@ -238,26 +237,6 @@ manyIgnore (Parser p) =
             Core.loop state helper
 
 
-manyCore : Core.Parser a -> Core.Parser (List a)
-manyCore p =
-    manyWithoutReverseCore [] p
-        |> Core.map List.reverse
-
-
-manyWithoutReverseCore : List a -> Core.Parser a -> Core.Parser (List a)
-manyWithoutReverseCore initList p =
-    let
-        helper : List a -> Core.Parser (Core.Step (List a) (List a))
-        helper items =
-            Core.oneOf
-                [ p
-                    |> Core.map (\item -> Core.Loop (item :: items))
-                , Core.succeed (Core.Done items)
-                ]
-    in
-    Core.loop initList helper
-
-
 many1Ignore : Parser state () -> Parser state ()
 many1Ignore p =
     p
@@ -359,17 +338,6 @@ sepBy1WithState sep p =
     succeed cons
         |> keep p
         |> keep (many (sep |> continueWith p))
-
-
-sepBy1Core : String -> Core.Parser a -> Core.Parser (List a)
-sepBy1Core sep p =
-    Core.succeed cons
-        |= p
-        |= manyCore
-            (Core.succeed identity
-                |. Core.symbol sep
-                |= p
-            )
 
 
 {-| Same as [`sepBy1`](#sepBy1), except that it doesn't reverse the list.

--- a/src/Combine/Char.elm
+++ b/src/Combine/Char.elm
@@ -1,15 +1,13 @@
 module Combine.Char exposing (anyChar, char)
 
-import Combine exposing (Parser)
 import Parser as Core
 
 
-char : Char -> Parser state Char
+char : Char -> Core.Parser Char
 char c =
     satisfy
         (\c_ -> c_ == c)
         ("expected '" ++ String.fromChar c ++ "'")
-        |> Combine.fromCore
 
 
 anyChar : Core.Parser Char

--- a/src/Combine/Char.elm
+++ b/src/Combine/Char.elm
@@ -12,12 +12,11 @@ char c =
         |> Combine.fromCore
 
 
-anyChar : Parser s Char
+anyChar : Core.Parser Char
 anyChar =
     satisfy
         (always True)
         "expected any character"
-        |> Combine.fromCore
 
 
 satisfy : (Char -> Bool) -> String -> Core.Parser Char

--- a/src/Combine/Char.elm
+++ b/src/Combine/Char.elm
@@ -1,31 +1,17 @@
-module Combine.Char exposing (anyChar, char)
+module Combine.Char exposing (anyChar)
 
 import Parser as Core
 
 
-char : Char -> Core.Parser Char
-char c =
-    satisfy
-        (\c_ -> c_ == c)
-        ("expected '" ++ String.fromChar c ++ "'")
-
-
 anyChar : Core.Parser Char
 anyChar =
-    satisfy
-        (always True)
-        "expected any character"
-
-
-satisfy : (Char -> Bool) -> String -> Core.Parser Char
-satisfy pred problem =
-    Core.chompIf pred
+    Core.chompIf (always True)
         |> Core.getChompedString
         |> Core.andThen
             (\s ->
                 case String.toList s of
                     [] ->
-                        Core.problem problem
+                        Core.problem "expected any character"
 
                     c :: _ ->
                         Core.succeed c

--- a/src/Combine/Char.elm
+++ b/src/Combine/Char.elm
@@ -9,6 +9,7 @@ char c =
     satisfy
         (\c_ -> c_ == c)
         ("expected '" ++ String.fromChar c ++ "'")
+        |> Combine.fromCore
 
 
 anyChar : Parser s Char
@@ -16,19 +17,19 @@ anyChar =
     satisfy
         (always True)
         "expected any character"
+        |> Combine.fromCore
 
 
-satisfy : (Char -> Bool) -> String -> Parser state Char
+satisfy : (Char -> Bool) -> String -> Core.Parser Char
 satisfy pred problem =
-    Combine.fromCore
-        (Core.getChompedString (Core.chompIf pred)
-            |> Core.andThen
-                (\s ->
-                    case String.toList s of
-                        [] ->
-                            Core.problem problem
+    Core.chompIf pred
+        |> Core.getChompedString
+        |> Core.andThen
+            (\s ->
+                case String.toList s of
+                    [] ->
+                        Core.problem problem
 
-                        c :: _ ->
-                            Core.succeed c
-                )
-        )
+                    c :: _ ->
+                        Core.succeed c
+            )

--- a/src/Elm/Json/Util.elm
+++ b/src/Elm/Json/Util.elm
@@ -19,7 +19,7 @@ decodeTyped opts =
             JD.field "type" JD.string
                 |> JD.andThen
                     (\t ->
-                        case List.filter (Tuple.first >> (==) t) opts |> List.head of
+                        case List.filter (\( opt, _ ) -> opt == t) opts |> List.head of
                             Just m ->
                                 JD.field (Tuple.first m) <| Tuple.second m
 

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -11,8 +11,7 @@ import Parser as Core exposing ((|.), (|=))
 moduleName : Parser state (Node ModuleName)
 moduleName =
     sepBy1Core (Core.symbol ".") Tokens.typeNameCore
-        |> Node.parserCore
-        |> Combine.fromCore
+        |> Node.parserFromCore
 
 
 typeIndicator : Parser state (Node ( ModuleName, String ))
@@ -31,5 +30,4 @@ typeIndicator =
     in
     Tokens.typeNameCore
         |> Core.andThen (\typeOrSegment -> helper [] typeOrSegment)
-        |> Node.parserCore
-        |> Combine.fromCore
+        |> Node.parserFromCore

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Base exposing (moduleName, typeIndicator)
 
-import Combine exposing (Parser, sepBy1Core)
+import Combine exposing (Parser)
 import Elm.Parser.Node as Node
 import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -10,7 +10,7 @@ import Parser as Core exposing ((|.), (|=))
 
 moduleName : Parser state (Node ModuleName)
 moduleName =
-    sepBy1Core (Core.symbol ".") Tokens.typeName
+    Combine.sepBy1Core (Core.symbol ".") Tokens.typeName
         |> Node.parserFromCore
 
 

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -10,7 +10,7 @@ import Parser as Core exposing ((|.), (|=))
 
 moduleName : Parser state (Node ModuleName)
 moduleName =
-    sepBy1Core (Core.symbol ".") Tokens.typeNameCore
+    sepBy1Core (Core.symbol ".") Tokens.typeName
         |> Node.parserFromCore
 
 
@@ -22,12 +22,12 @@ typeIndicator =
             Core.oneOf
                 [ Core.succeed identity
                     |. Core.symbol "."
-                    |= Tokens.typeNameCore
+                    |= Tokens.typeName
                     |> Core.andThen (\t -> helper (typeOrSegment :: moduleNameSoFar) t)
                 , Core.succeed ()
                     |> Core.map (\() -> ( List.reverse moduleNameSoFar, typeOrSegment ))
                 ]
     in
-    Tokens.typeNameCore
+    Tokens.typeName
         |> Core.andThen (\typeOrSegment -> helper [] typeOrSegment)
         |> Node.parserFromCore

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Base exposing (moduleName, typeIndicator)
 
-import Combine exposing (Parser)
+import Combine
 import Elm.Parser.Node as Node
 import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -8,10 +8,10 @@ import Elm.Syntax.Node exposing (Node)
 import Parser as Core exposing ((|.), (|=))
 
 
-moduleName : Parser state (Node ModuleName)
+moduleName : Core.Parser (Node ModuleName)
 moduleName =
     Combine.sepBy1Core "." Tokens.typeName
-        |> Node.parserFromCore
+        |> Node.parserCore
 
 
 typeIndicator : Core.Parser (Node ( ModuleName, String ))

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -10,7 +10,7 @@ import Parser as Core exposing ((|.), (|=))
 
 moduleName : Parser state (Node ModuleName)
 moduleName =
-    Combine.sepBy1Core (Core.symbol ".") Tokens.typeName
+    Combine.sepBy1Core "." Tokens.typeName
         |> Node.parserFromCore
 
 

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -1,16 +1,16 @@
 module Elm.Parser.Base exposing (moduleName, typeIndicator)
 
-import Combine
 import Elm.Parser.Node as Node
 import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node exposing (Node)
 import Parser as Core exposing ((|.), (|=))
+import Parser.Extra
 
 
 moduleName : Core.Parser (Node ModuleName)
 moduleName =
-    Combine.sepBy1Core "." Tokens.typeName
+    Parser.Extra.sepBy1 "." Tokens.typeName
         |> Node.parserCore
 
 

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -14,7 +14,7 @@ moduleName =
         |> Node.parserFromCore
 
 
-typeIndicator : Parser state (Node ( ModuleName, String ))
+typeIndicator : Core.Parser (Node ( ModuleName, String ))
 typeIndicator =
     let
         helper : ModuleName -> String -> Core.Parser ( ModuleName, String )
@@ -30,4 +30,4 @@ typeIndicator =
     in
     Tokens.typeName
         |> Core.andThen (\typeOrSegment -> helper [] typeOrSegment)
-        |> Node.parserFromCore
+        |> Node.parserCore

--- a/src/Elm/Parser/Base.elm
+++ b/src/Elm/Parser/Base.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Base exposing (moduleName, typeIndicator)
 
-import Combine exposing (Parser, sepBy1, string)
+import Combine exposing (Parser, sepBy1Core)
 import Elm.Parser.Node as Node
 import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -8,9 +8,11 @@ import Elm.Syntax.Node exposing (Node)
 import Parser as Core exposing ((|.), (|=))
 
 
-moduleName : Parser state ModuleName
+moduleName : Parser state (Node ModuleName)
 moduleName =
-    sepBy1 (string ".") Tokens.typeName
+    sepBy1Core (Core.symbol ".") Tokens.typeNameCore
+        |> Node.parserCore
+        |> Combine.fromCore
 
 
 typeIndicator : Parser state (Node ( ModuleName, String ))

--- a/src/Elm/Parser/Comments.elm
+++ b/src/Elm/Parser/Comments.elm
@@ -13,7 +13,7 @@ addCommentToState : Core.Parser (Node String) -> Parser State ()
 addCommentToState p =
     p
         |> Combine.fromCore
-        |> Combine.andThen (\pair -> modifyState (addComment pair))
+        |> Combine.andThen (\pair -> modifyState (\state -> addComment pair state))
 
 
 parseComment : Core.Parser String -> Parser State ()

--- a/src/Elm/Parser/Comments.elm
+++ b/src/Elm/Parser/Comments.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Comments exposing (declarationDocumentation, moduleDocumentation, multilineComment, singleLineComment)
 
-import Combine exposing (Parser, modifyState)
+import Combine exposing (Parser)
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State, addComment)
 import Elm.Parser.Whitespace exposing (untilNewlineToken)
@@ -13,7 +13,7 @@ addCommentToState : Core.Parser (Node String) -> Parser State ()
 addCommentToState p =
     p
         |> Combine.fromCore
-        |> Combine.andThen (\pair -> modifyState (\state -> addComment pair state))
+        |> Combine.andThen (\pair -> Combine.modifyState (\state -> addComment pair state))
 
 
 parseComment : Core.Parser String -> Parser State ()

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -45,7 +45,7 @@ maybeDocumentation =
 
 function : Maybe (Node Documentation) -> Parser State (Node Declaration)
 function maybeDoc =
-    Node.parserFromCore Tokens.functionNameCore
+    Node.parserFromCore Tokens.functionName
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen functionWithNameNode
         |> Combine.map
@@ -88,7 +88,7 @@ functionWithNameNode pointer =
                 |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
                 |> Combine.andThen
                     (\sig ->
-                        Node.parserFromCore Tokens.functionNameCore
+                        Node.parserFromCore Tokens.functionName
                             |> Combine.andThen (\fnName -> failIfDifferentFrom varPointer fnName)
                             |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                             |> Combine.andThen (\body -> functionImplementationFromVarPointer (Just sig) body)
@@ -107,7 +107,7 @@ functionWithNameNode pointer =
 signature : Parser State Signature
 signature =
     Combine.succeed Signature
-        |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
+        |> Combine.keep (Node.parserFromCore Tokens.functionName)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ":"))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
@@ -126,7 +126,7 @@ infixDeclaration =
         |> Combine.ignore Layout.layout
         |> Combine.ignore (Combine.symbol "=")
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
+        |> Combine.keep (Node.parserFromCore Tokens.functionName)
         |> Combine.map Declaration.InfixDeclaration
         |> Node.parser
 

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -13,7 +13,7 @@ import Elm.Parser.Typings exposing (typeDefinition)
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Documentation exposing (Documentation)
 import Elm.Syntax.Expression as Expression exposing (Function, FunctionImplementation)
-import Elm.Syntax.Infix as Infix exposing (Infix)
+import Elm.Syntax.Infix as Infix
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Signature exposing (Signature)
 import Parser as Core exposing ((|.), (|=))
@@ -106,7 +106,7 @@ functionWithNameNode pointer =
 
 signature : Parser State Signature
 signature =
-    Combine.succeed Signature
+    Combine.succeed (\name -> \typeAnnotation -> { name = name, typeAnnotation = typeAnnotation })
         |> Combine.keep (Node.parserFromCore Tokens.functionName)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ":"))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -115,7 +115,7 @@ signature =
 
 infixDeclaration : Parser State (Node Declaration)
 infixDeclaration =
-    Combine.succeed Infix
+    Combine.succeed (\direction -> \precedence -> \operator -> \fn -> { direction = direction, precedence = precedence, operator = operator, function = fn })
         |> Combine.ignoreEntirely (Core.keyword "infix")
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parser infixDirection)

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -118,7 +118,7 @@ infixDeclaration =
     Combine.succeed (\direction -> \precedence -> \operator -> \fn -> { direction = direction, precedence = precedence, operator = operator, function = fn })
         |> Combine.ignoreEntirely (Core.keyword "infix")
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parser infixDirection)
+        |> Combine.keep infixDirection
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parserFromCore Core.int)
         |> Combine.ignore Layout.layout
@@ -141,7 +141,7 @@ operatorWithParens =
         |> Combine.fromCore
 
 
-infixDirection : Parser State Infix.InfixDirection
+infixDirection : Parser State (Node Infix.InfixDirection)
 infixDirection =
     Core.oneOf
         [ Core.keyword "right"
@@ -151,6 +151,7 @@ infixDirection =
         , Core.keyword "non"
             |> Core.map (\() -> Infix.Non)
         ]
+        |> Node.parserCore
         |> Combine.fromCore
 
 

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -45,7 +45,7 @@ maybeDocumentation =
 
 function : Maybe (Node Documentation) -> Parser State (Node Declaration)
 function maybeDoc =
-    Node.parser Tokens.functionName
+    Node.parserFromCore Tokens.functionNameCore
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen functionWithNameNode
         |> Combine.map
@@ -88,7 +88,7 @@ functionWithNameNode pointer =
                 |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
                 |> Combine.andThen
                     (\sig ->
-                        Node.parser Tokens.functionName
+                        Node.parserFromCore Tokens.functionNameCore
                             |> Combine.andThen (\fnName -> failIfDifferentFrom varPointer fnName)
                             |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                             |> Combine.andThen (\body -> functionImplementationFromVarPointer (Just sig) body)
@@ -107,7 +107,7 @@ functionWithNameNode pointer =
 signature : Parser State Signature
 signature =
     Combine.succeed Signature
-        |> Combine.keep (Node.parser Tokens.functionName)
+        |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ":"))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
@@ -120,13 +120,13 @@ infixDeclaration =
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parser infixDirection)
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parser (Combine.fromCore Core.int))
+        |> Combine.keep (Node.parserFromCore Core.int)
         |> Combine.ignore Layout.layout
         |> Combine.keep operatorWithParens
         |> Combine.ignore Layout.layout
         |> Combine.ignore (Combine.symbol "=")
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parser Tokens.functionName)
+        |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
         |> Combine.map Declaration.InfixDeclaration
         |> Node.parser
 

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -78,7 +78,7 @@ functionWithNameNode pointer =
                     }
                 )
                 |> Combine.keep (Combine.many (pattern |> Combine.ignore (Combine.maybeIgnore Layout.layout)))
-                |> Combine.ignore (Combine.symbol "=")
+                |> Combine.ignoreEntirely (Core.symbol "=")
                 |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                 |> Combine.keep expression
 
@@ -116,7 +116,7 @@ signature =
 infixDeclaration : Parser State (Node Declaration)
 infixDeclaration =
     Combine.succeed Infix
-        |> Combine.ignore (Combine.fromCore (Core.keyword "infix"))
+        |> Combine.ignoreEntirely (Core.keyword "infix")
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parser infixDirection)
         |> Combine.ignore Layout.layout
@@ -124,7 +124,7 @@ infixDeclaration =
         |> Combine.ignore Layout.layout
         |> Combine.keep operatorWithParens
         |> Combine.ignore Layout.layout
-        |> Combine.ignore (Combine.symbol "=")
+        |> Combine.ignoreEntirely (Core.symbol "=")
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parserFromCore Tokens.functionName)
         |> Combine.map Declaration.InfixDeclaration
@@ -172,6 +172,6 @@ portDeclaration maybeDoc =
                     Combine.modifyState (State.addComment doc)
             )
         |> Combine.keep Combine.location
-        |> Combine.ignore Tokens.portToken
+        |> Combine.ignoreEntirely Tokens.portToken
         |> Combine.ignore Layout.layout
         |> Combine.keep signature

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -38,15 +38,14 @@ declaration =
 maybeDocumentation : Parser State (Maybe (Node Documentation))
 maybeDocumentation =
     Comments.declarationDocumentation
-        |> Combine.fromCore
-        |> Combine.ignore Layout.layoutStrict
+        |> Combine.ignoreFromCore Layout.layoutStrict
         |> Combine.maybe
 
 
 function : Maybe (Node Documentation) -> Parser State (Node Declaration)
 function maybeDoc =
-    Node.parserFromCore Tokens.functionName
-        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+    Node.parserCore Tokens.functionName
+        |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen functionWithNameNode
         |> Combine.map
             (\f ->

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -46,7 +46,7 @@ maybeDocumentation =
 function : Maybe (Node Documentation) -> Parser State (Node Declaration)
 function maybeDoc =
     Node.parser functionName
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen functionWithNameNode
         |> Combine.map
             (\f ->
@@ -77,20 +77,20 @@ functionWithNameNode pointer =
                             (FunctionImplementation varPointer args expr)
                     }
                 )
-                |> Combine.keep (Combine.many (pattern |> Combine.ignore (maybe Layout.layout)))
+                |> Combine.keep (Combine.many (pattern |> Combine.ignore (Combine.maybeIgnore Layout.layout)))
                 |> Combine.ignore (Combine.symbol "=")
-                |> Combine.ignore (maybe Layout.layout)
+                |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                 |> Combine.keep expression
 
         functionWithSignature : Node String -> Parser State Function
         functionWithSignature varPointer =
             functionSignatureFromVarPointer varPointer
-                |> Combine.ignore (maybe Layout.layoutStrict)
+                |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
                 |> Combine.andThen
                     (\sig ->
                         Node.parser functionName
                             |> Combine.andThen (\fnName -> failIfDifferentFrom varPointer fnName)
-                            |> Combine.ignore (maybe Layout.layout)
+                            |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                             |> Combine.andThen (\body -> functionImplementationFromVarPointer (Just sig) body)
                     )
 
@@ -109,7 +109,7 @@ signature =
     succeed Signature
         |> Combine.keep (Node.parser functionName)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ":"))
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
 
 

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -67,13 +67,13 @@ functionWithNameNode : Node String -> Parser State Function
 functionWithNameNode pointer =
     let
         functionImplementationFromVarPointer : Maybe (Node Signature) -> Node String -> Parser State Function
-        functionImplementationFromVarPointer signature_ varPointer =
+        functionImplementationFromVarPointer signature_ ((Node { start } _) as varPointer) =
             succeed
-                (\args expr ->
+                (\args ((Node { end } _) as expr) ->
                     { documentation = Nothing
                     , signature = signature_
                     , declaration =
-                        Node { start = (Node.range varPointer).start, end = (Node.range expr).end }
+                        Node { start = start, end = end }
                             (FunctionImplementation varPointer args expr)
                     }
                 )

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -17,6 +17,7 @@ import Elm.Syntax.Infix as Infix
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Signature exposing (Signature)
 import Parser as Core exposing ((|.), (|=))
+import Parser.Extra
 
 
 declaration : Parser State (Node Declaration)
@@ -171,7 +172,7 @@ portDeclaration maybeDoc =
                 Just doc ->
                     Combine.modifyState (State.addComment doc)
             )
-        |> Combine.keepFromCore Combine.location
+        |> Combine.keepFromCore Parser.Extra.location
         |> Combine.ignoreEntirely Tokens.portToken
         |> Combine.ignore Layout.layout
         |> Combine.keep signature

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -106,7 +106,7 @@ functionWithNameNode pointer =
 signature : Parser State Signature
 signature =
     Combine.succeed (\name -> \typeAnnotation -> { name = name, typeAnnotation = typeAnnotation })
-        |> Combine.keep (Node.parserFromCore Tokens.functionName)
+        |> Combine.keepFromCore (Node.parserCore Tokens.functionName)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ":"))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
@@ -119,13 +119,13 @@ infixDeclaration =
         |> Combine.ignore Layout.layout
         |> Combine.keep infixDirection
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parserFromCore Core.int)
+        |> Combine.keepFromCore (Node.parserCore Core.int)
         |> Combine.ignore Layout.layout
         |> Combine.keep operatorWithParens
         |> Combine.ignore Layout.layout
         |> Combine.ignoreEntirely (Core.symbol "=")
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parserFromCore Tokens.functionName)
+        |> Combine.keepFromCore (Node.parserCore Tokens.functionName)
         |> Combine.map Declaration.InfixDeclaration
         |> Node.parser
 

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -7,7 +7,7 @@ import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.Patterns exposing (pattern)
 import Elm.Parser.State as State exposing (State)
-import Elm.Parser.Tokens exposing (functionName, portToken, prefixOperatorToken)
+import Elm.Parser.Tokens as Tokens
 import Elm.Parser.TypeAnnotation exposing (typeAnnotation)
 import Elm.Parser.Typings exposing (typeDefinition)
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
@@ -45,7 +45,7 @@ maybeDocumentation =
 
 function : Maybe (Node Documentation) -> Parser State (Node Declaration)
 function maybeDoc =
-    Node.parser functionName
+    Node.parser Tokens.functionName
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen functionWithNameNode
         |> Combine.map
@@ -88,7 +88,7 @@ functionWithNameNode pointer =
                 |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
                 |> Combine.andThen
                     (\sig ->
-                        Node.parser functionName
+                        Node.parser Tokens.functionName
                             |> Combine.andThen (\fnName -> failIfDifferentFrom varPointer fnName)
                             |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                             |> Combine.andThen (\body -> functionImplementationFromVarPointer (Just sig) body)
@@ -107,7 +107,7 @@ functionWithNameNode pointer =
 signature : Parser State Signature
 signature =
     Combine.succeed Signature
-        |> Combine.keep (Node.parser functionName)
+        |> Combine.keep (Node.parser Tokens.functionName)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ":"))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
@@ -126,7 +126,7 @@ infixDeclaration =
         |> Combine.ignore Layout.layout
         |> Combine.ignore (Combine.symbol "=")
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parser functionName)
+        |> Combine.keep (Node.parser Tokens.functionName)
         |> Combine.map Declaration.InfixDeclaration
         |> Node.parser
 
@@ -135,7 +135,7 @@ operatorWithParens : Parser state (Node String)
 operatorWithParens =
     Core.succeed identity
         |. Core.symbol "("
-        |= prefixOperatorToken
+        |= Tokens.prefixOperatorToken
         |. Core.symbol ")"
         |> Node.parserCore
         |> Combine.fromCore
@@ -172,6 +172,6 @@ portDeclaration maybeDoc =
                     Combine.modifyState (State.addComment doc)
             )
         |> Combine.keep Combine.location
-        |> Combine.ignore portToken
+        |> Combine.ignore Tokens.portToken
         |> Combine.ignore Layout.layout
         |> Combine.keep signature

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -157,7 +157,7 @@ infixDirection =
 portDeclaration : Maybe (Node Documentation) -> Parser State (Node Declaration)
 portDeclaration maybeDoc =
     Combine.succeed
-        (\(Node { start } _) ->
+        (\start ->
             \sig ->
                 Node
                     { start = start, end = (Node.range sig.typeAnnotation).end }
@@ -171,6 +171,7 @@ portDeclaration maybeDoc =
                 Just doc ->
                     Combine.modifyState (State.addComment doc)
             )
-        |> Combine.keep (Node.parser portToken)
+        |> Combine.keep Combine.location
+        |> Combine.ignore portToken
         |> Combine.ignore Layout.layout
         |> Combine.keep signature

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Declarations exposing (declaration)
 
-import Combine exposing (Parser, maybe, oneOf, succeed)
+import Combine exposing (Parser)
 import Elm.Parser.Comments as Comments
 import Elm.Parser.Expression exposing (expression, failIfDifferentFrom, functionSignatureFromVarPointer)
 import Elm.Parser.Layout as Layout
@@ -21,12 +21,12 @@ import Parser as Core exposing ((|.), (|=))
 
 declaration : Parser State (Node Declaration)
 declaration =
-    oneOf
+    Combine.oneOf
         [ infixDeclaration
         , maybeDocumentation
             |> Combine.andThen
                 (\maybeDoc ->
-                    oneOf
+                    Combine.oneOf
                         [ function maybeDoc
                         , typeDefinition maybeDoc
                         , portDeclaration maybeDoc
@@ -40,7 +40,7 @@ maybeDocumentation =
     Comments.declarationDocumentation
         |> Combine.fromCore
         |> Combine.ignore Layout.layoutStrict
-        |> maybe
+        |> Combine.maybe
 
 
 function : Maybe (Node Documentation) -> Parser State (Node Declaration)
@@ -68,7 +68,7 @@ functionWithNameNode pointer =
     let
         functionImplementationFromVarPointer : Maybe (Node Signature) -> Node String -> Parser State Function
         functionImplementationFromVarPointer signature_ ((Node { start } _) as varPointer) =
-            succeed
+            Combine.succeed
                 (\args ((Node { end } _) as expr) ->
                     { documentation = Nothing
                     , signature = signature_
@@ -106,7 +106,7 @@ functionWithNameNode pointer =
 
 signature : Parser State Signature
 signature =
-    succeed Signature
+    Combine.succeed Signature
         |> Combine.keep (Node.parser functionName)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ":"))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -115,7 +115,7 @@ signature =
 
 infixDeclaration : Parser State (Node Declaration)
 infixDeclaration =
-    succeed Infix
+    Combine.succeed Infix
         |> Combine.ignore (Combine.fromCore (Core.keyword "infix"))
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parser infixDirection)

--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -171,7 +171,7 @@ portDeclaration maybeDoc =
                 Just doc ->
                     Combine.modifyState (State.addComment doc)
             )
-        |> Combine.keep Combine.location
+        |> Combine.keepFromCore Combine.location
         |> Combine.ignoreEntirely Tokens.portToken
         |> Combine.ignore Layout.layout
         |> Combine.keep signature

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -5,7 +5,7 @@ import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (exposingToken, functionNameCore, typeNameCore)
+import Elm.Parser.Tokens exposing (exposingToken, functionNameCore, typeName)
 import Elm.Syntax.Exposing exposing (ExposedType, Exposing(..), TopLevelExpose(..))
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Parser as Core exposing ((|.), (|=))
@@ -61,7 +61,7 @@ infixExpose =
 
 typeExpose : Parser State (Node TopLevelExpose)
 typeExpose =
-    Node.parserFromCore typeNameCore
+    Node.parserFromCore typeName
         |> Combine.ignore (maybe Layout.layout)
         |> Combine.andThen
             (\((Node typeRange typeValue) as tipe) ->

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -30,9 +30,9 @@ exposingListInner : Parser State Exposing
 exposingListInner =
     Combine.oneOf
         [ Combine.succeed (\start -> \end -> All { start = start, end = end })
-            |> Combine.keep Combine.location
+            |> Combine.keepFromCore Combine.location
             |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ".."))
-            |> Combine.keep Combine.location
+            |> Combine.keepFromCore Combine.location
         , Combine.sepBy1 "," (Layout.maybeAroundBothSides exposable)
             |> Combine.map Explicit
         ]

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Expose exposing (exposeDefinition)
 
-import Combine exposing (Parser, maybe, oneOf, parens, sepBy1, symbol)
+import Combine exposing (Parser, maybe, oneOf, parens, symbol)
 import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -34,7 +34,7 @@ exposingListInner =
             |> Combine.keep Combine.location
             |> Combine.ignore (Layout.maybeAroundBothSides (symbol ".."))
             |> Combine.keep Combine.location
-        , sepBy1 (char ',') (Layout.maybeAroundBothSides exposable)
+        , Combine.sepBy1 (Combine.fromCore (char ',')) (Layout.maybeAroundBothSides exposable)
             |> Combine.map Explicit
         ]
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -8,6 +8,7 @@ import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.Exposing exposing (ExposedType, Exposing(..), TopLevelExpose(..))
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Parser as Core exposing ((|.), (|=))
+import Parser.Extra
 
 
 exposeDefinition : Parser State Exposing
@@ -30,9 +31,9 @@ exposingListInner : Parser State Exposing
 exposingListInner =
     Combine.oneOf
         [ Combine.succeed (\start -> \end -> All { start = start, end = end })
-            |> Combine.keepFromCore Combine.location
+            |> Combine.keepFromCore Parser.Extra.location
             |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ".."))
-            |> Combine.keepFromCore Combine.location
+            |> Combine.keepFromCore Parser.Extra.location
         , Combine.sepBy1 "," (Layout.maybeAroundBothSides exposable)
             |> Combine.map Explicit
         ]

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -60,8 +60,8 @@ infixExpose =
 
 typeExpose : Parser State (Node TopLevelExpose)
 typeExpose =
-    Node.parserFromCore Tokens.typeName
-        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+    Node.parserCore Tokens.typeName
+        |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen
             (\((Node typeRange typeValue) as tipe) ->
                 Combine.oneOf

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Expose exposing (exposeDefinition)
 
-import Combine exposing (Parser, maybe, oneOf, parens, sepBy1, string, symbol)
+import Combine exposing (Parser, maybe, oneOf, parens, sepBy1, symbol)
 import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -66,7 +66,7 @@ typeExpose =
         |> Combine.andThen
             (\((Node typeRange typeValue) as tipe) ->
                 Combine.oneOf
-                    [ Node.parser (parens (Layout.maybeAroundBothSides (string "..")))
+                    [ Node.parser (parens (Layout.maybeAroundBothSides (Combine.symbol "..")))
                         |> Combine.map
                             (\(Node openRange _) ->
                                 Node

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -4,7 +4,7 @@ import Combine exposing (Parser)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (exposingToken, functionNameCore, typeName)
+import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.Exposing exposing (ExposedType, Exposing(..), TopLevelExpose(..))
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Parser as Core exposing ((|.), (|=))
@@ -12,7 +12,7 @@ import Parser as Core exposing ((|.), (|=))
 
 exposeDefinition : Parser State Exposing
 exposeDefinition =
-    exposingToken
+    Tokens.exposingToken
         |> Combine.continueWith (Combine.maybeIgnore Layout.layout)
         |> Combine.continueWith exposeListWith
 
@@ -60,7 +60,7 @@ infixExpose =
 
 typeExpose : Parser State (Node TopLevelExpose)
 typeExpose =
-    Node.parserFromCore typeName
+    Node.parserFromCore Tokens.typeName
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen
             (\((Node typeRange typeValue) as tipe) ->
@@ -80,4 +80,4 @@ typeExpose =
 
 functionExpose : Parser state (Node TopLevelExpose)
 functionExpose =
-    Node.parserFromCore (Core.map FunctionExpose functionNameCore)
+    Node.parserFromCore (Core.map FunctionExpose Tokens.functionNameCore)

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -1,7 +1,6 @@
 module Elm.Parser.Expose exposing (exposeDefinition)
 
 import Combine exposing (Parser)
-import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
@@ -34,7 +33,7 @@ exposingListInner =
             |> Combine.keep Combine.location
             |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ".."))
             |> Combine.keep Combine.location
-        , Combine.sepBy1 (Combine.fromCore (char ',')) (Layout.maybeAroundBothSides exposable)
+        , Combine.sepBy1 (Combine.symbol ",") (Layout.maybeAroundBothSides exposable)
             |> Combine.map Explicit
         ]
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -80,4 +80,4 @@ typeExpose =
 
 functionExpose : Parser state (Node TopLevelExpose)
 functionExpose =
-    Node.parserFromCore (Core.map FunctionExpose Tokens.functionNameCore)
+    Node.parserFromCore (Core.map FunctionExpose Tokens.functionName)

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Expose exposing (exposeDefinition)
 
-import Combine exposing (Parser, maybe, oneOf, parens, symbol)
+import Combine exposing (Parser)
 import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -14,13 +14,13 @@ import Parser as Core exposing ((|.), (|=))
 exposeDefinition : Parser State Exposing
 exposeDefinition =
     exposingToken
-        |> Combine.continueWith (maybe Layout.layout)
+        |> Combine.continueWith (Combine.maybe Layout.layout)
         |> Combine.continueWith exposeListWith
 
 
 exposeListWith : Parser State Exposing
 exposeListWith =
-    parens
+    Combine.parens
         (Layout.optimisticLayout
             |> Combine.continueWith exposingListInner
             |> Combine.ignore Layout.optimisticLayout
@@ -32,7 +32,7 @@ exposingListInner =
     Combine.oneOf
         [ Combine.succeed (\start -> \end -> All { start = start, end = end })
             |> Combine.keep Combine.location
-            |> Combine.ignore (Layout.maybeAroundBothSides (symbol ".."))
+            |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ".."))
             |> Combine.keep Combine.location
         , Combine.sepBy1 (Combine.fromCore (char ',')) (Layout.maybeAroundBothSides exposable)
             |> Combine.map Explicit
@@ -41,7 +41,7 @@ exposingListInner =
 
 exposable : Parser State (Node TopLevelExpose)
 exposable =
-    oneOf
+    Combine.oneOf
         [ typeExpose
         , infixExpose
         , functionExpose
@@ -66,7 +66,7 @@ typeExpose =
         |> Combine.andThen
             (\((Node typeRange typeValue) as tipe) ->
                 Combine.oneOf
-                    [ Node.parser (parens (Layout.maybeAroundBothSides (Combine.symbol "..")))
+                    [ Node.parser (Combine.parens (Layout.maybeAroundBothSides (Combine.symbol "..")))
                         |> Combine.map
                             (\(Node openRange _) ->
                                 Node

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -50,13 +50,12 @@ exposable =
 
 infixExpose : Parser state (Node TopLevelExpose)
 infixExpose =
-    Core.succeed identity
+    Core.succeed InfixExpose
         |. Core.symbol "("
         |= (Core.chompWhile (\c -> c /= ')')
                 |> Core.getChompedString
            )
         |. Core.symbol ")"
-        |> Core.map InfixExpose
         |> Node.parserCore
         |> Combine.fromCore
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -33,7 +33,7 @@ exposingListInner =
             |> Combine.keep Combine.location
             |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol ".."))
             |> Combine.keep Combine.location
-        , Combine.sepBy1 (Combine.symbol ",") (Layout.maybeAroundBothSides exposable)
+        , Combine.sepBy1 "," (Layout.maybeAroundBothSides exposable)
             |> Combine.map Explicit
         ]
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -5,7 +5,7 @@ import Combine.Char exposing (char)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (exposingToken, functionName, typeName)
+import Elm.Parser.Tokens exposing (exposingToken, functionNameCore, typeNameCore)
 import Elm.Syntax.Exposing exposing (ExposedType, Exposing(..), TopLevelExpose(..))
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Parser as Core exposing ((|.), (|=))
@@ -56,13 +56,12 @@ infixExpose =
                 |> Core.getChompedString
            )
         |. Core.symbol ")"
-        |> Node.parserCore
-        |> Combine.fromCore
+        |> Node.parserFromCore
 
 
 typeExpose : Parser State (Node TopLevelExpose)
 typeExpose =
-    Node.parser typeName
+    Node.parserFromCore typeNameCore
         |> Combine.ignore (maybe Layout.layout)
         |> Combine.andThen
             (\((Node typeRange typeValue) as tipe) ->
@@ -82,4 +81,4 @@ typeExpose =
 
 functionExpose : Parser state (Node TopLevelExpose)
 functionExpose =
-    Node.parser (Combine.map FunctionExpose functionName)
+    Node.parserFromCore (Core.map FunctionExpose functionNameCore)

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -13,7 +13,7 @@ import Parser as Core exposing ((|.), (|=))
 exposeDefinition : Parser State Exposing
 exposeDefinition =
     exposingToken
-        |> Combine.continueWith (Combine.maybe Layout.layout)
+        |> Combine.continueWith (Combine.maybeIgnore Layout.layout)
         |> Combine.continueWith exposeListWith
 
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -12,7 +12,7 @@ import Parser as Core exposing ((|.), (|=))
 
 exposeDefinition : Parser State Exposing
 exposeDefinition =
-    Tokens.exposingToken
+    Combine.fromCore Tokens.exposingToken
         |> Combine.continueWith (Combine.maybeIgnore Layout.layout)
         |> Combine.continueWith exposeListWith
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -62,7 +62,7 @@ infixExpose =
 typeExpose : Parser State (Node TopLevelExpose)
 typeExpose =
     Node.parserFromCore typeName
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen
             (\((Node typeRange typeValue) as tipe) ->
                 Combine.oneOf

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -17,6 +17,7 @@ import Elm.Syntax.Pattern as Pattern exposing (Pattern)
 import Elm.Syntax.Range exposing (Location)
 import Elm.Syntax.Signature exposing (Signature)
 import Parser as Core exposing ((|.), (|=), Nestable(..))
+import Parser.Extra
 import Pratt exposing (Config)
 
 
@@ -342,7 +343,7 @@ lambdaExpression config =
                         |> LambdaExpression
                         |> Node { start = start, end = end }
         )
-        |> Combine.keepFromCore Combine.location
+        |> Combine.keepFromCore Parser.Extra.location
         |> Combine.ignoreEntirely backSlash
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep (Combine.sepBy1WithState (Combine.maybeIgnore Layout.layout) Patterns.pattern)
@@ -364,7 +365,7 @@ caseExpression config =
                     Node { start = start, end = end }
                         (CaseExpression (CaseBlock caseBlock_ cases))
         )
-        |> Combine.keepFromCore Combine.location
+        |> Combine.keepFromCore Parser.Extra.location
         |> Combine.ignoreEntirely Tokens.caseToken
         |> Combine.ignore Layout.layout
         |> Combine.keep (Pratt.subExpression 0 config)
@@ -404,7 +405,7 @@ letExpression config =
                         Node { start = start, end = end }
                             (LetExpression (LetBlock declarations expr))
             )
-            |> Combine.keepFromCore Combine.location
+            |> Combine.keepFromCore Parser.Extra.location
             |> Combine.ignoreEntirely Tokens.letToken
             |> Combine.ignore Layout.layout
             |> Combine.keep (withIndentedState (letDeclarations config))
@@ -462,7 +463,7 @@ ifBlockExpression config =
                             { start = start, end = end }
                             (IfBlock condition ifTrue ifFalse)
         )
-        |> Combine.keepFromCore Combine.location
+        |> Combine.keepFromCore Parser.Extra.location
         |> Combine.ignoreEntirely Tokens.ifToken
         |> Combine.keep (Pratt.subExpression 0 config)
         |> Combine.ignoreEntirely Tokens.thenToken

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -623,7 +623,7 @@ functionWithSignature config varPointer =
         |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
         |> Combine.andThen
             (\sig ->
-                Node.parser Tokens.functionName
+                Node.parserFromCore Tokens.functionNameCore
                     |> Combine.andThen (\fnName -> failIfDifferentFrom varPointer fnName)
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.andThen (\newPointer -> functionImplementationFromVarPointer config newPointer)

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -221,8 +221,8 @@ listExpression config =
 
 recordExpression : Config State (Node Expression) -> Parser State (Node Expression)
 recordExpression config =
-    Combine.fromCore curlyStart
-        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+    curlyStart
+        |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
         |> Combine.continueWith
             (Combine.oneOf
                 [ curlyEnd
@@ -237,8 +237,7 @@ recordExpression config =
 recordContents : Config State (Node Expression) -> Parser State Expression
 recordContents config =
     Node.parserCore Tokens.functionName
-        |> Combine.fromCore
-        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+        |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen
             (\fname ->
                 Combine.oneOf
@@ -305,8 +304,8 @@ recordField config =
 
 recordFieldWithoutValue : Parser State (Node String)
 recordFieldWithoutValue =
-    Node.parserFromCore Tokens.functionName
-        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+    Node.parserCore Tokens.functionName
+        |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
         |> Combine.ignoreEntirely equal
 
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -165,7 +165,7 @@ recordAccessParser =
                 else
                     Core.succeed identity
                         |. dot
-                        |= Node.parserCore Tokens.functionNameCore
+                        |= Node.parserCore Tokens.functionName
             )
         |> Combine.fromCore
 
@@ -239,7 +239,7 @@ recordExpression config =
 
 recordContents : Config State (Node Expression) -> Parser State Expression
 recordContents config =
-    Node.parserCore Tokens.functionNameCore
+    Node.parserCore Tokens.functionName
         |> Combine.fromCore
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen
@@ -311,7 +311,7 @@ recordField config =
 
 recordFieldWithoutValue : Parser State (Node String)
 recordFieldWithoutValue =
-    Node.parserFromCore Tokens.functionNameCore
+    Node.parserFromCore Tokens.functionName
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.ignore equal
 
@@ -521,7 +521,7 @@ referenceExpression =
                     |= Core.oneOf
                         [ Tokens.typeName
                             |> Core.andThen (\t -> helper (nameOrSegment :: moduleNameSoFar) t)
-                        , Tokens.functionNameCore
+                        , Tokens.functionName
                             |> Core.map
                                 (\name ->
                                     FunctionOrValue
@@ -536,7 +536,7 @@ referenceExpression =
     Core.oneOf
         [ Tokens.typeName
             |> Core.andThen (\t -> helper [] t)
-        , Tokens.functionNameCore
+        , Tokens.functionName
             |> Core.map (\v -> FunctionOrValue [] v)
         ]
         |> Node.parserCore
@@ -547,7 +547,7 @@ recordAccessFunctionExpression : Parser state (Node Expression)
 recordAccessFunctionExpression =
     Core.succeed (\field -> RecordAccessFunction ("." ++ field))
         |. dot
-        |= Tokens.functionNameCore
+        |= Tokens.functionName
         |> Node.parserCore
         |> Combine.fromCore
 
@@ -623,7 +623,7 @@ functionWithSignature config varPointer =
         |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
         |> Combine.andThen
             (\sig ->
-                Node.parserFromCore Tokens.functionNameCore
+                Node.parserFromCore Tokens.functionName
                     |> Combine.andThen (\fnName -> failIfDifferentFrom varPointer fnName)
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.andThen (\newPointer -> functionImplementationFromVarPointer config newPointer)

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -246,7 +246,7 @@ recordContents config =
             (\fname ->
                 Combine.oneOf
                     [ recordUpdateSyntaxParser config fname
-                    , equal
+                    , Combine.fromCore equal
                         |> Combine.continueWith (Pratt.subExpression 0 config)
                         |> Combine.andThen
                             (\e ->
@@ -313,7 +313,7 @@ recordFieldWithoutValue : Parser State (Node String)
 recordFieldWithoutValue =
     Node.parserFromCore Tokens.functionName
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.ignore equal
+        |> Combine.ignoreEntirely equal
 
 
 literalExpression : Parser state (Node Expression)
@@ -372,11 +372,11 @@ caseExpression config =
                         (CaseExpression (CaseBlock caseBlock_ cases))
         )
         |> Combine.keep Combine.location
-        |> Combine.ignore Tokens.caseToken
+        |> Combine.ignoreEntirely Tokens.caseToken
         |> Combine.ignore Layout.layout
         |> Combine.keep (Pratt.subExpression 0 config)
         |> Combine.ignore Layout.positivelyIndented
-        |> Combine.ignore Tokens.ofToken
+        |> Combine.ignoreEntirely Tokens.ofToken
         |> Combine.ignore Layout.layout
         |> Combine.keep (withIndentedState (caseStatements config))
 
@@ -412,11 +412,11 @@ letExpression config =
                             (LetExpression (LetBlock declarations expr))
             )
             |> Combine.keep Combine.location
-            |> Combine.ignore Tokens.letToken
+            |> Combine.ignoreEntirely Tokens.letToken
             |> Combine.ignore Layout.layout
             |> Combine.keep (withIndentedState (letDeclarations config))
             |> Combine.ignore Layout.optimisticLayout
-            |> Combine.ignore Tokens.inToken
+            |> Combine.ignoreEntirely Tokens.inToken
         )
         |> Combine.keep (Pratt.subExpression 0 config)
 
@@ -448,7 +448,7 @@ letDestructuringDeclarationWithPattern config ((Node { start } _) as pattern) =
         (\((Node { end } _) as expr) ->
             Node { start = start, end = end } (LetDestructuring pattern expr)
         )
-        |> Combine.ignore equal
+        |> Combine.ignoreEntirely equal
         |> Combine.keep (Pratt.subExpression 0 config)
 
 
@@ -470,11 +470,11 @@ ifBlockExpression config =
                             (IfBlock condition ifTrue ifFalse)
         )
         |> Combine.keep Combine.location
-        |> Combine.ignore Tokens.ifToken
+        |> Combine.ignoreEntirely Tokens.ifToken
         |> Combine.keep (Pratt.subExpression 0 config)
-        |> Combine.ignore Tokens.thenToken
+        |> Combine.ignoreEntirely Tokens.thenToken
         |> Combine.keep (Pratt.subExpression 0 config)
-        |> Combine.ignore Tokens.elseToken
+        |> Combine.ignoreEntirely Tokens.elseToken
         |> Combine.ignore Layout.layout
         |> Combine.keep (Pratt.subExpression 0 config)
 
@@ -646,7 +646,7 @@ functionImplementationFromVarPointer config ((Node { start } _) as varPointer) =
                     (FunctionImplementation varPointer args expr)
         )
         |> Combine.keep (Combine.many (Patterns.pattern |> Combine.ignore (Combine.maybeIgnore Layout.layout)))
-        |> Combine.ignore equal
+        |> Combine.ignoreEntirely equal
         |> Combine.keep (Pratt.subExpression 0 config)
 
 
@@ -729,9 +729,9 @@ arrowRight =
     Combine.symbol "->"
 
 
-equal : Parser state ()
+equal : Core.Parser ()
 equal =
-    Combine.symbol "="
+    Core.symbol "="
 
 
 comma : Parser state ()

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -87,7 +87,7 @@ expression =
 infixLeft : Int -> String -> Config state (Node Expression) -> ( Int, Node Expression -> Parser state (Node Expression) )
 infixLeft precedence symbol =
     Pratt.infixLeft precedence
-        (Combine.symbol symbol)
+        (Core.symbol symbol)
         (\((Node { start } _) as left) ((Node { end } _) as right) ->
             Node
                 { start = start, end = end }
@@ -98,7 +98,7 @@ infixLeft precedence symbol =
 infixNonAssociative : Int -> String -> Config state (Node Expression) -> ( Int, Node Expression -> Parser state (Node Expression) )
 infixNonAssociative precedence symbol =
     Pratt.infixLeft precedence
-        (Combine.symbol symbol)
+        (Core.symbol symbol)
         (\((Node { start } _) as left) ((Node { end } _) as right) ->
             Node
                 { start = start, end = end }
@@ -109,7 +109,7 @@ infixNonAssociative precedence symbol =
 infixRight : Int -> String -> Config state (Node Expression) -> ( Int, Node Expression -> Parser state (Node Expression) )
 infixRight precedence symbol =
     Pratt.infixRight precedence
-        (Combine.symbol symbol)
+        (Core.symbol symbol)
         (\((Node { start } _) as left) ((Node { end } _) as right) ->
             Node
                 { start = start, end = end }
@@ -132,7 +132,6 @@ infixLeftSubtraction precedence =
                     else
                         minus
                 )
-            |> Combine.fromCore
         )
         (\((Node { start } _) as left) ((Node { end } _) as right) ->
             Node
@@ -172,7 +171,7 @@ recordAccessParser =
 
 functionCall : Pratt.Config State (Node Expression) -> ( Int, Node Expression -> Parser State (Node Expression) )
 functionCall =
-    Pratt.infixLeft 90
+    Pratt.infixLeftWithState 90
         Layout.positivelyIndented
         (\((Node { start } leftValue) as left) ((Node { end } _) as right) ->
             Node
@@ -548,8 +547,7 @@ recordAccessFunctionExpression =
     Core.succeed (\field -> RecordAccessFunction ("." ++ field))
         |. dot
         |= Tokens.functionName
-        |> Node.parserCore
-        |> Combine.fromCore
+        |> Node.parserFromCore
 
 
 tupledExpression : Config State (Node Expression) -> Parser State (Node Expression)

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -403,23 +403,21 @@ caseStatement config =
 
 letExpression : Config State (Node Expression) -> Parser State (Node Expression)
 letExpression config =
-    Combine.succeed
-        (\( start, decls ) ->
-            \((Node { end } _) as expr) ->
-                Node { start = start, end = end }
-                    (LetExpression (LetBlock decls expr))
-        )
-        |> Combine.keep
-            (withIndentedState
-                (Combine.succeed (\let_ -> \declarations -> ( let_, declarations ))
-                    |> Combine.keep Combine.location
-                    |> Combine.ignore Tokens.letToken
-                    |> Combine.ignore Layout.layout
-                    |> Combine.keep (withIndentedState (letDeclarations config))
-                    |> Combine.ignore Layout.optimisticLayout
-                    |> Combine.ignore Tokens.inToken
-                )
+    withIndentedState
+        (Combine.succeed
+            (\start ->
+                \declarations ->
+                    \((Node { end } _) as expr) ->
+                        Node { start = start, end = end }
+                            (LetExpression (LetBlock declarations expr))
             )
+            |> Combine.keep Combine.location
+            |> Combine.ignore Tokens.letToken
+            |> Combine.ignore Layout.layout
+            |> Combine.keep (withIndentedState (letDeclarations config))
+            |> Combine.ignore Layout.optimisticLayout
+            |> Combine.ignore Tokens.inToken
+        )
         |> Combine.keep (Pratt.subExpression 0 config)
 
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -210,11 +210,7 @@ listExpression config =
     Combine.succeed ListExpr
         |> Combine.ignore squareStart
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.keep
-            (Combine.sepBy
-                comma
-                (Pratt.subExpression 0 config)
-            )
+        |> Combine.keep (Combine.sepBy "," (Pratt.subExpression 0 config))
         |> Combine.ignore squareEnd
         |> Node.parser
 
@@ -266,7 +262,7 @@ recordContents config =
                                     [ endSymbol
                                         |> Combine.map (\() -> toRecordExpr [])
                                     , Combine.succeed toRecordExpr
-                                        |> Combine.ignore comma
+                                        |> Combine.ignoreEntirely comma
                                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                         |> Combine.keep (recordFields config)
                                         |> Combine.ignore endSymbol
@@ -292,7 +288,7 @@ recordFields config =
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep
             (Combine.many
-                (comma
+                (Combine.fromCore comma
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.continueWith (recordField config)
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -351,7 +347,7 @@ lambdaExpression config =
         |> Combine.keep Combine.location
         |> Combine.ignore backSlash
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.keep (Combine.sepBy1 (Combine.maybeIgnore Layout.layout) Patterns.pattern)
+        |> Combine.keep (Combine.sepBy1WithState (Combine.maybeIgnore Layout.layout) Patterns.pattern)
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.ignore arrowRight
         |> Combine.keep (Pratt.subExpression 0 config)
@@ -556,7 +552,7 @@ tupledExpression config =
         commaSep : Parser State (List (Node Expression))
         commaSep =
             Combine.many
-                (comma
+                (Combine.fromCore comma
                     |> Combine.continueWith (Pratt.subExpression 0 config)
                 )
 
@@ -732,9 +728,9 @@ equal =
     Core.symbol "="
 
 
-comma : Parser state ()
+comma : Core.Parser ()
 comma =
-    Combine.symbol ","
+    Core.symbol ","
 
 
 parensStart : Parser state ()

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -303,13 +303,12 @@ recordFields config =
 
 recordField : Config State (Node Expression) -> Parser State (Node RecordSetter)
 recordField config =
-    Node.parser
-        (Combine.succeed (\fnName -> \expr -> ( fnName, expr ))
-            |> Combine.keep (Node.parser Tokens.functionName)
-            |> Combine.ignore (Combine.maybe Layout.layout)
-            |> Combine.ignore equal
-            |> Combine.keep (Pratt.subExpression 0 config)
-        )
+    Combine.succeed (\fnName -> \expr -> ( fnName, expr ))
+        |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
+        |> Combine.ignore (Combine.maybe Layout.layout)
+        |> Combine.ignore equal
+        |> Combine.keep (Pratt.subExpression 0 config)
+        |> Node.parser
 
 
 literalExpression : Parser state (Node Expression)

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -326,7 +326,10 @@ literalExpression =
 
 charLiteralExpression : Parser state (Node Expression)
 charLiteralExpression =
-    Node.parser (Combine.map CharLiteral Tokens.characterLiteral)
+    Tokens.characterLiteral
+        |> Core.map CharLiteral
+        |> Node.parserCore
+        |> Combine.fromCore
 
 
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -315,13 +315,13 @@ recordField config =
 
 literalExpression : Parser state (Node Expression)
 literalExpression =
-    Combine.oneOf
+    Core.oneOf
         [ Tokens.multiLineStringLiteral
         , Tokens.stringLiteral
-            |> Combine.fromCore
         ]
-        |> Combine.map Literal
-        |> Node.parser
+        |> Core.map Literal
+        |> Node.parserCore
+        |> Combine.fromCore
 
 
 charLiteralExpression : Parser state (Node Expression)

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -199,7 +199,7 @@ glslExpression =
             "|]"
     in
     Core.mapChompedString
-        (\s _ -> s |> String.dropLeft (String.length start) |> GLSLExpression)
+        (\s () -> s |> String.dropLeft (String.length start) |> GLSLExpression)
         (Core.multiComment start end NotNestable)
         |. Core.symbol end
         |> Node.parserCore

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -342,7 +342,7 @@ lambdaExpression config =
                         |> LambdaExpression
                         |> Node { start = start, end = end }
         )
-        |> Combine.keep Combine.location
+        |> Combine.keepFromCore Combine.location
         |> Combine.ignoreEntirely backSlash
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep (Combine.sepBy1WithState (Combine.maybeIgnore Layout.layout) Patterns.pattern)
@@ -364,7 +364,7 @@ caseExpression config =
                     Node { start = start, end = end }
                         (CaseExpression (CaseBlock caseBlock_ cases))
         )
-        |> Combine.keep Combine.location
+        |> Combine.keepFromCore Combine.location
         |> Combine.ignoreEntirely Tokens.caseToken
         |> Combine.ignore Layout.layout
         |> Combine.keep (Pratt.subExpression 0 config)
@@ -404,7 +404,7 @@ letExpression config =
                         Node { start = start, end = end }
                             (LetExpression (LetBlock declarations expr))
             )
-            |> Combine.keep Combine.location
+            |> Combine.keepFromCore Combine.location
             |> Combine.ignoreEntirely Tokens.letToken
             |> Combine.ignore Layout.layout
             |> Combine.keep (withIndentedState (letDeclarations config))
@@ -462,7 +462,7 @@ ifBlockExpression config =
                             { start = start, end = end }
                             (IfBlock condition ifTrue ifFalse)
         )
-        |> Combine.keep Combine.location
+        |> Combine.keepFromCore Combine.location
         |> Combine.ignoreEntirely Tokens.ifToken
         |> Combine.keep (Pratt.subExpression 0 config)
         |> Combine.ignoreEntirely Tokens.thenToken

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -489,7 +489,7 @@ minusNotFollowedBySpace =
     Core.succeed identity
         |. Core.backtrackable minus
         |= Core.oneOf
-            [ Core.map (always True) (Core.backtrackable Whitespace.realNewLineCore)
+            [ Core.map (always True) (Core.backtrackable Whitespace.realNewLine)
             , Core.map (always True) (Core.backtrackable (Core.symbol " "))
             , Core.succeed False
             ]

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -175,16 +175,15 @@ functionCall =
     Pratt.infixLeft 90
         Layout.positivelyIndented
         (\((Node { start } leftValue) as left) ((Node { end } _) as right) ->
-            case leftValue of
-                Expression.Application args ->
-                    Node
-                        { start = start, end = end }
-                        (Expression.Application (args ++ [ right ]))
+            Node
+                { start = start, end = end }
+                (case leftValue of
+                    Expression.Application args ->
+                        Expression.Application (args ++ [ right ])
 
-                _ ->
-                    Node
-                        { start = start, end = end }
-                        (Expression.Application [ left, right ])
+                    _ ->
+                        Expression.Application [ left, right ]
+                )
         )
 
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -551,8 +551,8 @@ tupledExpression config =
         commaSep : Parser State (List (Node Expression))
         commaSep =
             Combine.many
-                (Combine.fromCore comma
-                    |> Combine.continueWith (Pratt.subExpression 0 config)
+                (comma
+                    |> Combine.continueFromCore (Pratt.subExpression 0 config)
                 )
 
         nested : Parser State Expression
@@ -561,8 +561,8 @@ tupledExpression config =
                 |> Combine.keep (Pratt.subExpression 0 config)
                 |> Combine.keep commaSep
     in
-    Combine.fromCore parensStart
-        |> Combine.continueWith
+    parensStart
+        |> Combine.continueFromCore
             (Combine.oneOf
                 [ parensEnd |> Core.map (always UnitExpr) |> Combine.fromCore
                 , closingPrefixOperator

--- a/src/Elm/Parser/File.elm
+++ b/src/Elm/Parser/File.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.File exposing (file)
 
-import Combine exposing (Parser, many, succeed, withState)
+import Combine exposing (Parser)
 import Elm.Parser.Comments as Comments
 import Elm.Parser.Declarations exposing (declaration)
 import Elm.Parser.Imports exposing (importDefinition)
@@ -15,24 +15,24 @@ import Elm.Syntax.Node exposing (Node)
 
 file : Parser State File
 file =
-    succeed File
+    Combine.succeed File
         |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
         |> Combine.keep (Node.parser moduleDefinition)
         |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
         |> Combine.ignore (Combine.maybeIgnore (Comments.moduleDocumentation |> Combine.ignore Layout.layoutStrict))
-        |> Combine.keep (many importDefinition)
+        |> Combine.keep (Combine.many importDefinition)
         |> Combine.keep fileDeclarations
         |> Combine.keep collectComments
 
 
 collectComments : Parser State (List (Node String))
 collectComments =
-    withState (State.getComments >> succeed)
+    Combine.withState (State.getComments >> Combine.succeed)
 
 
 fileDeclarations : Parser State (List (Node Declaration))
 fileDeclarations =
-    many
+    Combine.many
         (declaration
             |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
         )

--- a/src/Elm/Parser/File.elm
+++ b/src/Elm/Parser/File.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.File exposing (file)
 
-import Combine exposing (Parser, many, maybe, succeed, withState)
+import Combine exposing (Parser, many, succeed, withState)
 import Elm.Parser.Comments as Comments
 import Elm.Parser.Declarations exposing (declaration)
 import Elm.Parser.Imports exposing (importDefinition)
@@ -16,10 +16,10 @@ import Elm.Syntax.Node exposing (Node)
 file : Parser State File
 file =
     succeed File
-        |> Combine.ignore (maybe Layout.layoutStrict)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
         |> Combine.keep (Node.parser moduleDefinition)
-        |> Combine.ignore (maybe Layout.layoutStrict)
-        |> Combine.ignore (maybe (Comments.moduleDocumentation |> Combine.ignore Layout.layoutStrict))
+        |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
+        |> Combine.ignore (Combine.maybeIgnore (Comments.moduleDocumentation |> Combine.ignore Layout.layoutStrict))
         |> Combine.keep (many importDefinition)
         |> Combine.keep fileDeclarations
         |> Combine.keep collectComments
@@ -34,5 +34,5 @@ fileDeclarations : Parser State (List (Node Declaration))
 fileDeclarations =
     many
         (declaration
-            |> Combine.ignore (maybe Layout.layoutStrict)
+            |> Combine.ignore (Combine.maybeIgnore Layout.layoutStrict)
         )

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -41,8 +41,9 @@ importDefinition =
                 ]
                 |> Combine.map (\imp -> setupNode start imp)
     in
-    Combine.succeed (\(Node { start } ()) -> \mod -> parseAsDefinition start mod)
-        |> Combine.keep (Node.parser importToken)
+    Combine.succeed (\start -> \mod -> parseAsDefinition start mod)
+        |> Combine.keep Combine.location
+        |> Combine.ignore importToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.optimisticLayout

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -11,6 +11,7 @@ import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range exposing (Location, Range)
+import Parser.Extra
 
 
 importDefinition : Parser State (Node Import)
@@ -42,7 +43,7 @@ importDefinition =
                 |> Combine.map (\imp -> setupNode start imp)
     in
     Combine.succeed (\start -> \mod -> parseAsDefinition start mod)
-        |> Combine.keepFromCore Combine.location
+        |> Combine.keepFromCore Parser.Extra.location
         |> Combine.ignoreEntirely Tokens.importToken
         |> Combine.ignore Layout.layout
         |> Combine.keepFromCore moduleName

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -18,8 +18,8 @@ importDefinition =
     let
         asDefinition : Parser State (Node ModuleName)
         asDefinition =
-            Combine.fromCore Tokens.asToken
-                |> Combine.continueWith Layout.layout
+            Tokens.asToken
+                |> Combine.ignoreFromCore Layout.layout
                 |> Combine.continueWith moduleName
 
         parseExposingDefinition : Node ModuleName -> Maybe (Node ModuleName) -> Parser State Import

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -20,7 +20,7 @@ importDefinition =
         asDefinition =
             asToken
                 |> Combine.continueWith Layout.layout
-                |> Combine.continueWith (Node.parser moduleName)
+                |> Combine.continueWith moduleName
 
         parseExposingDefinition : Node ModuleName -> Maybe (Node ModuleName) -> Parser State Import
         parseExposingDefinition mod asDef =
@@ -44,7 +44,7 @@ importDefinition =
     Combine.succeed (\node -> \mod -> parseAsDefinition node mod)
         |> Combine.keep (Node.parser importToken)
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parser moduleName)
+        |> Combine.keep moduleName
         |> Combine.ignore Layout.optimisticLayout
         |> Combine.andThen identity
         |> Combine.ignore Layout.optimisticLayout

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -20,7 +20,7 @@ importDefinition =
         asDefinition =
             Tokens.asToken
                 |> Combine.ignoreFromCore Layout.layout
-                |> Combine.continueWith moduleName
+                |> Combine.continueWithCore moduleName
 
         parseExposingDefinition : Node ModuleName -> Maybe (Node ModuleName) -> Parser State Import
         parseExposingDefinition mod asDef =
@@ -45,7 +45,7 @@ importDefinition =
         |> Combine.keep Combine.location
         |> Combine.ignoreEntirely Tokens.importToken
         |> Combine.ignore Layout.layout
-        |> Combine.keep moduleName
+        |> Combine.keepFromCore moduleName
         |> Combine.ignore Layout.optimisticLayout
         |> Combine.andThen identity
         |> Combine.ignore Layout.optimisticLayout

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -18,7 +18,7 @@ importDefinition =
     let
         asDefinition : Parser State (Node ModuleName)
         asDefinition =
-            Tokens.asToken
+            Combine.fromCore Tokens.asToken
                 |> Combine.continueWith Layout.layout
                 |> Combine.continueWith moduleName
 
@@ -43,7 +43,7 @@ importDefinition =
     in
     Combine.succeed (\start -> \mod -> parseAsDefinition start mod)
         |> Combine.keep Combine.location
-        |> Combine.ignore Tokens.importToken
+        |> Combine.ignoreEntirely Tokens.importToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.optimisticLayout

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -6,7 +6,7 @@ import Elm.Parser.Expose exposing (exposeDefinition)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (asToken, importToken)
+import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))
@@ -18,7 +18,7 @@ importDefinition =
     let
         asDefinition : Parser State (Node ModuleName)
         asDefinition =
-            asToken
+            Tokens.asToken
                 |> Combine.continueWith Layout.layout
                 |> Combine.continueWith moduleName
 
@@ -43,7 +43,7 @@ importDefinition =
     in
     Combine.succeed (\start -> \mod -> parseAsDefinition start mod)
         |> Combine.keep Combine.location
-        |> Combine.ignore importToken
+        |> Combine.ignore Tokens.importToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.optimisticLayout

--- a/src/Elm/Parser/Imports.elm
+++ b/src/Elm/Parser/Imports.elm
@@ -42,7 +42,7 @@ importDefinition =
                 |> Combine.map (\imp -> setupNode start imp)
     in
     Combine.succeed (\start -> \mod -> parseAsDefinition start mod)
-        |> Combine.keep Combine.location
+        |> Combine.keepFromCore Combine.location
         |> Combine.ignoreEntirely Tokens.importToken
         |> Combine.ignore Layout.layout
         |> Combine.keepFromCore moduleName

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -8,7 +8,7 @@ module Elm.Parser.Layout exposing
     , positivelyIndented
     )
 
-import Combine exposing (Parser, many1Ignore, maybe, oneOf, problem, succeed, withLocation, withState)
+import Combine exposing (Parser, many1Ignore, oneOf, problem, succeed, withLocation, withState)
 import Elm.Parser.Comments as Comments
 import Elm.Parser.State as State exposing (State)
 import Elm.Parser.Whitespace exposing (many1Spaces, realNewLine)
@@ -139,6 +139,6 @@ verifyIndent verify failMessage =
 
 maybeAroundBothSides : Parser State b -> Parser State b
 maybeAroundBothSides x =
-    maybe layout
+    Combine.maybeIgnore layout
         |> Combine.continueWith x
-        |> Combine.ignore (maybe layout)
+        |> Combine.ignore (Combine.maybeIgnore layout)

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -8,7 +8,7 @@ module Elm.Parser.Layout exposing
     , positivelyIndented
     )
 
-import Combine exposing (Parser, many1Ignore, oneOf, problem, succeed, withLocation, withState)
+import Combine exposing (Parser)
 import Elm.Parser.Comments as Comments
 import Elm.Parser.State as State exposing (State)
 import Elm.Parser.Whitespace exposing (many1Spaces, realNewLine)
@@ -24,12 +24,12 @@ anyComment =
 
 layout : Parser State ()
 layout =
-    many1Ignore
-        (oneOf
+    Combine.many1Ignore
+        (Combine.oneOf
             [ anyComment
-            , many1Ignore realNewLine
+            , Combine.many1Ignore realNewLine
                 |> Combine.continueWith
-                    (oneOf
+                    (Combine.oneOf
                         [ many1Spaces
                         , anyComment
                         ]
@@ -52,14 +52,14 @@ optimisticLayoutWith onStrict onIndented =
 optimisticLayout : Parser State ()
 optimisticLayout =
     Combine.manyIgnore
-        (oneOf
+        (Combine.oneOf
             [ anyComment
             , Combine.many1Ignore realNewLine
                 |> Combine.continueWith
-                    (oneOf
+                    (Combine.oneOf
                         [ many1Spaces
                         , anyComment
-                        , succeed ()
+                        , Combine.succeed ()
                         ]
                     )
             , many1Spaces
@@ -69,13 +69,13 @@ optimisticLayout =
 
 compute : (() -> a) -> (() -> Parser State a) -> Parser State a
 compute onStrict onIndented =
-    withLocation
+    Combine.withLocation
         (\l ->
             if l.column == 1 then
                 Combine.succeed (onStrict ())
 
             else
-                withState
+                Combine.withState
                     (\state ->
                         if List.member l.column (State.storedColumns state) then
                             Combine.succeed (onStrict ())
@@ -88,10 +88,10 @@ compute onStrict onIndented =
 
 layoutStrict : Parser State ()
 layoutStrict =
-    many1Ignore
-        (oneOf
+    Combine.many1Ignore
+        (Combine.oneOf
             [ anyComment
-            , many1Ignore realNewLine
+            , Combine.many1Ignore realNewLine
             , many1Spaces
             ]
         )
@@ -123,9 +123,9 @@ positivelyIndented =
 
 verifyIndent : (Int -> Int -> Bool) -> (Int -> Int -> String) -> Parser State ()
 verifyIndent verify failMessage =
-    withState
+    Combine.withState
         (\state ->
-            withLocation
+            Combine.withLocation
                 (\{ column } ->
                     let
                         expectedColumn : Int
@@ -133,10 +133,10 @@ verifyIndent verify failMessage =
                             State.expectedColumn state
                     in
                     if verify expectedColumn column then
-                        succeed ()
+                        Combine.succeed ()
 
                     else
-                        problem (failMessage expectedColumn column)
+                        Combine.problem (failMessage expectedColumn column)
                 )
         )
 

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -69,16 +69,20 @@ optimisticLayout =
 
 compute : (() -> a) -> (() -> Parser State a) -> Parser State a
 compute onStrict onIndented =
-    withState
-        (\state ->
-            withLocation
-                (\l ->
-                    if l.column == 1 || List.member l.column (State.storedColumns state) then
-                        Combine.succeed (onStrict ())
+    withLocation
+        (\l ->
+            if l.column == 1 then
+                Combine.succeed (onStrict ())
 
-                    else
-                        onIndented ()
-                )
+            else
+                withState
+                    (\state ->
+                        if List.member l.column (State.storedColumns state) then
+                            Combine.succeed (onStrict ())
+
+                        else
+                            onIndented ()
+                    )
         )
 
 

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -43,7 +43,7 @@ layout =
             )
 
 
-optimisticLayoutWith : (() -> Parser State a) -> (() -> Parser State a) -> Parser State a
+optimisticLayoutWith : (() -> a) -> (() -> Parser State a) -> Parser State a
 optimisticLayoutWith onStrict onIndented =
     optimisticLayout
         |> Combine.continueWith (compute onStrict onIndented)
@@ -67,14 +67,14 @@ optimisticLayout =
         )
 
 
-compute : (() -> Parser State a) -> (() -> Parser State a) -> Parser State a
+compute : (() -> a) -> (() -> Parser State a) -> Parser State a
 compute onStrict onIndented =
     withState
         (\state ->
             withLocation
                 (\l ->
                     if l.column == 1 || List.member l.column (State.storedColumns state) then
-                        onStrict ()
+                        Combine.succeed (onStrict ())
 
                     else
                         onIndented ()

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -11,7 +11,8 @@ module Elm.Parser.Layout exposing
 import Combine exposing (Parser)
 import Elm.Parser.Comments as Comments
 import Elm.Parser.State as State exposing (State)
-import Elm.Parser.Whitespace exposing (many1Spaces, realNewLine)
+import Elm.Parser.Whitespace as Whitespace
+import Parser.Extra
 
 
 anyComment : Combine.Parser State ()
@@ -27,14 +28,14 @@ layout =
     Combine.many1Ignore
         (Combine.oneOf
             [ anyComment
-            , Combine.many1Ignore realNewLine
-                |> Combine.continueWith
+            , Parser.Extra.many1Ignore Whitespace.realNewLine
+                |> Combine.ignoreFromCore
                     (Combine.oneOf
-                        [ many1Spaces
+                        [ Whitespace.many1Spaces
                         , anyComment
                         ]
                     )
-            , many1Spaces
+            , Whitespace.many1Spaces
             ]
         )
         |> Combine.continueWith
@@ -54,15 +55,15 @@ optimisticLayout =
     Combine.manyIgnore
         (Combine.oneOf
             [ anyComment
-            , Combine.many1Ignore realNewLine
-                |> Combine.continueWith
+            , Parser.Extra.many1Ignore Whitespace.realNewLine
+                |> Combine.ignoreFromCore
                     (Combine.oneOf
-                        [ many1Spaces
+                        [ Whitespace.many1Spaces
                         , anyComment
                         , Combine.succeed ()
                         ]
                     )
-            , many1Spaces
+            , Whitespace.many1Spaces
             ]
         )
 
@@ -91,8 +92,9 @@ layoutStrict =
     Combine.many1Ignore
         (Combine.oneOf
             [ anyComment
-            , Combine.many1Ignore realNewLine
-            , many1Spaces
+            , Parser.Extra.many1Ignore Whitespace.realNewLine
+                |> Combine.fromCore
+            , Whitespace.many1Spaces
             ]
         )
         |> Combine.continueWith

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Modules exposing (moduleDefinition)
 
-import Combine exposing (Parser, between, oneOf, sepBy1, succeed, symbol)
+import Combine exposing (Parser)
 import Elm.Parser.Base exposing (moduleName)
 import Elm.Parser.Expose exposing (exposeDefinition)
 import Elm.Parser.Layout as Layout
@@ -16,7 +16,7 @@ import List.Extra
 
 moduleDefinition : Parser State Module
 moduleDefinition =
-    oneOf
+    Combine.oneOf
         [ normalModuleDefinition
         , portModuleDefinition
         , effectModuleDefinition
@@ -25,18 +25,18 @@ moduleDefinition =
 
 effectWhereClause : Parser State ( String, Node String )
 effectWhereClause =
-    succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
+    Combine.succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
         |> Combine.keep functionName
-        |> Combine.ignore (Layout.maybeAroundBothSides (symbol "="))
+        |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol "="))
         |> Combine.keep (Node.parserFromCore typeName)
 
 
 whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
 whereBlock =
-    between
-        (symbol "{")
-        (symbol "}")
-        (sepBy1 (symbol ",")
+    Combine.between
+        (Combine.symbol "{")
+        (Combine.symbol "}")
+        (Combine.sepBy1 (Combine.symbol ",")
             (Layout.maybeAroundBothSides effectWhereClause)
         )
         |> Combine.map
@@ -49,7 +49,7 @@ whereBlock =
 
 effectWhereClauses : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
 effectWhereClauses =
-    symbol "where"
+    Combine.symbol "where"
         |> Combine.continueWith Layout.layout
         |> Combine.continueWith whereBlock
 
@@ -66,8 +66,8 @@ effectModuleDefinition =
                 , subscription = whereClauses.subscription
                 }
     in
-    succeed (\name -> \whereClauses -> \exp -> createEffectModule name whereClauses exp)
-        |> Combine.ignore (symbol "effect")
+    Combine.succeed (\name -> \whereClauses -> \exp -> createEffectModule name whereClauses exp)
+        |> Combine.ignore (Combine.symbol "effect")
         |> Combine.ignore Layout.layout
         |> Combine.ignore moduleToken
         |> Combine.ignore Layout.layout
@@ -80,7 +80,7 @@ effectModuleDefinition =
 
 normalModuleDefinition : Parser State Module
 normalModuleDefinition =
-    succeed (\moduleName -> \exposingList -> NormalModule (DefaultModuleData moduleName exposingList))
+    Combine.succeed (\moduleName -> \exposingList -> NormalModule (DefaultModuleData moduleName exposingList))
         |> Combine.ignore moduleToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
@@ -90,7 +90,7 @@ normalModuleDefinition =
 
 portModuleDefinition : Parser State Module
 portModuleDefinition =
-    succeed (\moduleName -> \exposingList -> PortModule (DefaultModuleData moduleName exposingList))
+    Combine.succeed (\moduleName -> \exposingList -> PortModule (DefaultModuleData moduleName exposingList))
         |> Combine.ignore portToken
         |> Combine.ignore Layout.layout
         |> Combine.ignore moduleToken

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -71,7 +71,7 @@ effectModuleDefinition =
         |> Combine.ignore Layout.layout
         |> Combine.ignore moduleToken
         |> Combine.ignore Layout.layout
-        |> Combine.keep (Node.parser moduleName)
+        |> Combine.keep moduleName
         |> Combine.ignore Layout.layout
         |> Combine.keep effectWhereClauses
         |> Combine.ignore Layout.layout
@@ -84,7 +84,7 @@ normalModuleDefinition =
         (succeed (\moduleName -> \exposingList -> DefaultModuleData moduleName exposingList)
             |> Combine.ignore moduleToken
             |> Combine.ignore Layout.layout
-            |> Combine.keep (Node.parser moduleName)
+            |> Combine.keep moduleName
             |> Combine.ignore Layout.layout
             |> Combine.keep (Node.parser exposeDefinition)
         )
@@ -98,7 +98,7 @@ portModuleDefinition =
             |> Combine.ignore Layout.layout
             |> Combine.ignore moduleToken
             |> Combine.ignore Layout.layout
-            |> Combine.keep (Node.parser moduleName)
+            |> Combine.keep moduleName
             |> Combine.ignore Layout.layout
             |> Combine.keep (Node.parser exposeDefinition)
         )

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -27,9 +27,9 @@ moduleDefinition =
 effectWhereClause : Parser State ( String, Node String )
 effectWhereClause =
     Combine.succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
-        |> Combine.keep (Combine.fromCore Tokens.functionName)
+        |> Combine.keepFromCore Tokens.functionName
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol "="))
-        |> Combine.keep (Node.parserFromCore Tokens.typeName)
+        |> Combine.keepFromCore (Node.parserCore Tokens.typeName)
 
 
 whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
@@ -72,7 +72,7 @@ effectModuleDefinition =
         |> Combine.ignore Layout.layout
         |> Combine.ignoreEntirely Tokens.moduleToken
         |> Combine.ignore Layout.layout
-        |> Combine.keep moduleName
+        |> Combine.keepFromCore moduleName
         |> Combine.ignore Layout.layout
         |> Combine.keep effectWhereClauses
         |> Combine.ignore Layout.layout
@@ -84,7 +84,7 @@ normalModuleDefinition =
     Combine.succeed (\moduleName -> \exposingList -> NormalModule (DefaultModuleData moduleName exposingList))
         |> Combine.ignoreEntirely Tokens.moduleToken
         |> Combine.ignore Layout.layout
-        |> Combine.keep moduleName
+        |> Combine.keepFromCore moduleName
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parser exposeDefinition)
 
@@ -96,6 +96,6 @@ portModuleDefinition =
         |> Combine.ignore Layout.layout
         |> Combine.ignoreEntirely Tokens.moduleToken
         |> Combine.ignore Layout.layout
-        |> Combine.keep moduleName
+        |> Combine.keepFromCore moduleName
         |> Combine.ignore Layout.layout
         |> Combine.keep (Node.parser exposeDefinition)

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -6,7 +6,7 @@ import Elm.Parser.Expose exposing (exposeDefinition)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (functionName, moduleToken, portToken, typeName)
+import Elm.Parser.Tokens exposing (functionName, moduleToken, portToken, typeNameCore)
 import Elm.Syntax.Exposing exposing (Exposing)
 import Elm.Syntax.Module exposing (DefaultModuleData, Module(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -28,7 +28,7 @@ effectWhereClause =
     succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
         |> Combine.keep functionName
         |> Combine.ignore (Layout.maybeAroundBothSides (symbol "="))
-        |> Combine.keep (Node.parser typeName)
+        |> Combine.keep (Node.parserFromCore typeNameCore)
 
 
 whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -12,6 +12,7 @@ import Elm.Syntax.Module exposing (DefaultModuleData, Module(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node exposing (Node)
 import List.Extra
+import Parser as Core
 
 
 moduleDefinition : Parser State Module
@@ -67,9 +68,9 @@ effectModuleDefinition =
                 }
     in
     Combine.succeed (\name -> \whereClauses -> \exp -> createEffectModule name whereClauses exp)
-        |> Combine.ignore (Combine.symbol "effect")
+        |> Combine.ignoreEntirely (Core.symbol "effect")
         |> Combine.ignore Layout.layout
-        |> Combine.ignore Tokens.moduleToken
+        |> Combine.ignoreEntirely Tokens.moduleToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.layout
@@ -81,7 +82,7 @@ effectModuleDefinition =
 normalModuleDefinition : Parser State Module
 normalModuleDefinition =
     Combine.succeed (\moduleName -> \exposingList -> NormalModule (DefaultModuleData moduleName exposingList))
-        |> Combine.ignore Tokens.moduleToken
+        |> Combine.ignoreEntirely Tokens.moduleToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.layout
@@ -91,9 +92,9 @@ normalModuleDefinition =
 portModuleDefinition : Parser State Module
 portModuleDefinition =
     Combine.succeed (\moduleName -> \exposingList -> PortModule (DefaultModuleData moduleName exposingList))
-        |> Combine.ignore Tokens.portToken
+        |> Combine.ignoreEntirely Tokens.portToken
         |> Combine.ignore Layout.layout
-        |> Combine.ignore Tokens.moduleToken
+        |> Combine.ignoreEntirely Tokens.moduleToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.layout

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -50,8 +50,8 @@ whereBlock =
 
 effectWhereClauses : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
 effectWhereClauses =
-    Combine.symbol "where"
-        |> Combine.continueWith Layout.layout
+    Core.symbol "where"
+        |> Combine.continueFromCore Layout.layout
         |> Combine.continueWith whereBlock
 
 

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Modules exposing (moduleDefinition)
 
-import Combine exposing (Parser, between, oneOf, sepBy1, string, succeed, symbol)
+import Combine exposing (Parser, between, oneOf, sepBy1, succeed, symbol)
 import Elm.Parser.Base exposing (moduleName)
 import Elm.Parser.Expose exposing (exposeDefinition)
 import Elm.Parser.Layout as Layout
@@ -27,16 +27,16 @@ effectWhereClause : Parser State ( String, Node String )
 effectWhereClause =
     succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
         |> Combine.keep functionName
-        |> Combine.ignore (Layout.maybeAroundBothSides (string "="))
+        |> Combine.ignore (Layout.maybeAroundBothSides (symbol "="))
         |> Combine.keep (Node.parser typeName)
 
 
 whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
 whereBlock =
     between
-        (string "{")
-        (string "}")
-        (sepBy1 (string ",")
+        (symbol "{")
+        (symbol "}")
+        (sepBy1 (symbol ",")
             (Layout.maybeAroundBothSides effectWhereClause)
         )
         |> Combine.map
@@ -67,7 +67,7 @@ effectModuleDefinition =
                 }
     in
     succeed (\name -> \whereClauses -> \exp -> createEffectModule name whereClauses exp)
-        |> Combine.ignore (string "effect")
+        |> Combine.ignore (symbol "effect")
         |> Combine.ignore Layout.layout
         |> Combine.ignore moduleToken
         |> Combine.ignore Layout.layout
@@ -80,25 +80,21 @@ effectModuleDefinition =
 
 normalModuleDefinition : Parser State Module
 normalModuleDefinition =
-    Combine.map NormalModule
-        (succeed (\moduleName -> \exposingList -> DefaultModuleData moduleName exposingList)
-            |> Combine.ignore moduleToken
-            |> Combine.ignore Layout.layout
-            |> Combine.keep moduleName
-            |> Combine.ignore Layout.layout
-            |> Combine.keep (Node.parser exposeDefinition)
-        )
+    succeed (\moduleName -> \exposingList -> NormalModule (DefaultModuleData moduleName exposingList))
+        |> Combine.ignore moduleToken
+        |> Combine.ignore Layout.layout
+        |> Combine.keep moduleName
+        |> Combine.ignore Layout.layout
+        |> Combine.keep (Node.parser exposeDefinition)
 
 
 portModuleDefinition : Parser State Module
 portModuleDefinition =
-    Combine.map PortModule
-        (succeed (\moduleName -> \exposingList -> DefaultModuleData moduleName exposingList)
-            |> Combine.ignore portToken
-            |> Combine.ignore Layout.layout
-            |> Combine.ignore moduleToken
-            |> Combine.ignore Layout.layout
-            |> Combine.keep moduleName
-            |> Combine.ignore Layout.layout
-            |> Combine.keep (Node.parser exposeDefinition)
-        )
+    succeed (\moduleName -> \exposingList -> PortModule (DefaultModuleData moduleName exposingList))
+        |> Combine.ignore portToken
+        |> Combine.ignore Layout.layout
+        |> Combine.ignore moduleToken
+        |> Combine.ignore Layout.layout
+        |> Combine.keep moduleName
+        |> Combine.ignore Layout.layout
+        |> Combine.keep (Node.parser exposeDefinition)

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -6,7 +6,7 @@ import Elm.Parser.Expose exposing (exposeDefinition)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (functionName, moduleToken, portToken, typeName)
+import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.Exposing exposing (Exposing)
 import Elm.Syntax.Module exposing (DefaultModuleData, Module(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -26,9 +26,9 @@ moduleDefinition =
 effectWhereClause : Parser State ( String, Node String )
 effectWhereClause =
     Combine.succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
-        |> Combine.keep functionName
+        |> Combine.keep Tokens.functionName
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol "="))
-        |> Combine.keep (Node.parserFromCore typeName)
+        |> Combine.keep (Node.parserFromCore Tokens.typeName)
 
 
 whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
@@ -69,7 +69,7 @@ effectModuleDefinition =
     Combine.succeed (\name -> \whereClauses -> \exp -> createEffectModule name whereClauses exp)
         |> Combine.ignore (Combine.symbol "effect")
         |> Combine.ignore Layout.layout
-        |> Combine.ignore moduleToken
+        |> Combine.ignore Tokens.moduleToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.layout
@@ -81,7 +81,7 @@ effectModuleDefinition =
 normalModuleDefinition : Parser State Module
 normalModuleDefinition =
     Combine.succeed (\moduleName -> \exposingList -> NormalModule (DefaultModuleData moduleName exposingList))
-        |> Combine.ignore moduleToken
+        |> Combine.ignore Tokens.moduleToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.layout
@@ -91,9 +91,9 @@ normalModuleDefinition =
 portModuleDefinition : Parser State Module
 portModuleDefinition =
     Combine.succeed (\moduleName -> \exposingList -> PortModule (DefaultModuleData moduleName exposingList))
-        |> Combine.ignore portToken
+        |> Combine.ignore Tokens.portToken
         |> Combine.ignore Layout.layout
-        |> Combine.ignore moduleToken
+        |> Combine.ignore Tokens.moduleToken
         |> Combine.ignore Layout.layout
         |> Combine.keep moduleName
         |> Combine.ignore Layout.layout

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -26,7 +26,7 @@ moduleDefinition =
 effectWhereClause : Parser State ( String, Node String )
 effectWhereClause =
     Combine.succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
-        |> Combine.keep Tokens.functionName
+        |> Combine.keep (Combine.fromCore Tokens.functionName)
         |> Combine.ignore (Layout.maybeAroundBothSides (Combine.symbol "="))
         |> Combine.keep (Node.parserFromCore Tokens.typeName)
 

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -36,7 +36,7 @@ whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe 
 whereBlock =
     Combine.between
         (Combine.symbol "{")
-        (Combine.symbol "}")
+        "}"
         (Combine.sepBy1 ","
             (Layout.maybeAroundBothSides effectWhereClause)
         )

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -6,7 +6,7 @@ import Elm.Parser.Expose exposing (exposeDefinition)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (functionName, moduleToken, portToken, typeNameCore)
+import Elm.Parser.Tokens exposing (functionName, moduleToken, portToken, typeName)
 import Elm.Syntax.Exposing exposing (Exposing)
 import Elm.Syntax.Module exposing (DefaultModuleData, Module(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -28,7 +28,7 @@ effectWhereClause =
     succeed (\fnName -> \typeName_ -> ( fnName, typeName_ ))
         |> Combine.keep functionName
         |> Combine.ignore (Layout.maybeAroundBothSides (symbol "="))
-        |> Combine.keep (Node.parserFromCore typeNameCore)
+        |> Combine.keep (Node.parserFromCore typeName)
 
 
 whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -35,7 +35,7 @@ effectWhereClause =
 whereBlock : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
 whereBlock =
     Combine.between
-        (Combine.symbol "{")
+        "{"
         "}"
         (Combine.sepBy1 ","
             (Layout.maybeAroundBothSides effectWhereClause)

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -11,6 +11,7 @@ import Elm.Syntax.Exposing exposing (Exposing)
 import Elm.Syntax.Module exposing (DefaultModuleData, Module(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node exposing (Node)
+import List.Extra
 
 
 moduleDefinition : Parser State Module
@@ -40,8 +41,8 @@ whereBlock =
         )
         |> Combine.map
             (\pairs ->
-                { command = pairs |> List.filter (Tuple.first >> (==) "command") |> List.head |> Maybe.map Tuple.second
-                , subscription = pairs |> List.filter (Tuple.first >> (==) "subscription") |> List.head |> Maybe.map Tuple.second
+                { command = pairs |> List.Extra.find (\( fnName, _ ) -> fnName == "command") |> Maybe.map Tuple.second
+                , subscription = pairs |> List.Extra.find (\( fnName, _ ) -> fnName == "subscription") |> Maybe.map Tuple.second
                 }
             )
 

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -51,7 +51,7 @@ whereBlock =
 effectWhereClauses : Parser State { command : Maybe (Node String), subscription : Maybe (Node String) }
 effectWhereClauses =
     Core.symbol "where"
-        |> Combine.continueFromCore Layout.layout
+        |> Combine.ignoreFromCore Layout.layout
         |> Combine.continueWith whereBlock
 
 

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -37,7 +37,7 @@ whereBlock =
     Combine.between
         (Combine.symbol "{")
         (Combine.symbol "}")
-        (Combine.sepBy1 (Combine.symbol ",")
+        (Combine.sepBy1 ","
             (Layout.maybeAroundBothSides effectWhereClause)
         )
         |> Combine.map

--- a/src/Elm/Parser/Node.elm
+++ b/src/Elm/Parser/Node.elm
@@ -3,14 +3,15 @@ module Elm.Parser.Node exposing (parser, parserCore, parserFromCore)
 import Combine exposing (Parser)
 import Elm.Syntax.Node exposing (Node(..))
 import Parser as Core exposing ((|=))
+import Parser.Extra
 
 
 parser : Parser state a -> Parser state (Node a)
 parser p =
     Combine.succeed (\start -> \v -> \end -> Node { start = start, end = end } v)
-        |> Combine.keepFromCore Combine.location
+        |> Combine.keepFromCore Parser.Extra.location
         |> Combine.keep p
-        |> Combine.keepFromCore Combine.location
+        |> Combine.keepFromCore Parser.Extra.location
 
 
 parserFromCore : Core.Parser a -> Parser state (Node a)
@@ -22,6 +23,6 @@ parserFromCore p =
 parserCore : Core.Parser a -> Core.Parser (Node a)
 parserCore p =
     Core.succeed (\start -> \v -> \end -> Node { start = start, end = end } v)
-        |= Combine.location
+        |= Parser.Extra.location
         |= p
-        |= Combine.location
+        |= Parser.Extra.location

--- a/src/Elm/Parser/Node.elm
+++ b/src/Elm/Parser/Node.elm
@@ -1,4 +1,4 @@
-module Elm.Parser.Node exposing (parser, parserCore)
+module Elm.Parser.Node exposing (parser, parserCore, parserFromCore)
 
 import Combine exposing (Parser)
 import Elm.Syntax.Node exposing (Node(..))
@@ -11,6 +11,12 @@ parser p =
         |> Combine.keep Combine.location
         |> Combine.keep p
         |> Combine.keep Combine.location
+
+
+parserFromCore : Core.Parser a -> Parser state (Node a)
+parserFromCore p =
+    parserCore p
+        |> Combine.fromCore
 
 
 parserCore : Core.Parser a -> Core.Parser (Node a)

--- a/src/Elm/Parser/Node.elm
+++ b/src/Elm/Parser/Node.elm
@@ -8,9 +8,9 @@ import Parser as Core exposing ((|=))
 parser : Parser state a -> Parser state (Node a)
 parser p =
     Combine.succeed (\start -> \v -> \end -> Node { start = start, end = end } v)
-        |> Combine.keep Combine.location
+        |> Combine.keepFromCore Combine.location
         |> Combine.keep p
-        |> Combine.keep Combine.location
+        |> Combine.keepFromCore Combine.location
 
 
 parserFromCore : Core.Parser a -> Parser state (Node a)
@@ -21,7 +21,7 @@ parserFromCore p =
 
 parserCore : Core.Parser a -> Core.Parser (Node a)
 parserCore p =
-    Core.succeed (\( s_row, s_col ) -> \v -> \( e_row, e_col ) -> Node { start = { row = s_row, column = s_col }, end = { row = e_row, column = e_col } } v)
-        |= Core.getPosition
+    Core.succeed (\start -> \v -> \end -> Node { start = start, end = end } v)
+        |= Combine.location
         |= p
-        |= Core.getPosition
+        |= Combine.location

--- a/src/Elm/Parser/Numbers.elm
+++ b/src/Elm/Parser/Numbers.elm
@@ -1,6 +1,5 @@
 module Elm.Parser.Numbers exposing (forgivingNumber, number)
 
-import Combine exposing (Parser)
 import Parser as Core
 
 
@@ -22,7 +21,6 @@ forgivingNumber floatf intf hexf =
     Core.backtrackable (raw (Just floatf) intf hexf)
 
 
-number : (Int -> a) -> (Int -> a) -> Parser state a
+number : (Int -> a) -> (Int -> a) -> Core.Parser a
 number intf hexf =
     raw Nothing intf hexf
-        |> Combine.fromCore

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -60,9 +60,10 @@ variablePart =
         |> Combine.fromCore
 
 
-numberPart : Parser state Pattern
+numberPart : Parser state (Node Pattern)
 numberPart =
     Elm.Parser.Numbers.number IntPattern HexPattern
+        |> Node.parser
 
 
 listPattern : Parser State (Node Pattern)
@@ -89,7 +90,7 @@ composablePattern =
         , recordPattern
         , stringPattern
         , listPattern
-        , Node.parser numberPart
+        , numberPart
         , Node.parser (characterLiteral |> Combine.map CharPattern)
         ]
 
@@ -105,7 +106,7 @@ qualifiedPatternArg =
         , recordPattern
         , stringPattern
         , listPattern
-        , Node.parser numberPart
+        , numberPart
         , Node.parser (characterLiteral |> Combine.map CharPattern)
         ]
 

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -6,7 +6,7 @@ import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.Numbers
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (characterLiteral, functionName, functionNameCore, stringLiteral)
+import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern(..), QualifiedNameRef)
 import Parser as Core exposing ((|.))
@@ -20,7 +20,7 @@ tryToCompose x =
                 [ Combine.succeed (\y -> Node.combine AsPattern x y)
                     |> Combine.ignore (Combine.fromCore (Core.keyword "as"))
                     |> Combine.ignore Layout.layout
-                    |> Combine.keep (Node.parser functionName)
+                    |> Combine.keep (Node.parser Tokens.functionName)
                 , Combine.succeed (\y -> Node.combine UnConsPattern x y)
                     |> Combine.ignore (Combine.fromCore (Core.symbol "::"))
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -56,7 +56,7 @@ parensPattern =
 
 variablePart : Parser state (Node Pattern)
 variablePart =
-    Node.parserCore (Core.map VarPattern functionNameCore)
+    Node.parserCore (Core.map VarPattern Tokens.functionNameCore)
         |> Combine.fromCore
 
 
@@ -68,7 +68,7 @@ numberPart =
 
 charPattern : Parser state (Node Pattern)
 charPattern =
-    characterLiteral
+    Tokens.characterLiteral
         |> Core.map CharPattern
         |> Node.parserCore
         |> Combine.fromCore
@@ -137,7 +137,7 @@ unitPattern =
 
 stringPattern : Parser state (Node Pattern)
 stringPattern =
-    stringLiteral
+    Tokens.stringLiteral
         |> Core.map StringPattern
         |> Node.parserCore
         |> Combine.fromCore
@@ -171,5 +171,5 @@ recordPattern =
             Combine.between
                 (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
                 (Combine.symbol "}")
-                (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore functionNameCore)))
+                (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionNameCore)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -78,7 +78,7 @@ listPattern : Parser State (Node Pattern)
 listPattern =
     Node.parser <|
         Combine.between
-            (Combine.symbol "[")
+            "["
             "]"
             (Combine.maybeIgnore Layout.layout
                 |> Combine.continueWith (Combine.sepBy "," (Layout.maybeAroundBothSides pattern))
@@ -172,7 +172,7 @@ recordPattern =
     Node.parser
         (Combine.map RecordPattern <|
             Combine.between
-                (Combine.symbol "{")
+                "{"
                 "}"
                 (Combine.maybeIgnore Layout.layout
                     |> Combine.continueWith (Combine.sepBy "," (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -18,8 +18,10 @@ tryToCompose x =
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.succeed (\y -> Node.combine AsPattern x y)
-                    |> Combine.ignoreEntirely (Core.keyword "as")
-                    |> Combine.ignore Layout.layout
+                    |> Combine.ignore
+                        (Core.keyword "as"
+                            |> Combine.ignoreFromCore Layout.layout
+                        )
                     |> Combine.keep (Node.parserFromCore Tokens.functionName)
                 , Combine.succeed (\y -> Node.combine UnConsPattern x y)
                     |> Combine.ignoreEntirely (Core.symbol "::")
@@ -149,7 +151,7 @@ stringPattern =
 qualifiedPattern : ConsumeArgs -> Parser State (Node Pattern)
 qualifiedPattern consumeArgs =
     Base.typeIndicator
-        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+        |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen
             (\(Node range ( mod, name )) ->
                 (if consumeArgs then

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -14,7 +14,7 @@ import Parser as Core exposing ((|.))
 
 tryToCompose : Node Pattern -> Parser State (Node Pattern)
 tryToCompose x =
-    Combine.maybe Layout.layout
+    Combine.maybeIgnore Layout.layout
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.succeed (\y -> Node.combine AsPattern x y)

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -41,7 +41,7 @@ pattern =
 parensPattern : Parser State (Node Pattern)
 parensPattern =
     Node.parser
-        (Combine.parens (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern))
+        (Combine.parens (Combine.sepBy "," (Layout.maybeAroundBothSides pattern))
             |> Combine.map
                 (\c ->
                     case c of
@@ -80,7 +80,7 @@ listPattern =
         Combine.between
             (Combine.symbol "[" |> Combine.ignore (Combine.maybeIgnore Layout.layout))
             (Combine.symbol "]")
-            (Combine.map ListPattern (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern)))
+            (Combine.map ListPattern (Combine.sepBy "," (Layout.maybeAroundBothSides pattern)))
 
 
 type alias ConsumeArgs =
@@ -171,5 +171,5 @@ recordPattern =
             Combine.between
                 (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
                 (Combine.symbol "}")
-                (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
+                (Combine.sepBy "," (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -78,9 +78,12 @@ listPattern : Parser State (Node Pattern)
 listPattern =
     Node.parser <|
         Combine.between
-            (Combine.symbol "[" |> Combine.ignore (Combine.maybeIgnore Layout.layout))
+            (Combine.symbol "[")
             "]"
-            (Combine.map ListPattern (Combine.sepBy "," (Layout.maybeAroundBothSides pattern)))
+            (Combine.maybeIgnore Layout.layout
+                |> Combine.continueWith (Combine.sepBy "," (Layout.maybeAroundBothSides pattern))
+                |> Combine.map ListPattern
+            )
 
 
 type alias ConsumeArgs =
@@ -169,7 +172,9 @@ recordPattern =
     Node.parser
         (Combine.map RecordPattern <|
             Combine.between
-                (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
+                (Combine.symbol "{")
                 "}"
-                (Combine.sepBy "," (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
+                (Combine.maybeIgnore Layout.layout
+                    |> Combine.continueWith (Combine.sepBy "," (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
+                )
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -23,7 +23,7 @@ tryToCompose x =
                     |> Combine.keep (Node.parser functionName)
                 , Combine.succeed (\y -> Node.combine UnConsPattern x y)
                     |> Combine.ignore (Combine.fromCore (Core.symbol "::"))
-                    |> Combine.ignore (maybe Layout.layout)
+                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.keep pattern
                 , Combine.succeed x
                 ]
@@ -78,7 +78,7 @@ listPattern : Parser State (Node Pattern)
 listPattern =
     Node.parser <|
         between
-            (string "[" |> Combine.ignore (maybe Layout.layout))
+            (string "[" |> Combine.ignore (Combine.maybeIgnore Layout.layout))
             (string "]")
             (Combine.map ListPattern (sepBy (string ",") (Layout.maybeAroundBothSides pattern)))
 
@@ -146,11 +146,11 @@ stringPattern =
 qualifiedPattern : ConsumeArgs -> Parser State (Node Pattern)
 qualifiedPattern consumeArgs =
     Base.typeIndicator
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.andThen
             (\(Node range ( mod, name )) ->
                 (if consumeArgs then
-                    Combine.manyWithEndLocationForLastElement range Node.range (qualifiedPatternArg |> Combine.ignore (maybe Layout.layout))
+                    Combine.manyWithEndLocationForLastElement range Node.range (qualifiedPatternArg |> Combine.ignore (Combine.maybeIgnore Layout.layout))
 
                  else
                     Combine.succeed ( range.end, [] )
@@ -169,7 +169,7 @@ recordPattern =
     Node.parser
         (Combine.map RecordPattern <|
             between
-                (string "{" |> Combine.continueWith (maybe Layout.layout))
+                (string "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
                 (string "}")
                 (sepBy (string ",") (Layout.maybeAroundBothSides (Node.parser functionName)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -72,8 +72,7 @@ charPattern : Parser state (Node Pattern)
 charPattern =
     Tokens.characterLiteral
         |> Core.map CharPattern
-        |> Node.parserCore
-        |> Combine.fromCore
+        |> Node.parserFromCore
 
 
 listPattern : Parser State (Node Pattern)

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -79,7 +79,7 @@ listPattern =
     Node.parser <|
         Combine.between
             (Combine.symbol "[" |> Combine.ignore (Combine.maybeIgnore Layout.layout))
-            (Combine.symbol "]")
+            "]"
             (Combine.map ListPattern (Combine.sepBy "," (Layout.maybeAroundBothSides pattern)))
 
 
@@ -170,6 +170,6 @@ recordPattern =
         (Combine.map RecordPattern <|
             Combine.between
                 (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
-                (Combine.symbol "}")
+                "}"
                 (Combine.sepBy "," (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Patterns exposing (pattern)
 
-import Combine exposing (Parser, between, maybe, parens, sepBy)
+import Combine exposing (Parser)
 import Elm.Parser.Base as Base
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -14,7 +14,7 @@ import Parser as Core exposing ((|.))
 
 tryToCompose : Node Pattern -> Parser State (Node Pattern)
 tryToCompose x =
-    maybe Layout.layout
+    Combine.maybe Layout.layout
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.succeed (\y -> Node.combine AsPattern x y)
@@ -41,7 +41,7 @@ pattern =
 parensPattern : Parser State (Node Pattern)
 parensPattern =
     Node.parser
-        (parens (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern))
+        (Combine.parens (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern))
             |> Combine.map
                 (\c ->
                     case c of
@@ -77,10 +77,10 @@ charPattern =
 listPattern : Parser State (Node Pattern)
 listPattern =
     Node.parser <|
-        between
+        Combine.between
             (Combine.symbol "[" |> Combine.ignore (Combine.maybeIgnore Layout.layout))
             (Combine.symbol "]")
-            (Combine.map ListPattern (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern)))
+            (Combine.map ListPattern (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern)))
 
 
 type alias ConsumeArgs =
@@ -168,8 +168,8 @@ recordPattern : Parser State (Node Pattern)
 recordPattern =
     Node.parser
         (Combine.map RecordPattern <|
-            between
+            Combine.between
                 (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
                 (Combine.symbol "}")
-                (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore functionNameCore)))
+                (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore functionNameCore)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Patterns exposing (pattern)
 
-import Combine exposing (Parser, between, maybe, parens, sepBy, string)
+import Combine exposing (Parser, between, maybe, parens, sepBy)
 import Elm.Parser.Base as Base
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -41,7 +41,7 @@ pattern =
 parensPattern : Parser State (Node Pattern)
 parensPattern =
     Node.parser
-        (parens (sepBy (string ",") (Layout.maybeAroundBothSides pattern))
+        (parens (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern))
             |> Combine.map
                 (\c ->
                     case c of
@@ -78,9 +78,9 @@ listPattern : Parser State (Node Pattern)
 listPattern =
     Node.parser <|
         between
-            (string "[" |> Combine.ignore (Combine.maybeIgnore Layout.layout))
-            (string "]")
-            (Combine.map ListPattern (sepBy (string ",") (Layout.maybeAroundBothSides pattern)))
+            (Combine.symbol "[" |> Combine.ignore (Combine.maybeIgnore Layout.layout))
+            (Combine.symbol "]")
+            (Combine.map ListPattern (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides pattern)))
 
 
 type alias ConsumeArgs =
@@ -169,7 +169,7 @@ recordPattern =
     Node.parser
         (Combine.map RecordPattern <|
             between
-                (string "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
-                (string "}")
-                (sepBy (string ",") (Layout.maybeAroundBothSides (Node.parser functionName)))
+                (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
+                (Combine.symbol "}")
+                (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parser functionName)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -18,11 +18,11 @@ tryToCompose x =
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.succeed (\y -> Node.combine AsPattern x y)
-                    |> Combine.ignore (Combine.fromCore (Core.keyword "as"))
+                    |> Combine.ignoreEntirely (Core.keyword "as")
                     |> Combine.ignore Layout.layout
                     |> Combine.keep (Node.parserFromCore Tokens.functionName)
                 , Combine.succeed (\y -> Node.combine UnConsPattern x y)
-                    |> Combine.ignore (Combine.fromCore (Core.symbol "::"))
+                    |> Combine.ignoreEntirely (Core.symbol "::")
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.keep pattern
                 , Combine.succeed x

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -22,7 +22,7 @@ tryToCompose x =
                         (Core.keyword "as"
                             |> Combine.ignoreFromCore Layout.layout
                         )
-                    |> Combine.keep (Node.parserFromCore Tokens.functionName)
+                    |> Combine.keepFromCore (Node.parserCore Tokens.functionName)
                 , Combine.succeed (\y -> Node.combine UnConsPattern x y)
                     |> Combine.ignoreEntirely (Core.symbol "::")
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -20,7 +20,7 @@ tryToCompose x =
                 [ Combine.succeed (\y -> Node.combine AsPattern x y)
                     |> Combine.ignore (Combine.fromCore (Core.keyword "as"))
                     |> Combine.ignore Layout.layout
-                    |> Combine.keep (Node.parser Tokens.functionName)
+                    |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
                 , Combine.succeed (\y -> Node.combine UnConsPattern x y)
                     |> Combine.ignore (Combine.fromCore (Core.symbol "::"))
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -63,7 +63,7 @@ variablePart =
 numberPart : Parser state (Node Pattern)
 numberPart =
     Elm.Parser.Numbers.number IntPattern HexPattern
-        |> Node.parser
+        |> Node.parserFromCore
 
 
 charPattern : Parser state (Node Pattern)

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -169,12 +169,11 @@ qualifiedPattern consumeArgs =
 
 recordPattern : Parser State (Node Pattern)
 recordPattern =
-    Node.parser
-        (Combine.map RecordPattern <|
-            Combine.between
-                "{"
-                "}"
-                (Combine.maybeIgnore Layout.layout
-                    |> Combine.continueWith (Combine.sepBy "," (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
-                )
+    Combine.between
+        "{"
+        "}"
+        (Combine.maybeIgnore Layout.layout
+            |> Combine.continueWith (Combine.sepBy "," (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
         )
+        |> Combine.map RecordPattern
+        |> Node.parser

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -171,5 +171,5 @@ recordPattern =
             between
                 (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
                 (Combine.symbol "}")
-                (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parser functionName)))
+                (sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore functionNameCore)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -20,7 +20,7 @@ tryToCompose x =
                 [ Combine.succeed (\y -> Node.combine AsPattern x y)
                     |> Combine.ignore (Combine.fromCore (Core.keyword "as"))
                     |> Combine.ignore Layout.layout
-                    |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
+                    |> Combine.keep (Node.parserFromCore Tokens.functionName)
                 , Combine.succeed (\y -> Node.combine UnConsPattern x y)
                     |> Combine.ignore (Combine.fromCore (Core.symbol "::"))
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -56,7 +56,7 @@ parensPattern =
 
 variablePart : Parser state (Node Pattern)
 variablePart =
-    Node.parserCore (Core.map VarPattern Tokens.functionNameCore)
+    Node.parserCore (Core.map VarPattern Tokens.functionName)
         |> Combine.fromCore
 
 
@@ -171,5 +171,5 @@ recordPattern =
             Combine.between
                 (Combine.symbol "{" |> Combine.continueWith (Combine.maybeIgnore Layout.layout))
                 (Combine.symbol "}")
-                (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionNameCore)))
+                (Combine.sepBy (Combine.symbol ",") (Layout.maybeAroundBothSides (Node.parserFromCore Tokens.functionName)))
         )

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -66,6 +66,14 @@ numberPart =
         |> Node.parser
 
 
+charPattern : Parser state (Node Pattern)
+charPattern =
+    characterLiteral
+        |> Core.map CharPattern
+        |> Node.parserCore
+        |> Combine.fromCore
+
+
 listPattern : Parser State (Node Pattern)
 listPattern =
     Node.parser <|
@@ -91,7 +99,7 @@ composablePattern =
         , stringPattern
         , listPattern
         , numberPart
-        , Node.parser (characterLiteral |> Combine.map CharPattern)
+        , charPattern
         ]
 
 
@@ -107,7 +115,7 @@ qualifiedPatternArg =
         , stringPattern
         , listPattern
         , numberPart
-        , Node.parser (characterLiteral |> Combine.map CharPattern)
+        , charPattern
         ]
 
 

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -205,7 +205,7 @@ type alias MultilineStringLiteralLoopState =
     }
 
 
-multiLineStringLiteral : Parser state String
+multiLineStringLiteral : Core.Parser String
 multiLineStringLiteral =
     let
         helper : MultilineStringLiteralLoopState -> Core.Parser (Step MultilineStringLiteralLoopState String)
@@ -239,7 +239,6 @@ multiLineStringLiteral =
     Core.succeed identity
         |. Core.symbol "\"\"\""
         |= Core.loop { escaped = False, parts = [], counter = 0 } helper
-        |> Combine.fromCore
 
 
 functionName : Parser state String

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -5,7 +5,6 @@ module Elm.Parser.Tokens exposing
     , elseToken
     , exposingToken
     , functionName
-    , functionNameCore
     , ifToken
     , importToken
     , inToken
@@ -240,13 +239,8 @@ multiLineStringLiteral =
         |= Core.loop { escaped = False, parts = [], counter = 0 } helper
 
 
-functionName : Parser state String
+functionName : Core.Parser String
 functionName =
-    Combine.fromCore functionNameCore
-
-
-functionNameCore : Core.Parser String
-functionNameCore =
     Core.variable
         { start = Unicode.isLower
         , inner = \c -> Unicode.isAlphaNum c || c == '_'

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -21,7 +21,7 @@ module Elm.Parser.Tokens exposing
     )
 
 import Char
-import Combine exposing (Parser, symbol)
+import Combine exposing (Parser)
 import Combine.Char exposing (anyChar)
 import Hex
 import Parser as Core exposing ((|.), (|=), Step(..))
@@ -56,17 +56,17 @@ reservedList =
 
 portToken : Parser state ()
 portToken =
-    symbol "port"
+    Combine.symbol "port"
 
 
 moduleToken : Parser state ()
 moduleToken =
-    symbol "module"
+    Combine.symbol "module"
 
 
 exposingToken : Parser state ()
 exposingToken =
-    symbol "exposing"
+    Combine.symbol "exposing"
 
 
 importToken : Parser state ()
@@ -81,37 +81,37 @@ asToken =
 
 ifToken : Parser state ()
 ifToken =
-    symbol "if"
+    Combine.symbol "if"
 
 
 thenToken : Parser state ()
 thenToken =
-    symbol "then"
+    Combine.symbol "then"
 
 
 elseToken : Parser state ()
 elseToken =
-    symbol "else"
+    Combine.symbol "else"
 
 
 caseToken : Parser state ()
 caseToken =
-    symbol "case"
+    Combine.symbol "case"
 
 
 ofToken : Parser state ()
 ofToken =
-    symbol "of"
+    Combine.symbol "of"
 
 
 letToken : Parser state ()
 letToken =
-    symbol "let"
+    Combine.symbol "let"
 
 
 inToken : Parser state ()
 inToken =
-    symbol "in"
+    Combine.symbol "in"
 
 
 escapedCharValue : Core.Parser Char

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -18,7 +18,6 @@ module Elm.Parser.Tokens exposing
     , stringLiteral
     , thenToken
     , typeName
-    , typeNameCore
     )
 
 import Char
@@ -255,13 +254,8 @@ functionNameCore =
         }
 
 
-typeName : Parser state String
+typeName : Core.Parser String
 typeName =
-    Combine.fromCore typeNameCore
-
-
-typeNameCore : Core.Parser String
-typeNameCore =
     Core.variable
         { start = Unicode.isUpper
         , inner = \c -> Unicode.isAlphaNum c || c == '_'

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -20,9 +20,9 @@ module Elm.Parser.Tokens exposing
     )
 
 import Char
-import Combine.Char exposing (anyChar)
 import Hex
 import Parser as Core exposing ((|.), (|=), Step(..))
+import Parser.Extra
 import Set exposing (Set)
 import Unicode
 
@@ -158,7 +158,7 @@ characterLiteral =
         [ quotedSingleQuote
         , Core.succeed identity
             |. Core.symbol "'"
-            |= anyChar
+            |= Parser.Extra.anyChar
             |. Core.symbol "'"
         ]
 

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -20,7 +20,6 @@ module Elm.Parser.Tokens exposing
     )
 
 import Char
-import Combine exposing (Parser)
 import Combine.Char exposing (anyChar)
 import Hex
 import Parser as Core exposing ((|.), (|=), Step(..))
@@ -54,64 +53,64 @@ reservedList =
         |> Set.fromList
 
 
-portToken : Parser state ()
+portToken : Core.Parser ()
 portToken =
-    Combine.symbol "port"
+    Core.symbol "port"
 
 
-moduleToken : Parser state ()
+moduleToken : Core.Parser ()
 moduleToken =
-    Combine.symbol "module"
+    Core.symbol "module"
 
 
-exposingToken : Parser state ()
+exposingToken : Core.Parser ()
 exposingToken =
-    Combine.symbol "exposing"
+    Core.symbol "exposing"
 
 
-importToken : Parser state ()
+importToken : Core.Parser ()
 importToken =
-    Combine.fromCore (Core.keyword "import")
+    Core.keyword "import"
 
 
-asToken : Parser state ()
+asToken : Core.Parser ()
 asToken =
-    Combine.fromCore (Core.keyword "as")
+    Core.keyword "as"
 
 
-ifToken : Parser state ()
+ifToken : Core.Parser ()
 ifToken =
-    Combine.symbol "if"
+    Core.symbol "if"
 
 
-thenToken : Parser state ()
+thenToken : Core.Parser ()
 thenToken =
-    Combine.symbol "then"
+    Core.symbol "then"
 
 
-elseToken : Parser state ()
+elseToken : Core.Parser ()
 elseToken =
-    Combine.symbol "else"
+    Core.symbol "else"
 
 
-caseToken : Parser state ()
+caseToken : Core.Parser ()
 caseToken =
-    Combine.symbol "case"
+    Core.symbol "case"
 
 
-ofToken : Parser state ()
+ofToken : Core.Parser ()
 ofToken =
-    Combine.symbol "of"
+    Core.symbol "of"
 
 
-letToken : Parser state ()
+letToken : Core.Parser ()
 letToken =
-    Combine.symbol "let"
+    Core.symbol "let"
 
 
-inToken : Parser state ()
+inToken : Core.Parser ()
 inToken =
-    Combine.symbol "in"
+    Core.symbol "in"
 
 
 escapedCharValue : Core.Parser Char

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -24,11 +24,11 @@ import Combine exposing (Parser)
 import Combine.Char exposing (anyChar)
 import Hex
 import Parser as Core exposing ((|.), (|=), Step(..))
-import Set
+import Set exposing (Set)
 import Unicode
 
 
-reservedList : List String
+reservedList : Set String
 reservedList =
     [ "module"
     , "exposing"
@@ -51,6 +51,7 @@ reservedList =
     --, "alias" Apparently this is not a reserved keyword
     , "where"
     ]
+        |> Set.fromList
 
 
 portToken : Parser state ()
@@ -244,7 +245,7 @@ functionName =
     Core.variable
         { start = Unicode.isLower
         , inner = \c -> Unicode.isAlphaNum c || c == '_'
-        , reserved = Set.fromList reservedList
+        , reserved = reservedList
         }
 
 
@@ -253,7 +254,7 @@ typeName =
     Core.variable
         { start = Unicode.isUpper
         , inner = \c -> Unicode.isAlphaNum c || c == '_'
-        , reserved = Set.fromList reservedList
+        , reserved = reservedList
         }
 
 

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -23,7 +23,7 @@ module Elm.Parser.Tokens exposing
 
 import Char
 import Combine exposing (Parser, symbol)
-import Combine.Char exposing (anyChar, char)
+import Combine.Char exposing (anyChar)
 import Hex
 import Parser as Core exposing ((|.), (|=), Step(..))
 import Set
@@ -133,7 +133,7 @@ escapedCharValue =
         ]
 
 
-quotedSingleQuote : Parser s Char
+quotedSingleQuote : Core.Parser Char
 quotedSingleQuote =
     Core.succeed (String.toList >> List.head >> Maybe.withDefault ' ')
         |. Core.symbol "'"
@@ -144,16 +144,16 @@ quotedSingleQuote =
             , Core.getChompedString (Core.chompIf (always True))
             ]
         |. Core.symbol "'"
-        |> Combine.fromCore
 
 
-characterLiteral : Parser s Char
+characterLiteral : Core.Parser Char
 characterLiteral =
-    Combine.oneOf
+    Core.oneOf
         [ quotedSingleQuote
-        , char '\''
-            |> Combine.continueWith anyChar
-            |> Combine.ignore (char '\'')
+        , Core.succeed identity
+            |. Core.symbol "'"
+            |= anyChar
+            |. Core.symbol "'"
         ]
 
 

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -124,7 +124,15 @@ escapedCharValue =
         , -- Eventhough Elm-format will change \r to a unicode version. When you dont use elm-format, this will not happen.
           Core.succeed '\u{000D}' |. Core.symbol "r"
         , Core.succeed '\\' |. Core.symbol "\\"
-        , Core.succeed (String.toLower >> Hex.fromString >> Result.withDefault 0 >> Char.fromCode)
+        , Core.succeed
+            (\hex ->
+                case String.toLower hex |> Hex.fromString of
+                    Ok n ->
+                        Char.fromCode n
+
+                    Err _ ->
+                        '\u{0000}'
+            )
             |. Core.symbol "u"
             |. Core.symbol "{"
             |= (Core.chompWhile Char.isHexDigit |> Core.getChompedString)

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -228,7 +228,7 @@ multiLineStringLiteral =
                     [ Core.symbol "\"\"\""
                         |> Core.map (\_ -> Done (String.concat (List.reverse s.parts)))
                     , Core.symbol "\""
-                        |> Core.mapChompedString (\v _ -> Loop { counter = s.counter + 1, escaped = s.escaped, parts = v :: s.parts })
+                        |> Core.mapChompedString (\v () -> Loop { counter = s.counter + 1, escaped = s.escaped, parts = v :: s.parts })
                     , Core.symbol "\\"
                         |> Core.map (\_ -> Loop { counter = s.counter + 1, escaped = True, parts = s.parts })
                     , Core.succeed

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -128,7 +128,7 @@ recordTypeAnnotation =
                                     |> Combine.ignore (Combine.symbol "|")
                                     |> Combine.keep (Node.parser recordFieldsTypeAnnotation)
                                     |> Combine.ignore (Combine.symbol "}")
-                                , Combine.succeed (\ta rest -> TypeAnnotation.Record <| Node.combine Tuple.pair fname ta :: rest)
+                                , Combine.succeed (\ta -> \rest -> TypeAnnotation.Record <| Node.combine Tuple.pair fname ta :: rest)
                                     |> Combine.ignore (Combine.symbol ":")
                                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                     |> Combine.keep typeAnnotation
@@ -152,7 +152,7 @@ recordTypeAnnotation =
 
 recordFieldDefinition : Parser State TypeAnnotation.RecordField
 recordFieldDefinition =
-    succeed Tuple.pair
+    Combine.succeed (\functionName -> \value -> ( functionName, value ))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep (Node.parserFromCore functionNameCore)
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -27,8 +27,8 @@ typeAnnotation =
                     (\() -> typeRef)
                     (\() ->
                         Combine.oneOf
-                            [ Combine.symbol "->"
-                                |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+                            [ Core.symbol "->"
+                                |> Combine.continueFromCore (Combine.maybeIgnore Layout.layout)
                                 |> Combine.continueWith typeAnnotation
                                 |> Combine.map (\ta -> Node.combine TypeAnnotation.FunctionTypeAnnotation typeRef ta)
                             , Combine.succeed typeRef
@@ -66,8 +66,8 @@ parensTypeAnnotation =
         commaSep : Parser State (List (Node TypeAnnotation))
         commaSep =
             Combine.many
-                (Combine.symbol ","
-                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+                (Core.symbol ","
+                    |> Combine.continueFromCore (Combine.maybeIgnore Layout.layout)
                     |> Combine.continueWith typeAnnotation
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                 )
@@ -80,10 +80,12 @@ parensTypeAnnotation =
                 |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                 |> Combine.keep commaSep
     in
-    Combine.symbol "("
-        |> Combine.continueWith
+    Core.symbol "("
+        |> Combine.continueFromCore
             (Combine.oneOf
-                [ Combine.symbol ")" |> Combine.map (always TypeAnnotation.Unit)
+                [ Core.symbol ")"
+                    |> Core.map (always TypeAnnotation.Unit)
+                    |> Combine.fromCore
                 , nested |> Combine.ignoreEntirely (Core.symbol ")")
                 ]
             )
@@ -114,8 +116,8 @@ recordFieldsTypeAnnotation =
 
 recordTypeAnnotation : Parser State (Node TypeAnnotation)
 recordTypeAnnotation =
-    Combine.symbol "{"
-        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+    Core.symbol "{"
+        |> Combine.continueFromCore (Combine.maybeIgnore Layout.layout)
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.succeed (TypeAnnotation.Record [])
@@ -137,8 +139,8 @@ recordTypeAnnotation =
                                     |> Combine.keep
                                         (Combine.oneOf
                                             [ -- Skip a comma and then look for at least 1 more field
-                                              Combine.symbol ","
-                                                |> Combine.continueWith recordFieldsTypeAnnotation
+                                              Core.symbol ","
+                                                |> Combine.continueFromCore recordFieldsTypeAnnotation
                                             , -- Single field record, so just end with no additional fields
                                               Combine.succeed []
                                             ]

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -24,7 +24,7 @@ typeAnnotation =
         |> Combine.andThen
             (\typeRef ->
                 Layout.optimisticLayoutWith
-                    (\() -> succeed typeRef)
+                    (\() -> typeRef)
                     (\() ->
                         Combine.oneOf
                             [ string "->"
@@ -167,7 +167,7 @@ typedTypeAnnotation mode =
         |> Combine.andThen
             (\((Node tir _) as original) ->
                 Layout.optimisticLayoutWith
-                    (\() -> Combine.succeed (Node tir (TypeAnnotation.Typed original [])))
+                    (\() -> Node tir (TypeAnnotation.Typed original []))
                     (\() ->
                         case mode of
                             Eager ->
@@ -189,7 +189,7 @@ eagerTypedTypeAnnotation ((Node range _) as original) =
                     |> Combine.andThen
                         (\next ->
                             Layout.optimisticLayoutWith
-                                (\() -> Combine.succeed (next :: items))
+                                (\() -> next :: items)
                                 (\() -> genericHelper (next :: items))
                                 |> Combine.ignore (maybe Layout.layout)
                         )

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -84,7 +84,7 @@ parensTypeAnnotation =
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.symbol ")" |> Combine.map (always TypeAnnotation.Unit)
-                , nested |> Combine.ignore (Combine.symbol ")")
+                , nested |> Combine.ignoreEntirely (Core.symbol ")")
                 ]
             )
         |> Node.parser
@@ -119,18 +119,18 @@ recordTypeAnnotation =
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.succeed (TypeAnnotation.Record [])
-                    |> Combine.ignore (Combine.symbol "}")
+                    |> Combine.ignoreEntirely (Core.symbol "}")
                 , Node.parserFromCore Tokens.functionName
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.andThen
                         (\fname ->
                             Combine.oneOf
                                 [ Combine.succeed (TypeAnnotation.GenericRecord fname)
-                                    |> Combine.ignore (Combine.symbol "|")
+                                    |> Combine.ignoreEntirely (Core.symbol "|")
                                     |> Combine.keep (Node.parser recordFieldsTypeAnnotation)
-                                    |> Combine.ignore (Combine.symbol "}")
+                                    |> Combine.ignoreEntirely (Core.symbol "}")
                                 , Combine.succeed (\ta -> \rest -> TypeAnnotation.Record <| Node.combine Tuple.pair fname ta :: rest)
-                                    |> Combine.ignore (Combine.symbol ":")
+                                    |> Combine.ignoreEntirely (Core.symbol ":")
                                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                     |> Combine.keep typeAnnotation
                                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -143,7 +143,7 @@ recordTypeAnnotation =
                                               Combine.succeed []
                                             ]
                                         )
-                                    |> Combine.ignore (Combine.symbol "}")
+                                    |> Combine.ignoreEntirely (Core.symbol "}")
                                 ]
                         )
                 ]
@@ -157,7 +157,7 @@ recordFieldDefinition =
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep (Node.parserFromCore Tokens.functionName)
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.ignore (Combine.symbol ":")
+        |> Combine.ignoreEntirely (Core.symbol ":")
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
 

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -154,7 +154,7 @@ recordFieldDefinition : Parser State TypeAnnotation.RecordField
 recordFieldDefinition =
     succeed Tuple.pair
         |> Combine.ignore (maybe Layout.layout)
-        |> Combine.keep (Node.parser functionName)
+        |> Combine.keep (Node.parserFromCore functionNameCore)
         |> Combine.ignore (maybe Layout.layout)
         |> Combine.ignore (string ":")
         |> Combine.ignore (maybe Layout.layout)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -157,7 +157,7 @@ recordFieldDefinition : Parser State TypeAnnotation.RecordField
 recordFieldDefinition =
     Combine.succeed (\functionName -> \value -> ( functionName, value ))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.keep (Node.parserFromCore Tokens.functionName)
+        |> Combine.keepFromCore (Node.parserCore Tokens.functionName)
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.ignoreEntirely (Core.symbol ":")
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -122,8 +122,8 @@ recordTypeAnnotation =
             (Combine.oneOf
                 [ Combine.succeed (TypeAnnotation.Record [])
                     |> Combine.ignoreEntirely (Core.symbol "}")
-                , Node.parserFromCore Tokens.functionName
-                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+                , Node.parserCore Tokens.functionName
+                    |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
                     |> Combine.andThen
                         (\fname ->
                             Combine.oneOf
@@ -167,6 +167,7 @@ recordFieldDefinition =
 typedTypeAnnotation : Mode -> Parser State (Node TypeAnnotation)
 typedTypeAnnotation mode =
     typeIndicator
+        |> Combine.fromCore
         |> Combine.andThen
             (\((Node tir _) as original) ->
                 Layout.optimisticLayoutWith

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -5,7 +5,7 @@ import Elm.Parser.Base exposing (typeIndicator)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (functionName, functionNameCore)
+import Elm.Parser.Tokens as Tokens
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range exposing (Range)
@@ -102,8 +102,9 @@ asTypeAnnotation ((Node _ value) as x) xs =
 
 genericTypeAnnotation : Parser state (Node TypeAnnotation)
 genericTypeAnnotation =
-    Node.parserCore (Core.map TypeAnnotation.GenericType functionNameCore)
-        |> Combine.fromCore
+    Tokens.functionNameCore
+        |> Core.map TypeAnnotation.GenericType
+        |> Node.parserFromCore
 
 
 recordFieldsTypeAnnotation : Parser State TypeAnnotation.RecordDefinition
@@ -119,7 +120,7 @@ recordTypeAnnotation =
             (Combine.oneOf
                 [ Combine.succeed (TypeAnnotation.Record [])
                     |> Combine.ignore (Combine.symbol "}")
-                , Node.parser functionName
+                , Node.parserFromCore Tokens.functionNameCore
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.andThen
                         (\fname ->
@@ -154,7 +155,7 @@ recordFieldDefinition : Parser State TypeAnnotation.RecordField
 recordFieldDefinition =
     Combine.succeed (\functionName -> \value -> ( functionName, value ))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.keep (Node.parserFromCore functionNameCore)
+        |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.ignore (Combine.symbol ":")
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.TypeAnnotation exposing (typeAnnotation, typeAnnotationNonGreedy)
 
-import Combine exposing (..)
+import Combine exposing (Parser)
 import Elm.Parser.Base exposing (typeIndicator)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
@@ -31,7 +31,7 @@ typeAnnotation =
                                 |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                 |> Combine.continueWith typeAnnotation
                                 |> Combine.map (\ta -> Node.combine TypeAnnotation.FunctionTypeAnnotation typeRef ta)
-                            , succeed typeRef
+                            , Combine.succeed typeRef
                             ]
                     )
             )
@@ -39,7 +39,7 @@ typeAnnotation =
 
 typeAnnotationNonGreedy : Parser State (Node TypeAnnotation)
 typeAnnotationNonGreedy =
-    oneOf
+    Combine.oneOf
         [ parensTypeAnnotation
         , typedTypeAnnotation Lazy
         , genericTypeAnnotation
@@ -49,9 +49,9 @@ typeAnnotationNonGreedy =
 
 typeAnnotationNoFn : Mode -> Parser State (Node TypeAnnotation)
 typeAnnotationNoFn mode =
-    lazy
+    Combine.lazy
         (\() ->
-            oneOf
+            Combine.oneOf
                 [ parensTypeAnnotation
                 , typedTypeAnnotation mode
                 , genericTypeAnnotation
@@ -65,7 +65,7 @@ parensTypeAnnotation =
     let
         commaSep : Parser State (List (Node TypeAnnotation))
         commaSep =
-            many
+            Combine.many
                 (Combine.symbol ","
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.continueWith typeAnnotation
@@ -108,7 +108,7 @@ genericTypeAnnotation =
 
 recordFieldsTypeAnnotation : Parser State TypeAnnotation.RecordDefinition
 recordFieldsTypeAnnotation =
-    sepBy1 (Combine.symbol ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition)
+    Combine.sepBy1 (Combine.symbol ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition)
 
 
 recordTypeAnnotation : Parser State (Node TypeAnnotation)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -27,7 +27,7 @@ typeAnnotation =
                     (\() -> typeRef)
                     (\() ->
                         Combine.oneOf
-                            [ string "->"
+                            [ Combine.symbol "->"
                                 |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                 |> Combine.continueWith typeAnnotation
                                 |> Combine.map (\ta -> Node.combine TypeAnnotation.FunctionTypeAnnotation typeRef ta)
@@ -108,12 +108,12 @@ genericTypeAnnotation =
 
 recordFieldsTypeAnnotation : Parser State TypeAnnotation.RecordDefinition
 recordFieldsTypeAnnotation =
-    sepBy1 (string ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition)
+    sepBy1 (Combine.symbol ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition)
 
 
 recordTypeAnnotation : Parser State (Node TypeAnnotation)
 recordTypeAnnotation =
-    string "{"
+    Combine.symbol "{"
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.continueWith
             (Combine.oneOf
@@ -136,7 +136,7 @@ recordTypeAnnotation =
                                     |> Combine.keep
                                         (Combine.oneOf
                                             [ -- Skip a comma and then look for at least 1 more field
-                                              string ","
+                                              Combine.symbol ","
                                                 |> Combine.continueWith recordFieldsTypeAnnotation
                                             , -- Single field record, so just end with no additional fields
                                               Combine.succeed []
@@ -156,7 +156,7 @@ recordFieldDefinition =
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep (Node.parserFromCore functionNameCore)
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.ignore (string ":")
+        |> Combine.ignore (Combine.symbol ":")
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
 

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -28,7 +28,7 @@ typeAnnotation =
                     (\() ->
                         Combine.oneOf
                             [ string "->"
-                                |> Combine.ignore (maybe Layout.layout)
+                                |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                 |> Combine.continueWith typeAnnotation
                                 |> Combine.map (\ta -> Node.combine TypeAnnotation.FunctionTypeAnnotation typeRef ta)
                             , succeed typeRef
@@ -67,17 +67,17 @@ parensTypeAnnotation =
         commaSep =
             many
                 (Combine.symbol ","
-                    |> Combine.ignore (maybe Layout.layout)
+                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.continueWith typeAnnotation
-                    |> Combine.ignore (maybe Layout.layout)
+                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                 )
 
         nested : Parser State TypeAnnotation
         nested =
             Combine.succeed (\x -> \xs -> asTypeAnnotation x xs)
-                |> Combine.ignore (maybe Layout.layout)
+                |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                 |> Combine.keep typeAnnotation
-                |> Combine.ignore (maybe Layout.layout)
+                |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                 |> Combine.keep commaSep
     in
     Combine.symbol "("
@@ -114,13 +114,13 @@ recordFieldsTypeAnnotation =
 recordTypeAnnotation : Parser State (Node TypeAnnotation)
 recordTypeAnnotation =
     string "{"
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.continueWith
             (Combine.oneOf
                 [ Combine.succeed (TypeAnnotation.Record [])
                     |> Combine.ignore (Combine.symbol "}")
                 , Node.parser functionName
-                    |> Combine.ignore (maybe Layout.layout)
+                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.andThen
                         (\fname ->
                             Combine.oneOf
@@ -130,9 +130,9 @@ recordTypeAnnotation =
                                     |> Combine.ignore (Combine.symbol "}")
                                 , Combine.succeed (\ta rest -> TypeAnnotation.Record <| Node.combine Tuple.pair fname ta :: rest)
                                     |> Combine.ignore (Combine.symbol ":")
-                                    |> Combine.ignore (maybe Layout.layout)
+                                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                     |> Combine.keep typeAnnotation
-                                    |> Combine.ignore (maybe Layout.layout)
+                                    |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                                     |> Combine.keep
                                         (Combine.oneOf
                                             [ -- Skip a comma and then look for at least 1 more field
@@ -153,11 +153,11 @@ recordTypeAnnotation =
 recordFieldDefinition : Parser State TypeAnnotation.RecordField
 recordFieldDefinition =
     succeed Tuple.pair
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep (Node.parserFromCore functionNameCore)
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.ignore (string ":")
-        |> Combine.ignore (maybe Layout.layout)
+        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.keep typeAnnotation
 
 
@@ -191,7 +191,7 @@ eagerTypedTypeAnnotation ((Node range _) as original) =
                             Layout.optimisticLayoutWith
                                 (\() -> next :: items)
                                 (\() -> genericHelper (next :: items))
-                                |> Combine.ignore (maybe Layout.layout)
+                                |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         )
                 , Combine.succeed items
                 ]

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -102,7 +102,7 @@ asTypeAnnotation ((Node _ value) as x) xs =
 
 genericTypeAnnotation : Parser state (Node TypeAnnotation)
 genericTypeAnnotation =
-    Tokens.functionNameCore
+    Tokens.functionName
         |> Core.map TypeAnnotation.GenericType
         |> Node.parserFromCore
 
@@ -120,7 +120,7 @@ recordTypeAnnotation =
             (Combine.oneOf
                 [ Combine.succeed (TypeAnnotation.Record [])
                     |> Combine.ignore (Combine.symbol "}")
-                , Node.parserFromCore Tokens.functionNameCore
+                , Node.parserFromCore Tokens.functionName
                     |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                     |> Combine.andThen
                         (\fname ->
@@ -155,7 +155,7 @@ recordFieldDefinition : Parser State TypeAnnotation.RecordField
 recordFieldDefinition =
     Combine.succeed (\functionName -> \value -> ( functionName, value ))
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-        |> Combine.keep (Node.parserFromCore Tokens.functionNameCore)
+        |> Combine.keep (Node.parserFromCore Tokens.functionName)
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
         |> Combine.ignore (Combine.symbol ":")
         |> Combine.ignore (Combine.maybeIgnore Layout.layout)

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -109,7 +109,7 @@ genericTypeAnnotation =
 
 recordFieldsTypeAnnotation : Parser State TypeAnnotation.RecordDefinition
 recordFieldsTypeAnnotation =
-    Combine.sepBy1 (Combine.symbol ",") (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition)
+    Combine.sepBy1 "," (Layout.maybeAroundBothSides <| Node.parser recordFieldDefinition)
 
 
 recordTypeAnnotation : Parser State (Node TypeAnnotation)

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -13,6 +13,7 @@ import Elm.Syntax.Range exposing (Location, Range)
 import Elm.Syntax.Type exposing (ValueConstructor)
 import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
 import Parser as Core
+import Parser.Extra
 
 
 typeDefinition : Maybe (Node Documentation) -> Parser State (Node Declaration.Declaration)
@@ -25,7 +26,7 @@ typeDefinition maybeDoc =
                     Core.succeed start
 
                 Nothing ->
-                    Combine.location
+                    Parser.Extra.location
     in
     startParser
         |> Combine.ignoreFromCore typePrefix

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -16,8 +16,17 @@ import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
 
 typeDefinition : Maybe (Node Documentation) -> Parser State (Node Declaration.Declaration)
 typeDefinition maybeDoc =
-    Combine.succeed identity
-        |> Combine.keep Combine.location
+    let
+        startParser : Parser state Location
+        startParser =
+            case maybeDoc of
+                Just (Node { start } _) ->
+                    Combine.succeed start
+
+                Nothing ->
+                    Combine.location
+    in
+    startParser
         |> Combine.ignore typePrefix
         |> Combine.andThen
             (\start ->
@@ -27,7 +36,7 @@ typeDefinition maybeDoc =
                             \generics ->
                                 \((Node { end } _) as typeAnnotation) ->
                                     Node
-                                        { start = maybeDoc |> Maybe.map (Node.range >> .start) |> Maybe.withDefault start
+                                        { start = start
                                         , end = end
                                         }
                                         (Declaration.AliasDeclaration
@@ -61,7 +70,7 @@ typeDefinition maybeDoc =
                                                     start
                                     in
                                     Node
-                                        { start = maybeDoc |> Maybe.map (Node.range >> .start) |> Maybe.withDefault start
+                                        { start = start
                                         , end = end
                                         }
                                         (Declaration.CustomTypeDeclaration

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -141,10 +141,13 @@ valueConstructor =
 
 genericList : Parser State (List (Node String))
 genericList =
-    Combine.many (Node.parserFromCore Tokens.functionName |> Combine.ignore (Combine.maybeIgnore Layout.layout))
+    Combine.many
+        (Node.parserCore Tokens.functionName
+            |> Combine.ignoreFromCore (Combine.maybeIgnore Layout.layout)
+        )
 
 
 typePrefix : Parser State ()
 typePrefix =
     Core.symbol "type"
-        |> Combine.continueFromCore Layout.layout
+        |> Combine.ignoreFromCore Layout.layout

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -4,7 +4,7 @@ import Combine exposing (Parser)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (functionNameCore, typeName)
+import Elm.Parser.Tokens as Tokens
 import Elm.Parser.TypeAnnotation exposing (typeAnnotation, typeAnnotationNonGreedy)
 import Elm.Syntax.Declaration as Declaration
 import Elm.Syntax.Documentation exposing (Documentation)
@@ -49,7 +49,7 @@ typeDefinition maybeDoc =
                         )
                         |> Combine.ignore (Combine.symbol "alias")
                         |> Combine.ignore Layout.layout
-                        |> Combine.keep (Node.parserFromCore typeName)
+                        |> Combine.keep (Node.parserFromCore Tokens.typeName)
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (Combine.symbol "=")
@@ -81,7 +81,7 @@ typeDefinition maybeDoc =
                                             }
                                         )
                         )
-                        |> Combine.keep (Node.parserFromCore typeName)
+                        |> Combine.keep (Node.parserFromCore Tokens.typeName)
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
@@ -101,7 +101,7 @@ valueConstructors =
 
 valueConstructor : Parser State (Node ValueConstructor)
 valueConstructor =
-    Node.parserFromCore typeName
+    Node.parserFromCore Tokens.typeName
         |> Combine.andThen
             (\((Node range _) as tnn) ->
                 let
@@ -138,7 +138,7 @@ valueConstructor =
 
 genericList : Parser State (List (Node String))
 genericList =
-    Combine.many (Node.parserFromCore functionNameCore |> Combine.ignore (Combine.maybeIgnore Layout.layout))
+    Combine.many (Node.parserFromCore Tokens.functionNameCore |> Combine.ignore (Combine.maybeIgnore Layout.layout))
 
 
 typePrefix : Parser State ()

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -96,7 +96,9 @@ typeDefinition maybeDoc =
 valueConstructors : Parser State (List (Node ValueConstructor))
 valueConstructors =
     Combine.sepBy1WithoutReverse
-        (Combine.ignore (Combine.maybeIgnore Layout.layout) (Combine.symbol "|"))
+        (Combine.symbol "|"
+            |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+        )
         valueConstructor
 
 

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -4,7 +4,7 @@ import Combine exposing (Parser, many, maybe, string)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (functionName, typeName)
+import Elm.Parser.Tokens exposing (functionNameCore, typeNameCore)
 import Elm.Parser.TypeAnnotation exposing (typeAnnotation, typeAnnotationNonGreedy)
 import Elm.Syntax.Declaration as Declaration
 import Elm.Syntax.Documentation exposing (Documentation)
@@ -38,7 +38,7 @@ typeDefinition maybeDoc =
                         )
                         |> Combine.ignore (string "alias")
                         |> Combine.ignore Layout.layout
-                        |> Combine.keep (Node.parser typeName)
+                        |> Combine.keep (Node.parserFromCore typeNameCore)
                         |> Combine.ignore (maybe Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (string "=")
@@ -70,7 +70,7 @@ typeDefinition maybeDoc =
                                             }
                                         )
                         )
-                        |> Combine.keep (Node.parser typeName)
+                        |> Combine.keep (Node.parserFromCore typeNameCore)
                         |> Combine.ignore (maybe Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (maybe Layout.layout)
@@ -90,7 +90,7 @@ valueConstructors =
 
 valueConstructor : Parser State (Node ValueConstructor)
 valueConstructor =
-    Node.parser typeName
+    Node.parserFromCore typeNameCore
         |> Combine.andThen
             (\((Node range _) as tnn) ->
                 let
@@ -129,7 +129,7 @@ valueConstructor =
 
 genericList : Parser State (List (Node String))
 genericList =
-    many (Node.parser functionName |> Combine.ignore (maybe Layout.layout))
+    many (Node.parserFromCore functionNameCore |> Combine.ignore (maybe Layout.layout))
 
 
 typePrefix : Parser State (Node String)

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -123,7 +123,7 @@ valueConstructor =
                                 |> Combine.andThen
                                     (\ta ->
                                         Layout.optimisticLayoutWith
-                                            (\() -> Combine.succeed (complete (ta :: xs)))
+                                            (\() -> complete (ta :: xs))
                                             (\() -> argHelper (ta :: xs))
                                     )
                             , Combine.succeed xs
@@ -131,7 +131,7 @@ valueConstructor =
                             ]
                 in
                 Layout.optimisticLayoutWith
-                    (\() -> Combine.succeed (complete []))
+                    (\() -> complete [])
                     (\() -> argHelper [])
             )
 

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -96,8 +96,8 @@ typeDefinition maybeDoc =
 valueConstructors : Parser State (List (Node ValueConstructor))
 valueConstructors =
     Combine.sepBy1WithoutReverse
-        (Combine.symbol "|"
-            |> Combine.ignore (Combine.maybeIgnore Layout.layout)
+        (Core.symbol "|"
+            |> Combine.continueFromCore (Combine.maybeIgnore Layout.layout)
         )
         valueConstructor
 
@@ -146,5 +146,5 @@ genericList =
 
 typePrefix : Parser State ()
 typePrefix =
-    Combine.symbol "type"
-        |> Combine.ignore Layout.layout
+    Core.symbol "type"
+        |> Combine.continueFromCore Layout.layout

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -18,17 +18,17 @@ import Parser as Core
 typeDefinition : Maybe (Node Documentation) -> Parser State (Node Declaration.Declaration)
 typeDefinition maybeDoc =
     let
-        startParser : Parser state Location
+        startParser : Core.Parser Location
         startParser =
             case maybeDoc of
                 Just (Node { start } _) ->
-                    Combine.succeed start
+                    Core.succeed start
 
                 Nothing ->
                     Combine.location
     in
     startParser
-        |> Combine.ignore typePrefix
+        |> Combine.ignoreFromCore typePrefix
         |> Combine.andThen
             (\start ->
                 Combine.oneOf

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -12,6 +12,7 @@ import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range exposing (Location, Range)
 import Elm.Syntax.Type exposing (ValueConstructor)
 import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
+import Parser as Core
 
 
 typeDefinition : Maybe (Node Documentation) -> Parser State (Node Declaration.Declaration)
@@ -47,12 +48,12 @@ typeDefinition maybeDoc =
                                             }
                                         )
                         )
-                        |> Combine.ignore (Combine.symbol "alias")
+                        |> Combine.ignoreEntirely (Core.symbol "alias")
                         |> Combine.ignore Layout.layout
                         |> Combine.keep (Node.parserFromCore Tokens.typeName)
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
-                        |> Combine.ignore (Combine.symbol "=")
+                        |> Combine.ignoreEntirely (Core.symbol "=")
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep typeAnnotation
                     , Combine.succeed
@@ -85,7 +86,7 @@ typeDefinition maybeDoc =
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-                        |> Combine.ignore (Combine.symbol "=")
+                        |> Combine.ignoreEntirely (Core.symbol "=")
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep valueConstructors
                     ]

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Typings exposing (typeDefinition)
 
-import Combine exposing (Parser, many)
+import Combine exposing (Parser)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
@@ -138,7 +138,7 @@ valueConstructor =
 
 genericList : Parser State (List (Node String))
 genericList =
-    many (Node.parserFromCore functionNameCore |> Combine.ignore (Combine.maybeIgnore Layout.layout))
+    Combine.many (Node.parserFromCore functionNameCore |> Combine.ignore (Combine.maybeIgnore Layout.layout))
 
 
 typePrefix : Parser State ()

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -4,7 +4,7 @@ import Combine exposing (Parser, many, maybe, string)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
-import Elm.Parser.Tokens exposing (functionNameCore, typeNameCore)
+import Elm.Parser.Tokens exposing (functionNameCore, typeName)
 import Elm.Parser.TypeAnnotation exposing (typeAnnotation, typeAnnotationNonGreedy)
 import Elm.Syntax.Declaration as Declaration
 import Elm.Syntax.Documentation exposing (Documentation)
@@ -38,7 +38,7 @@ typeDefinition maybeDoc =
                         )
                         |> Combine.ignore (string "alias")
                         |> Combine.ignore Layout.layout
-                        |> Combine.keep (Node.parserFromCore typeNameCore)
+                        |> Combine.keep (Node.parserFromCore typeName)
                         |> Combine.ignore (maybe Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (string "=")
@@ -70,7 +70,7 @@ typeDefinition maybeDoc =
                                             }
                                         )
                         )
-                        |> Combine.keep (Node.parserFromCore typeNameCore)
+                        |> Combine.keep (Node.parserFromCore typeName)
                         |> Combine.ignore (maybe Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (maybe Layout.layout)
@@ -90,7 +90,7 @@ valueConstructors =
 
 valueConstructor : Parser State (Node ValueConstructor)
 valueConstructor =
-    Node.parserFromCore typeNameCore
+    Node.parserFromCore typeName
         |> Combine.andThen
             (\((Node range _) as tnn) ->
                 let

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Typings exposing (typeDefinition)
 
-import Combine exposing (Parser, many, maybe, string)
+import Combine exposing (Parser, many, string)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
@@ -50,10 +50,10 @@ typeDefinition maybeDoc =
                         |> Combine.ignore (string "alias")
                         |> Combine.ignore Layout.layout
                         |> Combine.keep (Node.parserFromCore typeName)
-                        |> Combine.ignore (maybe Layout.layout)
+                        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (string "=")
-                        |> Combine.ignore (maybe Layout.layout)
+                        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep typeAnnotation
                     , Combine.succeed
                         (\name ->
@@ -82,11 +82,11 @@ typeDefinition maybeDoc =
                                         )
                         )
                         |> Combine.keep (Node.parserFromCore typeName)
-                        |> Combine.ignore (maybe Layout.layout)
+                        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
-                        |> Combine.ignore (maybe Layout.layout)
+                        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.ignore (string "=")
-                        |> Combine.ignore (maybe Layout.layout)
+                        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep valueConstructors
                     ]
             )
@@ -95,7 +95,7 @@ typeDefinition maybeDoc =
 valueConstructors : Parser State (List (Node ValueConstructor))
 valueConstructors =
     Combine.sepBy1WithoutReverse
-        (Combine.ignore (maybe Layout.layout) (string "|"))
+        (Combine.ignore (Combine.maybeIgnore Layout.layout) (string "|"))
         valueConstructor
 
 
@@ -138,7 +138,7 @@ valueConstructor =
 
 genericList : Parser State (List (Node String))
 genericList =
-    many (Node.parserFromCore functionNameCore |> Combine.ignore (maybe Layout.layout))
+    many (Node.parserFromCore functionNameCore |> Combine.ignore (Combine.maybeIgnore Layout.layout))
 
 
 typePrefix : Parser State ()

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -141,8 +141,7 @@ genericList =
     many (Node.parserFromCore functionNameCore |> Combine.ignore (maybe Layout.layout))
 
 
-typePrefix : Parser State (Node String)
+typePrefix : Parser State ()
 typePrefix =
-    Combine.string "type"
-        |> Node.parser
+    Combine.symbol "type"
         |> Combine.ignore Layout.layout

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -16,9 +16,11 @@ import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
 
 typeDefinition : Maybe (Node Documentation) -> Parser State (Node Declaration.Declaration)
 typeDefinition maybeDoc =
-    typePrefix
+    Combine.succeed identity
+        |> Combine.keep Combine.location
+        |> Combine.ignore typePrefix
         |> Combine.andThen
-            (\(Node { start } _) ->
+            (\start ->
                 Combine.oneOf
                     [ Combine.succeed
                         (\name ->

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -1,6 +1,6 @@
 module Elm.Parser.Typings exposing (typeDefinition)
 
-import Combine exposing (Parser, many, string)
+import Combine exposing (Parser, many)
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Node as Node
 import Elm.Parser.State exposing (State)
@@ -47,12 +47,12 @@ typeDefinition maybeDoc =
                                             }
                                         )
                         )
-                        |> Combine.ignore (string "alias")
+                        |> Combine.ignore (Combine.symbol "alias")
                         |> Combine.ignore Layout.layout
                         |> Combine.keep (Node.parserFromCore typeName)
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
-                        |> Combine.ignore (string "=")
+                        |> Combine.ignore (Combine.symbol "=")
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep typeAnnotation
                     , Combine.succeed
@@ -85,7 +85,7 @@ typeDefinition maybeDoc =
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
-                        |> Combine.ignore (string "=")
+                        |> Combine.ignore (Combine.symbol "=")
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep valueConstructors
                     ]
@@ -95,7 +95,7 @@ typeDefinition maybeDoc =
 valueConstructors : Parser State (List (Node ValueConstructor))
 valueConstructors =
     Combine.sepBy1WithoutReverse
-        (Combine.ignore (Combine.maybeIgnore Layout.layout) (string "|"))
+        (Combine.ignore (Combine.maybeIgnore Layout.layout) (Combine.symbol "|"))
         valueConstructor
 
 

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -138,7 +138,7 @@ valueConstructor =
 
 genericList : Parser State (List (Node String))
 genericList =
-    Combine.many (Node.parserFromCore Tokens.functionNameCore |> Combine.ignore (Combine.maybeIgnore Layout.layout))
+    Combine.many (Node.parserFromCore Tokens.functionName |> Combine.ignore (Combine.maybeIgnore Layout.layout))
 
 
 typePrefix : Parser State ()

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -50,7 +50,7 @@ typeDefinition maybeDoc =
                         )
                         |> Combine.ignoreEntirely (Core.symbol "alias")
                         |> Combine.ignore Layout.layout
-                        |> Combine.keep (Node.parserFromCore Tokens.typeName)
+                        |> Combine.keepFromCore (Node.parserCore Tokens.typeName)
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignoreEntirely (Core.symbol "=")
@@ -82,7 +82,7 @@ typeDefinition maybeDoc =
                                             }
                                         )
                         )
-                        |> Combine.keep (Node.parserFromCore Tokens.typeName)
+                        |> Combine.keepFromCore (Node.parserCore Tokens.typeName)
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)
                         |> Combine.keep genericList
                         |> Combine.ignore (Combine.maybeIgnore Layout.layout)

--- a/src/Elm/Parser/Typings.elm
+++ b/src/Elm/Parser/Typings.elm
@@ -105,18 +105,16 @@ valueConstructor =
         |> Combine.andThen
             (\((Node range _) as tnn) ->
                 let
-                    complete : List (Node TypeAnnotation) -> Parser State (Node ValueConstructor)
+                    complete : List (Node TypeAnnotation) -> Node ValueConstructor
                     complete args =
                         let
                             endRange : Range
                             endRange =
                                 List.head args |> Maybe.map Node.range |> Maybe.withDefault range
                         in
-                        Combine.succeed
-                            (Node
-                                { start = range.start, end = endRange.end }
-                                (ValueConstructor tnn (List.reverse args))
-                            )
+                        Node
+                            { start = range.start, end = endRange.end }
+                            (ValueConstructor tnn (List.reverse args))
 
                     argHelper : List (Node TypeAnnotation) -> Parser State (Node ValueConstructor)
                     argHelper xs =
@@ -125,15 +123,15 @@ valueConstructor =
                                 |> Combine.andThen
                                     (\ta ->
                                         Layout.optimisticLayoutWith
-                                            (\() -> complete (ta :: xs))
+                                            (\() -> Combine.succeed (complete (ta :: xs)))
                                             (\() -> argHelper (ta :: xs))
                                     )
                             , Combine.succeed xs
-                                |> Combine.andThen complete
+                                |> Combine.map complete
                             ]
                 in
                 Layout.optimisticLayoutWith
-                    (\() -> complete [])
+                    (\() -> Combine.succeed (complete []))
                     (\() -> argHelper [])
             )
 

--- a/src/Elm/Parser/Whitespace.elm
+++ b/src/Elm/Parser/Whitespace.elm
@@ -1,4 +1,4 @@
-module Elm.Parser.Whitespace exposing (many1Spaces, realNewLine, realNewLineCore, untilNewlineToken)
+module Elm.Parser.Whitespace exposing (many1Spaces, realNewLine, untilNewlineToken)
 
 import Combine exposing (Parser)
 import Parser as Core exposing ((|.))
@@ -11,13 +11,8 @@ many1Spaces =
         |> Combine.fromCore
 
 
-realNewLine : Parser state ()
+realNewLine : Core.Parser ()
 realNewLine =
-    Combine.fromCore realNewLineCore
-
-
-realNewLineCore : Core.Parser ()
-realNewLineCore =
     Core.oneOf
         [ Core.chompIf (\c -> c == '\u{000D}')
         , Core.succeed ()

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -1,6 +1,13 @@
-module List.Extra exposing (unique)
+module List.Extra exposing
+    ( find
+    , unique
+    )
 
 {-| Helper for List functions. Taken from elm-community/list-extra.
+
+@docs find
+@docs unique
+
 -}
 
 
@@ -27,3 +34,17 @@ uniqueHelp existing remaining accumulator =
 
             else
                 uniqueHelp (first :: existing) rest (first :: accumulator)
+
+
+find : (a -> Bool) -> List a -> Maybe a
+find predicate list =
+    case list of
+        [] ->
+            Nothing
+
+        x :: xs ->
+            if predicate x then
+                Just x
+
+            else
+                find predicate xs

--- a/src/Parser/Extra.elm
+++ b/src/Parser/Extra.elm
@@ -1,7 +1,7 @@
-module Parser.Extra exposing (anyChar, location)
+module Parser.Extra exposing (anyChar, location, sepBy1)
 
 import Elm.Syntax.Range exposing (Location)
-import Parser as Core
+import Parser as Core exposing ((|.), (|=))
 
 
 location : Core.Parser Location
@@ -26,3 +26,39 @@ anyChar =
                     c :: _ ->
                         Core.succeed c
             )
+
+
+sepBy1 : String -> Core.Parser a -> Core.Parser (List a)
+sepBy1 sep p =
+    Core.succeed cons
+        |= p
+        |= many
+            (Core.succeed identity
+                |. Core.symbol sep
+                |= p
+            )
+
+
+many : Core.Parser a -> Core.Parser (List a)
+many p =
+    manyWithoutReverse [] p
+        |> Core.map List.reverse
+
+
+manyWithoutReverse : List a -> Core.Parser a -> Core.Parser (List a)
+manyWithoutReverse initList p =
+    let
+        helper : List a -> Core.Parser (Core.Step (List a) (List a))
+        helper items =
+            Core.oneOf
+                [ p
+                    |> Core.map (\item -> Core.Loop (item :: items))
+                , Core.succeed (Core.Done items)
+                ]
+    in
+    Core.loop initList helper
+
+
+cons : a -> List a -> List a
+cons first =
+    \rest -> first :: rest

--- a/src/Parser/Extra.elm
+++ b/src/Parser/Extra.elm
@@ -1,6 +1,16 @@
-module Parser.Extra exposing (anyChar)
+module Parser.Extra exposing (anyChar, location)
 
+import Elm.Syntax.Range exposing (Location)
 import Parser as Core
+
+
+location : Core.Parser Location
+location =
+    Core.getPosition
+        |> Core.map
+            (\( row, col ) ->
+                { row = row, column = col }
+            )
 
 
 anyChar : Core.Parser Char

--- a/src/Parser/Extra.elm
+++ b/src/Parser/Extra.elm
@@ -1,4 +1,4 @@
-module Parser.Extra exposing (anyChar, location, sepBy1)
+module Parser.Extra exposing (anyChar, location, many1Ignore, sepBy1)
 
 import Elm.Syntax.Range exposing (Location)
 import Parser as Core exposing ((|.), (|=))
@@ -62,3 +62,23 @@ manyWithoutReverse initList p =
 cons : a -> List a -> List a
 cons first =
     \rest -> first :: rest
+
+
+many1Ignore : Core.Parser () -> Core.Parser ()
+many1Ignore p =
+    p
+        |. manyIgnore p
+
+
+manyIgnore : Core.Parser () -> Core.Parser ()
+manyIgnore p =
+    let
+        helper : () -> Core.Parser (Core.Step () ())
+        helper () =
+            Core.oneOf
+                [ p
+                    |> Core.map (\() -> Core.Loop ())
+                , Core.succeed (Core.Done ())
+                ]
+    in
+    Core.loop () helper

--- a/src/Parser/Extra.elm
+++ b/src/Parser/Extra.elm
@@ -1,4 +1,4 @@
-module Combine.Char exposing (anyChar)
+module Parser.Extra exposing (anyChar)
 
 import Parser as Core
 

--- a/tests/Elm/Parser/BaseTest.elm
+++ b/tests/Elm/Parser/BaseTest.elm
@@ -1,5 +1,6 @@
 module Elm.Parser.BaseTest exposing (all)
 
+import Combine
 import Elm.Parser.Base as Parser
 import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Syntax.Node as Node
@@ -12,12 +13,12 @@ all =
     describe "BaseTest"
         [ test "moduleName" <|
             \() ->
-                parseWithFailure "Foo" Parser.moduleName
+                parseWithFailure "Foo" (Combine.fromCore Parser.moduleName)
                     |> Result.map Node.value
                     |> Expect.equal (Ok [ "Foo" ])
         , test "moduleNameDir" <|
             \() ->
-                parseWithFailure "Foo.Bar" Parser.moduleName
+                parseWithFailure "Foo.Bar" (Combine.fromCore Parser.moduleName)
                     |> Result.map Node.value
                     |> Expect.equal (Ok [ "Foo", "Bar" ])
         ]

--- a/tests/Elm/Parser/BaseTest.elm
+++ b/tests/Elm/Parser/BaseTest.elm
@@ -1,11 +1,10 @@
 module Elm.Parser.BaseTest exposing (all)
 
-import Combine
 import Elm.Parser.Base as Parser
-import Elm.Parser.CombineTestUtil exposing (..)
+import Elm.Parser.TestUtil as TestUtil
 import Elm.Syntax.Node as Node
 import Expect
-import Test exposing (..)
+import Test exposing (Test, describe, test)
 
 
 all : Test
@@ -13,12 +12,12 @@ all =
     describe "BaseTest"
         [ test "moduleName" <|
             \() ->
-                parseWithFailure "Foo" (Combine.fromCore Parser.moduleName)
-                    |> Result.map Node.value
-                    |> Expect.equal (Ok [ "Foo" ])
+                TestUtil.parse "Foo" Parser.moduleName
+                    |> Maybe.map Node.value
+                    |> Expect.equal (Just [ "Foo" ])
         , test "moduleNameDir" <|
             \() ->
-                parseWithFailure "Foo.Bar" (Combine.fromCore Parser.moduleName)
-                    |> Result.map Node.value
-                    |> Expect.equal (Ok [ "Foo", "Bar" ])
+                TestUtil.parse "Foo.Bar" Parser.moduleName
+                    |> Maybe.map Node.value
+                    |> Expect.equal (Just [ "Foo", "Bar" ])
         ]

--- a/tests/Elm/Parser/BaseTest.elm
+++ b/tests/Elm/Parser/BaseTest.elm
@@ -2,6 +2,7 @@ module Elm.Parser.BaseTest exposing (all)
 
 import Elm.Parser.Base as Parser
 import Elm.Parser.CombineTestUtil exposing (..)
+import Elm.Syntax.Node as Node
 import Expect
 import Test exposing (..)
 
@@ -12,9 +13,11 @@ all =
         [ test "moduleName" <|
             \() ->
                 parseWithFailure "Foo" Parser.moduleName
+                    |> Result.map Node.value
                     |> Expect.equal (Ok [ "Foo" ])
         , test "moduleNameDir" <|
             \() ->
                 parseWithFailure "Foo.Bar" Parser.moduleName
+                    |> Result.map Node.value
                     |> Expect.equal (Ok [ "Foo", "Bar" ])
         ]

--- a/tests/Elm/Parser/CombineTestUtil.elm
+++ b/tests/Elm/Parser/CombineTestUtil.elm
@@ -1,4 +1,4 @@
-module Elm.Parser.CombineTestUtil exposing (expectAst, expectAstWithComments, expectInvalid, parse, parseWithFailure, parseWithState)
+module Elm.Parser.CombineTestUtil exposing (expectAst, expectAstWithComments, expectInvalid, parse, parseWithState)
 
 import Combine exposing (Parser)
 import Elm.Parser.State as State exposing (State, emptyState)

--- a/tests/Elm/Parser/NumbersTests.elm
+++ b/tests/Elm/Parser/NumbersTests.elm
@@ -1,5 +1,6 @@
 module Elm.Parser.NumbersTests exposing (all)
 
+import Combine
 import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Parser.Numbers as Parser
 import Expect
@@ -11,12 +12,12 @@ all =
     describe "NumbersTests"
         [ test "hex" <|
             \() ->
-                parse "0x03FFFFFF" (Parser.number (always Nothing) Just)
+                parse "0x03FFFFFF" (Combine.fromCore (Parser.number (always Nothing) Just))
                     |> Expect.equal
                         (Just (Just 67108863))
         , test "hex - 2" <|
             \() ->
-                parse "0xFF" (Parser.number (always Nothing) Just)
+                parse "0xFF" (Combine.fromCore (Parser.number (always Nothing) Just))
                     |> Expect.equal
                         (Just (Just 255))
         ]

--- a/tests/Elm/Parser/NumbersTests.elm
+++ b/tests/Elm/Parser/NumbersTests.elm
@@ -1,8 +1,7 @@
 module Elm.Parser.NumbersTests exposing (all)
 
-import Combine
-import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Parser.Numbers as Parser
+import Elm.Parser.TestUtil exposing (..)
 import Expect
 import Test exposing (..)
 
@@ -12,12 +11,12 @@ all =
     describe "NumbersTests"
         [ test "hex" <|
             \() ->
-                parse "0x03FFFFFF" (Combine.fromCore (Parser.number (always Nothing) Just))
+                parse "0x03FFFFFF" (Parser.number (always Nothing) Just)
                     |> Expect.equal
                         (Just (Just 67108863))
         , test "hex - 2" <|
             \() ->
-                parse "0xFF" (Combine.fromCore (Parser.number (always Nothing) Just))
+                parse "0xFF" (Parser.number (always Nothing) Just)
                     |> Expect.equal
                         (Just (Just 255))
         ]

--- a/tests/Elm/Parser/TestUtil.elm
+++ b/tests/Elm/Parser/TestUtil.elm
@@ -1,0 +1,9 @@
+module Elm.Parser.TestUtil exposing (parse)
+
+import Parser as Core exposing ((|.))
+
+
+parse : String -> Core.Parser a -> Maybe a
+parse source p =
+    Core.run (p |. Core.end) source
+        |> Result.toMaybe

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -70,11 +70,11 @@ all =
                     |> Expect.equal (Just "T1")
         , test "moduleToken" <|
             \() ->
-                parse "module" Parser.moduleToken
+                parse "module" (Combine.fromCore Parser.moduleToken)
                     |> Expect.equal (Just ())
         , test "exposingToken" <|
             \() ->
-                parse "exposing" Parser.exposingToken
+                parse "exposing" (Combine.fromCore Parser.exposingToken)
                     |> Expect.equal (Just ())
         , test "operatorToken 11 -- is not an operator" <|
             \() ->

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -98,19 +98,19 @@ all =
                     |> Expect.equal (Just """ \"\"\" """)
         , test "character escaped" <|
             \() ->
-                parse "'\\''" Parser.characterLiteral
+                parse "'\\''" (Combine.fromCore Parser.characterLiteral)
                     |> Expect.equal (Just '\'')
         , test "character escaped - 2" <|
             \() ->
-                parse "'\\r'" Parser.characterLiteral
+                parse "'\\r'" (Combine.fromCore Parser.characterLiteral)
                     |> Expect.equal (Just '\u{000D}')
         , test "unicode char" <|
             \() ->
-                parse "'\\u{000D}'" Parser.characterLiteral
+                parse "'\\u{000D}'" (Combine.fromCore Parser.characterLiteral)
                     |> Expect.equal (Just '\u{000D}')
         , test "unicode char with lowercase hex" <|
             \() ->
-                parse "'\\u{000d}'" Parser.characterLiteral
+                parse "'\\u{000d}'" (Combine.fromCore Parser.characterLiteral)
                     |> Expect.equal (Just '\u{000D}')
         , test "string escaped 3" <|
             \() ->
@@ -122,7 +122,7 @@ all =
                     |> Expect.equal (Just "foo\\")
         , test "character escaped 3" <|
             \() ->
-                parse "'\\n'" Parser.characterLiteral
+                parse "'\\n'" (Combine.fromCore Parser.characterLiteral)
                     |> Expect.equal (Just '\n')
         , test "long string" <|
             \() ->

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -22,39 +22,39 @@ all =
     describe "TokenTests"
         [ test "functionName" <|
             \() ->
-                parse "foo" Parser.functionName
+                parse "foo" (Combine.fromCore Parser.functionName)
                     |> Expect.equal (Just "foo")
         , test "functionName may not be a keyword" <|
             \() ->
-                parse "type" Parser.functionName
+                parse "type" (Combine.fromCore Parser.functionName)
                     |> Expect.equal Nothing
         , test "functionName may be a keyword suffixed with an underscore" <|
             \() ->
-                parse "type_" Parser.functionName
+                parse "type_" (Combine.fromCore Parser.functionName)
                     |> Expect.equal (Just "type_")
         , test "functionName not empty" <|
             \() ->
-                parse "" Parser.functionName
+                parse "" (Combine.fromCore Parser.functionName)
                     |> Expect.equal Nothing
         , test "functionName with number" <|
             \() ->
-                parse "n1" Parser.functionName
+                parse "n1" (Combine.fromCore Parser.functionName)
                     |> Expect.equal (Just "n1")
         , test "alias can be a functionName (it is not reserved)" <|
             \() ->
-                parse "alias" Parser.functionName
+                parse "alias" (Combine.fromCore Parser.functionName)
                     |> Expect.equal (Just "alias")
         , test "infix can be a functionName (it is not reserved)" <|
             \() ->
-                parse "infix" Parser.functionName
+                parse "infix" (Combine.fromCore Parser.functionName)
                     |> Expect.equal (Just "infix")
         , test "functionName is not matched with 'if'" <|
             \() ->
-                parse "if" Parser.functionName
+                parse "if" (Combine.fromCore Parser.functionName)
                     |> Expect.equal Nothing
         , test "functionName with _" <|
             \() ->
-                parse "foo_" Parser.functionName
+                parse "foo_" (Combine.fromCore Parser.functionName)
                     |> Expect.equal (Just "foo_")
         , test "typeName" <|
             \() ->
@@ -134,23 +134,23 @@ all =
                     |> Expect.notEqual Nothing
         , test "ρ function" <|
             \() ->
-                parse "ρ" Parser.functionName
+                parse "ρ" (Combine.fromCore Parser.functionName)
                     |> Expect.notEqual Nothing
         , test "ε2 function" <|
             \() ->
-                parse "ε2" Parser.functionName
+                parse "ε2" (Combine.fromCore Parser.functionName)
                     |> Expect.notEqual Nothing
         , test "εε function" <|
             \() ->
-                parse "εε" Parser.functionName
+                parse "εε" (Combine.fromCore Parser.functionName)
                     |> Expect.notEqual Nothing
         , test "ρ uppercase function" <|
             \() ->
-                parse (String.toUpper "ρ") Parser.functionName
+                parse (String.toUpper "ρ") (Combine.fromCore Parser.functionName)
                     |> Expect.equal Nothing
         , test "ε uppercase function" <|
             \() ->
-                parse (String.toUpper "ε") Parser.functionName
+                parse (String.toUpper "ε") (Combine.fromCore Parser.functionName)
                     |> Expect.equal Nothing
         , test "ρ type name" <|
             \() ->

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -90,11 +90,11 @@ all =
                     |> Expect.equal Nothing
         , test "multiline string" <|
             \() ->
-                parse "\"\"\"Bar foo \n a\"\"\"" Parser.multiLineStringLiteral
+                parse "\"\"\"Bar foo \n a\"\"\"" (Combine.fromCore Parser.multiLineStringLiteral)
                     |> Expect.equal (Just "Bar foo \n a")
         , test "multiline string escape" <|
             \() ->
-                parse """\"\"\" \\\"\"\" \"\"\"""" Parser.multiLineStringLiteral
+                parse """\"\"\" \\\"\"\" \"\"\"""" (Combine.fromCore Parser.multiLineStringLiteral)
                     |> Expect.equal (Just """ \"\"\" """)
         , test "character escaped" <|
             \() ->
@@ -130,7 +130,7 @@ all =
                     |> Expect.notEqual Nothing
         , test "long multi line string" <|
             \() ->
-                parse longMultiLineString Parser.multiLineStringLiteral
+                parse longMultiLineString (Combine.fromCore Parser.multiLineStringLiteral)
                     |> Expect.notEqual Nothing
         , test "ρ function" <|
             \() ->

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -58,15 +58,15 @@ all =
                     |> Expect.equal (Just "foo_")
         , test "typeName" <|
             \() ->
-                parse "MyCmd" Parser.typeName
+                parse "MyCmd" (Combine.fromCore Parser.typeName)
                     |> Expect.equal (Just "MyCmd")
         , test "typeName not empty" <|
             \() ->
-                parse "" Parser.typeName
+                parse "" (Combine.fromCore Parser.typeName)
                     |> Expect.equal Nothing
         , test "typeName with number" <|
             \() ->
-                parse "T1" Parser.typeName
+                parse "T1" (Combine.fromCore Parser.typeName)
                     |> Expect.equal (Just "T1")
         , test "moduleToken" <|
             \() ->
@@ -154,22 +154,22 @@ all =
                     |> Expect.equal Nothing
         , test "ρ type name" <|
             \() ->
-                parse "ρ" Parser.typeName
+                parse "ρ" (Combine.fromCore Parser.typeName)
                     |> Expect.equal Nothing
         , test "ε2 type name" <|
             \() ->
-                parse "ε2" Parser.typeName
+                parse "ε2" (Combine.fromCore Parser.typeName)
                     |> Expect.equal Nothing
         , test "εε type name" <|
             \() ->
-                parse "εε" Parser.typeName
+                parse "εε" (Combine.fromCore Parser.typeName)
                     |> Expect.equal Nothing
         , test "ρ uppercase type name" <|
             \() ->
-                parse (String.toUpper "ρ") Parser.typeName
+                parse (String.toUpper "ρ") (Combine.fromCore Parser.typeName)
                     |> Expect.notEqual Nothing
         , test "ε uppercase type name" <|
             \() ->
-                parse (String.toUpper "ε") Parser.typeName
+                parse (String.toUpper "ε") (Combine.fromCore Parser.typeName)
                     |> Expect.notEqual Nothing
         ]

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -1,7 +1,6 @@
 module Elm.Parser.TokenTests exposing (all)
 
-import Combine
-import Elm.Parser.CombineTestUtil exposing (..)
+import Elm.Parser.TestUtil exposing (..)
 import Elm.Parser.Tokens as Parser
 import Expect
 import Test exposing (..)
@@ -22,154 +21,154 @@ all =
     describe "TokenTests"
         [ test "functionName" <|
             \() ->
-                parse "foo" (Combine.fromCore Parser.functionName)
+                parse "foo" Parser.functionName
                     |> Expect.equal (Just "foo")
         , test "functionName may not be a keyword" <|
             \() ->
-                parse "type" (Combine.fromCore Parser.functionName)
+                parse "type" Parser.functionName
                     |> Expect.equal Nothing
         , test "functionName may be a keyword suffixed with an underscore" <|
             \() ->
-                parse "type_" (Combine.fromCore Parser.functionName)
+                parse "type_" Parser.functionName
                     |> Expect.equal (Just "type_")
         , test "functionName not empty" <|
             \() ->
-                parse "" (Combine.fromCore Parser.functionName)
+                parse "" Parser.functionName
                     |> Expect.equal Nothing
         , test "functionName with number" <|
             \() ->
-                parse "n1" (Combine.fromCore Parser.functionName)
+                parse "n1" Parser.functionName
                     |> Expect.equal (Just "n1")
         , test "alias can be a functionName (it is not reserved)" <|
             \() ->
-                parse "alias" (Combine.fromCore Parser.functionName)
+                parse "alias" Parser.functionName
                     |> Expect.equal (Just "alias")
         , test "infix can be a functionName (it is not reserved)" <|
             \() ->
-                parse "infix" (Combine.fromCore Parser.functionName)
+                parse "infix" Parser.functionName
                     |> Expect.equal (Just "infix")
         , test "functionName is not matched with 'if'" <|
             \() ->
-                parse "if" (Combine.fromCore Parser.functionName)
+                parse "if" Parser.functionName
                     |> Expect.equal Nothing
         , test "functionName with _" <|
             \() ->
-                parse "foo_" (Combine.fromCore Parser.functionName)
+                parse "foo_" Parser.functionName
                     |> Expect.equal (Just "foo_")
         , test "typeName" <|
             \() ->
-                parse "MyCmd" (Combine.fromCore Parser.typeName)
+                parse "MyCmd" Parser.typeName
                     |> Expect.equal (Just "MyCmd")
         , test "typeName not empty" <|
             \() ->
-                parse "" (Combine.fromCore Parser.typeName)
+                parse "" Parser.typeName
                     |> Expect.equal Nothing
         , test "typeName with number" <|
             \() ->
-                parse "T1" (Combine.fromCore Parser.typeName)
+                parse "T1" Parser.typeName
                     |> Expect.equal (Just "T1")
         , test "moduleToken" <|
             \() ->
-                parse "module" (Combine.fromCore Parser.moduleToken)
+                parse "module" Parser.moduleToken
                     |> Expect.equal (Just ())
         , test "exposingToken" <|
             \() ->
-                parse "exposing" (Combine.fromCore Parser.exposingToken)
+                parse "exposing" Parser.exposingToken
                     |> Expect.equal (Just ())
         , test "operatorToken 11 -- is not an operator" <|
             \() ->
-                parse "--" (Combine.fromCore Parser.prefixOperatorToken)
+                parse "--" Parser.prefixOperatorToken
                     |> Expect.equal Nothing
         , test "operatorToken 14" <|
             \() ->
-                parse "=" (Combine.fromCore Parser.prefixOperatorToken)
+                parse "=" Parser.prefixOperatorToken
                     |> Expect.equal Nothing
         , test "operatorToken 15" <|
             \() ->
-                parse "?" (Combine.fromCore Parser.prefixOperatorToken)
+                parse "?" Parser.prefixOperatorToken
                     |> Expect.equal Nothing
         , test "multiline string" <|
             \() ->
-                parse "\"\"\"Bar foo \n a\"\"\"" (Combine.fromCore Parser.multiLineStringLiteral)
+                parse "\"\"\"Bar foo \n a\"\"\"" Parser.multiLineStringLiteral
                     |> Expect.equal (Just "Bar foo \n a")
         , test "multiline string escape" <|
             \() ->
-                parse """\"\"\" \\\"\"\" \"\"\"""" (Combine.fromCore Parser.multiLineStringLiteral)
+                parse """\"\"\" \\\"\"\" \"\"\"""" Parser.multiLineStringLiteral
                     |> Expect.equal (Just """ \"\"\" """)
         , test "character escaped" <|
             \() ->
-                parse "'\\''" (Combine.fromCore Parser.characterLiteral)
+                parse "'\\''" Parser.characterLiteral
                     |> Expect.equal (Just '\'')
         , test "character escaped - 2" <|
             \() ->
-                parse "'\\r'" (Combine.fromCore Parser.characterLiteral)
+                parse "'\\r'" Parser.characterLiteral
                     |> Expect.equal (Just '\u{000D}')
         , test "unicode char" <|
             \() ->
-                parse "'\\u{000D}'" (Combine.fromCore Parser.characterLiteral)
+                parse "'\\u{000D}'" Parser.characterLiteral
                     |> Expect.equal (Just '\u{000D}')
         , test "unicode char with lowercase hex" <|
             \() ->
-                parse "'\\u{000d}'" (Combine.fromCore Parser.characterLiteral)
+                parse "'\\u{000d}'" Parser.characterLiteral
                     |> Expect.equal (Just '\u{000D}')
         , test "string escaped 3" <|
             \() ->
-                parse "\"\\\"\"" (Combine.fromCore Parser.stringLiteral)
+                parse "\"\\\"\"" Parser.stringLiteral
                     |> Expect.equal (Just "\"")
         , test "string escaped" <|
             \() ->
-                parse "\"foo\\\\\"" (Combine.fromCore Parser.stringLiteral)
+                parse "\"foo\\\\\"" Parser.stringLiteral
                     |> Expect.equal (Just "foo\\")
         , test "character escaped 3" <|
             \() ->
-                parse "'\\n'" (Combine.fromCore Parser.characterLiteral)
+                parse "'\\n'" Parser.characterLiteral
                     |> Expect.equal (Just '\n')
         , test "long string" <|
             \() ->
-                parse longString (Combine.fromCore Parser.stringLiteral)
+                parse longString Parser.stringLiteral
                     |> Expect.notEqual Nothing
         , test "long multi line string" <|
             \() ->
-                parse longMultiLineString (Combine.fromCore Parser.multiLineStringLiteral)
+                parse longMultiLineString Parser.multiLineStringLiteral
                     |> Expect.notEqual Nothing
         , test "ρ function" <|
             \() ->
-                parse "ρ" (Combine.fromCore Parser.functionName)
+                parse "ρ" Parser.functionName
                     |> Expect.notEqual Nothing
         , test "ε2 function" <|
             \() ->
-                parse "ε2" (Combine.fromCore Parser.functionName)
+                parse "ε2" Parser.functionName
                     |> Expect.notEqual Nothing
         , test "εε function" <|
             \() ->
-                parse "εε" (Combine.fromCore Parser.functionName)
+                parse "εε" Parser.functionName
                     |> Expect.notEqual Nothing
         , test "ρ uppercase function" <|
             \() ->
-                parse (String.toUpper "ρ") (Combine.fromCore Parser.functionName)
+                parse (String.toUpper "ρ") Parser.functionName
                     |> Expect.equal Nothing
         , test "ε uppercase function" <|
             \() ->
-                parse (String.toUpper "ε") (Combine.fromCore Parser.functionName)
+                parse (String.toUpper "ε") Parser.functionName
                     |> Expect.equal Nothing
         , test "ρ type name" <|
             \() ->
-                parse "ρ" (Combine.fromCore Parser.typeName)
+                parse "ρ" Parser.typeName
                     |> Expect.equal Nothing
         , test "ε2 type name" <|
             \() ->
-                parse "ε2" (Combine.fromCore Parser.typeName)
+                parse "ε2" Parser.typeName
                     |> Expect.equal Nothing
         , test "εε type name" <|
             \() ->
-                parse "εε" (Combine.fromCore Parser.typeName)
+                parse "εε" Parser.typeName
                     |> Expect.equal Nothing
         , test "ρ uppercase type name" <|
             \() ->
-                parse (String.toUpper "ρ") (Combine.fromCore Parser.typeName)
+                parse (String.toUpper "ρ") Parser.typeName
                     |> Expect.notEqual Nothing
         , test "ε uppercase type name" <|
             \() ->
-                parse (String.toUpper "ε") (Combine.fromCore Parser.typeName)
+                parse (String.toUpper "ε") Parser.typeName
                     |> Expect.notEqual Nothing
         ]

--- a/tests/Elm/Parser/WhitespaceTests.elm
+++ b/tests/Elm/Parser/WhitespaceTests.elm
@@ -1,5 +1,6 @@
 module Elm.Parser.WhitespaceTests exposing (all)
 
+import Combine
 import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Parser.Whitespace as Whitespace
 import Expect
@@ -15,14 +16,14 @@ all =
                     |> Expect.equal (Just ())
         , test "realNewLine - normal" <|
             \() ->
-                parse "\n" Whitespace.realNewLine
+                parse "\n" (Combine.fromCore Whitespace.realNewLine)
                     |> Expect.equal (Just ())
         , test "realNewLine - with line feed" <|
             \() ->
-                parse "\u{000D}\n" Whitespace.realNewLine
+                parse "\u{000D}\n" (Combine.fromCore Whitespace.realNewLine)
                     |> Expect.equal (Just ())
         , test "realNewLine - incorrect" <|
             \() ->
-                parse "foo" Whitespace.realNewLine
+                parse "foo" (Combine.fromCore Whitespace.realNewLine)
                     |> Expect.equal Nothing
         ]

--- a/tests/Elm/Parser/WhitespaceTests.elm
+++ b/tests/Elm/Parser/WhitespaceTests.elm
@@ -1,7 +1,7 @@
 module Elm.Parser.WhitespaceTests exposing (all)
 
-import Combine
-import Elm.Parser.CombineTestUtil exposing (..)
+import Elm.Parser.CombineTestUtil as CombineTestUtil
+import Elm.Parser.TestUtil as TestUtil
 import Elm.Parser.Whitespace as Whitespace
 import Expect
 import Test exposing (..)
@@ -12,18 +12,18 @@ all =
     describe "LayoutTests"
         [ test "many1Spaces - not empty" <|
             \() ->
-                parse "   " Whitespace.many1Spaces
+                CombineTestUtil.parse "   " Whitespace.many1Spaces
                     |> Expect.equal (Just ())
         , test "realNewLine - normal" <|
             \() ->
-                parse "\n" (Combine.fromCore Whitespace.realNewLine)
+                TestUtil.parse "\n" Whitespace.realNewLine
                     |> Expect.equal (Just ())
         , test "realNewLine - with line feed" <|
             \() ->
-                parse "\u{000D}\n" (Combine.fromCore Whitespace.realNewLine)
+                TestUtil.parse "\u{000D}\n" Whitespace.realNewLine
                     |> Expect.equal (Just ())
         , test "realNewLine - incorrect" <|
             \() ->
-                parse "foo" (Combine.fromCore Whitespace.realNewLine)
+                TestUtil.parse "foo" Whitespace.realNewLine
                     |> Expect.equal Nothing
         ]


### PR DESCRIPTION
Follow up to #222

(Metrics are for my machine, not directly comparable to @jiegillet's results)

Before pratt-parser: 73400.5 ms to do 100 runs => 734.005 ms/run (weird, @jiegillet's results for this was much slower?)
Before: 146231.60000002384 ms to do 100 runs => 1462.3160000002383 ms/run
After: 101167.20000004768 ms to do 100 runs => 1011.6720000004768 ms/run

There are plenty of optimizations done here:
- Improve the arity of functions (see https://blogg.bekk.no/how-elm-functions-work-71cab7426a2f), which leads to some odd code in applicatives
- Trying to avoid using `Combine` as much as possible, and using the core parser as much as possible instead, wrapping as late as possible.
	- `Combine` has a lot of overhead, so sticking to using core parser is much better.
- Try to avoid unnecessary collection of data for things that get ignored (this is now enforced when using `Combine.ignore` and friends)