### PR TITLE
[Pratt parser] handle nested comments

### DIFF
--- a/find_regressions.sh
+++ b/find_regressions.sh
@@ -2,7 +2,7 @@
 
 FILES=$@
 TARGET="tests/RegressionTests.elm"
-PRATT_BRANCH="pratt-parser"
+BRANCH="pratt-parser"
 
 mkdir -p regressions
 
@@ -33,12 +33,14 @@ EOF
     git checkout master > /dev/null 2>&1
     npx elm-test | grep __RESULT__ > master_result.tmp
 
-    git checkout $PRATT_BRANCH > /dev/null 2>&1
-    npx elm-test | grep __RESULT__ > pratt_result.tmp
+    git checkout $BRANCH > /dev/null 2>&1
+    npx elm-test | grep __RESULT__ > branch_result.tmp
 
-    diff master_result.tmp pratt_result.tmp > /dev/null
+    diff master_result.tmp branch_result.tmp > /dev/null
     if [ $? -ne 0 ] ;then
         echo "❌❌❌ Found a parsing difference in $FILE"
         cp $FILE regressions
+    else
+       echo "✅✅✅ No problem"
     fi
 done

--- a/src/Elm/Parser/Comments.elm
+++ b/src/Elm/Parser/Comments.elm
@@ -59,5 +59,16 @@ moduleDocumentation =
 
 declarationDocumentation : Core.Parser (Node Documentation)
 declarationDocumentation =
-    Core.getChompedString (Core.multiComment "{-|" "-}" Nestable)
+    Core.succeed (\offset -> \source -> String.slice offset (offset + 3) source)
+        |= Core.getOffset
+        |= Core.getSource
+        |> Core.andThen
+            (\opening ->
+                if opening == "{-|" then
+                    Core.multiComment "{-" "-}" Nestable
+
+                else
+                    Core.problem "not a documentation comment"
+            )
+        |> Core.getChompedString
         |> Node.parserCore

--- a/tests/Elm/Parser/CommentTest.elm
+++ b/tests/Elm/Parser/CommentTest.elm
@@ -60,6 +60,12 @@ all =
                     |> Maybe.map toIndentAndComments
                     |> Expect.equal
                         (Just [ Node { start = { row = 1, column = 1 }, end = { row = 2, column = 6 } } "{-|foo\nbar-}" ])
+        , test "module documentation can handle nested comments" <|
+            \() ->
+                parseWithState "{-| {- hello -} -}" Parser.moduleDocumentation
+                    |> Maybe.map toIndentAndComments
+                    |> Expect.equal
+                        (Just [ Node { start = { row = 1, column = 1 }, end = { row = 1, column = 19 } } "{-| {- hello -} -}" ])
         ]
 
 


### PR DESCRIPTION
I ran the regression script on many Elm packages and found one.
I'm pretty confident it's the last one.

I don't particularly like the way we are parsing comments right now, but looking ahead without consuming is required here, and I'm not sure how to handle that best, so I'm open to suggestions.