### PR TITLE
Compute the precedence before passing the config to the parser

### DIFF
--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -85,7 +85,7 @@ expression =
         }
 
 
-infixLeft : Int -> String -> Config state (Node Expression) -> ( Int, Node Expression -> Parser state (Node Expression) )
+infixLeft : Int -> String -> ( Int, Config state (Node Expression) -> Node Expression -> Parser state (Node Expression) )
 infixLeft precedence symbol =
     Pratt.infixLeft precedence
         (Core.symbol symbol)
@@ -96,7 +96,7 @@ infixLeft precedence symbol =
         )
 
 
-infixNonAssociative : Int -> String -> Config state (Node Expression) -> ( Int, Node Expression -> Parser state (Node Expression) )
+infixNonAssociative : Int -> String -> ( Int, Config state (Node Expression) -> Node Expression -> Parser state (Node Expression) )
 infixNonAssociative precedence symbol =
     Pratt.infixLeft precedence
         (Core.symbol symbol)
@@ -107,7 +107,7 @@ infixNonAssociative precedence symbol =
         )
 
 
-infixRight : Int -> String -> Config state (Node Expression) -> ( Int, Node Expression -> Parser state (Node Expression) )
+infixRight : Int -> String -> ( Int, Config state (Node Expression) -> Node Expression -> Parser state (Node Expression) )
 infixRight precedence symbol =
     Pratt.infixRight precedence
         (Core.symbol symbol)
@@ -118,7 +118,7 @@ infixRight precedence symbol =
         )
 
 
-infixLeftSubtraction : Int -> Config State (Node Expression) -> ( Int, Node Expression -> Parser State (Node Expression) )
+infixLeftSubtraction : Int -> ( Int, Config State (Node Expression) -> Node Expression -> Parser State (Node Expression) )
 infixLeftSubtraction precedence =
     Pratt.infixLeft precedence
         (Core.succeed (\offset -> \source -> String.slice (offset - 1) offset source)
@@ -141,7 +141,7 @@ infixLeftSubtraction precedence =
         )
 
 
-recordAccess : Config State (Node Expression) -> ( Int, Node Expression -> Parser State (Node Expression) )
+recordAccess : ( Int, Config State (Node Expression) -> Node Expression -> Parser State (Node Expression) )
 recordAccess =
     Pratt.postfix 100
         recordAccessParser
@@ -170,7 +170,7 @@ recordAccessParser =
         |> Combine.fromCore
 
 
-functionCall : Pratt.Config State (Node Expression) -> ( Int, Node Expression -> Parser State (Node Expression) )
+functionCall : ( Int, Pratt.Config State (Node Expression) -> Node Expression -> Parser State (Node Expression) )
 functionCall =
     Pratt.infixLeftWithState 90
         Layout.positivelyIndented

--- a/src/Pratt.elm
+++ b/src/Pratt.elm
@@ -200,7 +200,7 @@ subExpression currentPrecedence ((Config conf) as config) =
                 )
             )
         |> Combine.andThen
-            (\leftExpression -> Combine.loop leftExpression (expressionHelp config currentPrecedence))
+            (\leftExpression -> Combine.loop leftExpression (\expr -> expressionHelp config currentPrecedence expr))
 
 
 {-| This is the core of the Pratt parser algorithm.

--- a/src/Pratt.elm
+++ b/src/Pratt.elm
@@ -229,17 +229,15 @@ expressionHelp ((Config conf) as config) currentPrecedence leftExpression =
 operation : Config state e -> Int -> e -> Parser state e
 operation ((Config conf) as config) currentPrecedence leftExpression =
     conf.andThenOneOf
-        |> List.filterMap (\toOperation -> filter config toOperation currentPrecedence leftExpression)
+        |> List.filterMap
+            (\( precedence, parser ) ->
+                if precedence > currentPrecedence then
+                    Just (parser config leftExpression)
+
+                else
+                    Nothing
+            )
         |> Combine.oneOf
-
-
-filter : Config state e -> ( Int, Config state e -> e -> Parser state e ) -> Int -> e -> Maybe (Parser state e)
-filter config ( precedence, parser ) currentPrecedence leftExpression =
-    if precedence > currentPrecedence then
-        Just (parser config leftExpression)
-
-    else
-        Nothing
 
 
 


### PR DESCRIPTION
This makes it so that we can check the precedence of something, to check whether we need to evaluate **before** we create the prser by calling it with the config.

This reaches 822 ms/run! That's about 20% faster. And this should now be faster than than `master`!

To me, this very much indicates that creating the parsers over and over again is a big slowdown.
One annoying thing with the current state of the pratt parser, is that we pass the `Config` to the parsers, which means we re-evaluate it every time.

```elm
listExpression : Config State (Node Expression) -> Parser State (Node Expression)
listExpression config =
    Combine.succeed ListExpr
        |> Combine.ignoreEntirely squareStart
        |> Combine.ignore (Combine.maybeIgnore Layout.layout)
        |> Combine.keep (Combine.sepBy "," (Pratt.subExpression 0 config))
        |> Combine.ignoreEntirely squareEnd
        |> Node.parser
```

This gets re-created over and over inside of `Pratt.subExpression`, which gets called loads of times.

Maybe we could memoize the config somehow, or move it to inside the `State`. I don't know yet.