### PR TITLE
Enable NoUnsortedRecords rule

### DIFF
--- a/review/elm.json
+++ b/review/elm.json
@@ -6,6 +6,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "SiriusStarr/elm-review-no-unsorted": "1.1.8",
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
@@ -16,9 +17,10 @@
             "jfmengels/elm-review-documentation": "2.0.4",
             "jfmengels/elm-review-simplify": "2.1.5",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.2"
+            "stil4m/elm-syntax": "7.3.3"
         },
         "indirect": {
+            "avh4/elm-fifo": "1.0.4",
             "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
@@ -26,6 +28,13 @@
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
+            "elm-community/dict-extra": "2.4.0",
+            "elm-community/graph": "6.0.0",
+            "elm-community/intdict": "3.0.0",
+            "elm-community/list-extra": "8.7.0",
+            "elm-community/maybe-extra": "5.3.0",
+            "elm-community/result-extra": "2.4.0",
+            "elm-community/string-extra": "4.0.1",
             "elm-explorations/test": "2.2.0",
             "miniBill/elm-unicode": "1.1.1",
             "pzp1997/assoc-list": "1.0.0",

--- a/review/src/AstFormatting.elm
+++ b/review/src/AstFormatting.elm
@@ -1,4 +1,4 @@
-module OrderedRanges exposing (rule)
+module AstFormatting exposing (rule)
 
 import Elm.Syntax.Expression as Expression exposing (Expression, RecordSetter)
 import Elm.Syntax.Node as Node exposing (Node(..))
@@ -10,7 +10,7 @@ import Review.Rule as Rule exposing (Error, Rule)
 
 rule : Rule
 rule =
-    Rule.newModuleRuleSchema "OrderedRanges" ()
+    Rule.newModuleRuleSchema "AstFormatting" ()
         |> Rule.withSimpleExpressionVisitor expressionVisitor
         |> Rule.fromModuleRuleSchema
 

--- a/review/src/AstFormatting.elm
+++ b/review/src/AstFormatting.elm
@@ -1,10 +1,8 @@
 module AstFormatting exposing (rule)
 
-import Elm.Syntax.Expression as Expression exposing (Expression, RecordSetter)
+import Elm.Syntax.Expression as Expression exposing (Expression)
 import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Range exposing (Range)
-import Elm.Writer
-import Review.Fix exposing (Fix)
+import Review.Fix
 import Review.Rule as Rule exposing (Error, Rule)
 
 
@@ -36,40 +34,5 @@ expressionVisitor node =
             else
                 []
 
-        Expression.RecordExpr recordSetters ->
-            case recordSetters of
-                [ Node _ ( Node _ "end", _ ), Node _ ( Node _ "start", _ ) ] ->
-                    [ Rule.errorWithFix
-                        { message = "Writing a node range is more readable from the start"
-                        , details =
-                            [ "If like me you have the bad habit of copying nodes from test outputs, this rule will cover for you." ]
-                        }
-                        (Node.range node)
-                        [ fixWithFlippedOrder (Node.range node) recordSetters ]
-                    ]
-
-                [ Node _ ( Node _ "column", _ ), Node _ ( Node _ "row", _ ) ] ->
-                    [ Rule.errorWithFix
-                        { message = "Writing a Location is more readable with the row first"
-                        , details =
-                            [ "If like me you have the bad habit of copying locations from test outputs, this rule will cover for you." ]
-                        }
-                        (Node.range node)
-                        [ fixWithFlippedOrder (Node.range node) recordSetters ]
-                    ]
-
-                _ ->
-                    []
-
         _ ->
             []
-
-
-fixWithFlippedOrder : Range -> List (Node RecordSetter) -> Fix
-fixWithFlippedOrder range =
-    List.reverse
-        >> Expression.RecordExpr
-        >> Node.empty
-        >> Elm.Writer.writeExpression
-        >> Elm.Writer.write
-        >> Review.Fix.replaceRangeBy range

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -26,6 +26,7 @@ import NoMissingTypeAnnotationInLetIn
 import NoMissingTypeExpose
 import NoPrematureLetComputation
 import NoSimpleLetBody
+import NoUnsortedRecords
 import NoUnused.CustomTypeConstructorArgs
 import NoUnused.CustomTypeConstructors
 import NoUnused.Dependencies
@@ -76,4 +77,5 @@ config =
     , NoUnused.Variables.rule
     , Simplify.rule Simplify.defaults
     , OrderedRanges.rule
+    , NoUnsortedRecords.rule NoUnsortedRecords.defaults
     ]

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -34,7 +34,7 @@ import NoUnused.Exports exposing (annotatedBy)
 import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
-import OrderedRanges
+import AstFormatting
 import Review.Rule as Rule exposing (Rule)
 import Simplify
 
@@ -76,6 +76,6 @@ config =
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule
     , Simplify.rule Simplify.defaults
-    , OrderedRanges.rule
+    , AstFormatting.rule
     , NoUnsortedRecords.rule NoUnsortedRecords.defaults
     ]

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -11,6 +11,7 @@ when inside the directory containing this file.
 
 -}
 
+import AstFormatting
 import Docs.NoMissing exposing (exposedModules, onlyExposed)
 import Docs.ReviewAtDocs
 import Docs.ReviewLinksAndSections
@@ -34,7 +35,6 @@ import NoUnused.Exports exposing (annotatedBy)
 import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
-import AstFormatting
 import Review.Rule as Rule exposing (Rule)
 import Simplify
 

--- a/src/Elm/Parser/Expose.elm
+++ b/src/Elm/Parser/Expose.elm
@@ -61,9 +61,9 @@ infixExpose =
     Core.succeed InfixExpose
         |. Tokens.parensStart
         |= Core.variable
-            { start = \c -> c /= ')'
-            , inner = \c -> c /= ')'
+            { inner = \c -> c /= ')'
             , reserved = Set.empty
+            , start = \c -> c /= ')'
             }
         |. Tokens.parensEnd
 

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -27,9 +27,9 @@ layout =
     Combine.many1Ignore
         (Combine.oneOf
             ((Core.variable
-                { start = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
-                , inner = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
+                { inner = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
                 , reserved = Set.empty
+                , start = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
                 }
                 |> Combine.fromCoreMap (\_ -> ())
              )
@@ -53,9 +53,9 @@ optimisticLayout =
     Combine.manyIgnore
         (Combine.oneOf
             ((Core.variable
-                { start = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
-                , inner = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
+                { inner = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
                 , reserved = Set.empty
+                , start = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
                 }
                 |> Combine.fromCoreMap (\_ -> ())
              )
@@ -88,9 +88,9 @@ layoutStrict =
     Combine.many1Ignore
         (Combine.oneOf
             ((Core.variable
-                { start = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
-                , inner = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
+                { inner = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
                 , reserved = Set.empty
+                , start = \c -> c == ' ' || c == '\n' || c == '\u{000D}'
                 }
                 |> Combine.fromCoreMap (\_ -> ())
              )

--- a/src/Elm/Parser/Numbers.elm
+++ b/src/Elm/Parser/Numbers.elm
@@ -6,11 +6,11 @@ import Parser as Core
 raw : Maybe (Float -> a) -> (Int -> a) -> (Int -> a) -> Core.Parser a
 raw floatf intf hexf =
     Core.number
-        { int = Just intf
-        , hex = Just hexf
-        , octal = Nothing
-        , binary = Nothing
+        { binary = Nothing
         , float = floatf
+        , hex = Just hexf
+        , int = Just intf
+        , octal = Nothing
         }
 
 

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -143,9 +143,9 @@ escapedCharValue =
             )
             |. Core.symbol "u{"
             |= Core.variable
-                { start = Char.isHexDigit
-                , inner = Char.isHexDigit
+                { inner = Char.isHexDigit
                 , reserved = Set.empty
+                , start = Char.isHexDigit
                 }
             |. Core.symbol "}"
         ]
@@ -215,24 +215,24 @@ multiLineStringLiteralStep stringSoFar =
 functionName : Core.Parser String
 functionName =
     Core.variable
-        { start = \c -> Char.isLower c || Unicode.isLower c
-        , inner =
+        { inner =
             \c ->
                 -- checking for Char.isAlphaNum early is much faster
                 Char.isAlphaNum c || c == '_' || Unicode.isAlphaNum c
         , reserved = reservedList
+        , start = \c -> Char.isLower c || Unicode.isLower c
         }
 
 
 typeName : Core.Parser String
 typeName =
     Core.variable
-        { start = \c -> Char.isUpper c || Unicode.isUpper c
-        , inner =
+        { inner =
             \c ->
                 -- checking for Char.isAlphaNum early is much faster
                 Char.isAlphaNum c || c == '_' || Unicode.isAlphaNum c
         , reserved = Set.empty
+        , start = \c -> Char.isUpper c || Unicode.isUpper c
         }
 
 

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -414,7 +414,7 @@ encodeDestructuring pattern expression =
 
 
 encodeCaseBlock : CaseBlock -> Value
-encodeCaseBlock { cases, expression } =
+encodeCaseBlock { expression, cases } =
     JE.object
         [ ( "cases", JE.list encodeCase cases )
         , ( "expression", Node.encode encode expression )

--- a/tests/Elm/Parser/CaseExpressionTests.elm
+++ b/tests/Elm/Parser/CaseExpressionTests.elm
@@ -109,7 +109,8 @@ True -> 1"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 2, column = 21 } }
                             (CaseExpression
-                                { cases =
+                                { expression = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (FunctionOrValue [] "x")
+                                , cases =
                                     [ ( Node { start = { row = 1, column = 11 }, end = { row = 1, column = 15 } } (NamedPattern { moduleName = [], name = "True" } [])
                                       , Node { start = { row = 1, column = 19 }, end = { row = 1, column = 20 } } (Integer 1)
                                       )
@@ -117,7 +118,6 @@ True -> 1"""
                                       , Node { start = { row = 2, column = 20 }, end = { row = 2, column = 21 } } (Integer 2)
                                       )
                                     ]
-                                , expression = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (FunctionOrValue [] "x")
                                 }
                             )
                         )
@@ -176,7 +176,8 @@ True -> 1"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 6, column = 6 } }
                             (CaseExpression
-                                { cases =
+                                { expression = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 9 } } (FunctionOrValue [] "msg")
+                                , cases =
                                     [ ( Node { start = { row = 2, column = 3 }, end = { row = 2, column = 12 } } (NamedPattern { moduleName = [], name = "Increment" } [])
                                       , Node { start = { row = 3, column = 5 }, end = { row = 3, column = 6 } } (Integer 1)
                                       )
@@ -184,7 +185,6 @@ True -> 1"""
                                       , Node { start = { row = 6, column = 5 }, end = { row = 6, column = 6 } } (Integer 2)
                                       )
                                     ]
-                                , expression = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 9 } } (FunctionOrValue [] "msg")
                                 }
                             )
                         )

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -21,14 +21,14 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } }
                                         { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } "foo"
                                         , arguments = []
                                         , expression = Node { start = { row = 1, column = 7 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "bar")
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -39,14 +39,14 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 2, column = 10 } }
                             (FunctionDeclaration
-                                { declaration =
-                                    Node { start = { row = 2, column = 1 }, end = { row = 2, column = 10 } }
-                                        { arguments = []
-                                        , expression = Node { start = { row = 2, column = 7 }, end = { row = 2, column = 10 } } (FunctionOrValue [] "bar")
-                                        , name = Node { start = { row = 2, column = 1 }, end = { row = 2, column = 4 } } "foo"
-                                        }
-                                , documentation = Just (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 20 } } "{-| Foo does bar -}")
+                                { documentation = Just (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 20 } } "{-| Foo does bar -}")
                                 , signature = Nothing
+                                , declaration =
+                                    Node { start = { row = 2, column = 1 }, end = { row = 2, column = 10 } }
+                                        { name = Node { start = { row = 2, column = 1 }, end = { row = 2, column = 4 } } "foo"
+                                        , arguments = []
+                                        , expression = Node { start = { row = 2, column = 7 }, end = { row = 2, column = 10 } } (FunctionOrValue [] "bar")
+                                        }
                                 }
                             )
                         )
@@ -60,8 +60,8 @@ foo = bar"""
                                 , signature = Nothing
                                 , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 1, column = 9 } }
-                                        { arguments = []
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } "foo"
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } "foo"
+                                        , arguments = []
                                         , expression = Node { start = { row = 1, column = 7 }, end = { row = 1, column = 9 } } (RecordExpr [])
                                         }
                                 }
@@ -164,33 +164,33 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 5, column = 4 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 5, column = 4 } }
-                                        { arguments = []
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } "foo"
+                                        , arguments = []
                                         , expression =
                                             Node { start = { row = 2, column = 2 }, end = { row = 5, column = 4 } }
                                                 (LetExpression
                                                     { declarations =
                                                         [ Node { start = { row = 3, column = 3 }, end = { row = 3, column = 8 } }
                                                             (LetFunction
-                                                                { declaration =
-                                                                    Node { start = { row = 3, column = 3 }, end = { row = 3, column = 8 } }
-                                                                        { arguments = []
-                                                                        , expression = Node { start = { row = 3, column = 7 }, end = { row = 3, column = 8 } } (Integer 1)
-                                                                        , name = Node { start = { row = 3, column = 3 }, end = { row = 3, column = 4 } } "b"
-                                                                        }
-                                                                , documentation = Nothing
+                                                                { documentation = Nothing
                                                                 , signature = Nothing
+                                                                , declaration =
+                                                                    Node { start = { row = 3, column = 3 }, end = { row = 3, column = 8 } }
+                                                                        { name = Node { start = { row = 3, column = 3 }, end = { row = 3, column = 4 } } "b"
+                                                                        , arguments = []
+                                                                        , expression = Node { start = { row = 3, column = 7 }, end = { row = 3, column = 8 } } (Integer 1)
+                                                                        }
                                                                 }
                                                             )
                                                         ]
                                                     , expression = Node { start = { row = 5, column = 3 }, end = { row = 5, column = 4 } } (FunctionOrValue [] "b")
                                                     }
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } "foo"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -212,9 +212,12 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 5, column = 4 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 5, column = 4 } }
-                                        { arguments = []
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } "foo"
+                                        , arguments = []
                                         , expression =
                                             Node { start = { row = 2, column = 2 }, end = { row = 5, column = 4 } }
                                                 (LetExpression
@@ -240,10 +243,7 @@ foo = bar"""
                                                     , expression = Node { start = { row = 5, column = 3 }, end = { row = 5, column = 4 } } (FunctionOrValue [] "b")
                                                     }
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } } "foo"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -254,9 +254,12 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 2, column = 62 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 2, column = 62 } }
-                                        { arguments = []
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
+                                        , arguments = []
                                         , expression =
                                             Node { start = { row = 2, column = 3 }, end = { row = 2, column = 62 } }
                                                 (Application
@@ -279,10 +282,7 @@ foo = bar"""
                                                         )
                                                     ]
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -298,16 +298,20 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 7, column = 16 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 7, column = 16 } }
-                                        { arguments =
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } } "update"
+                                        , arguments =
                                             [ Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } (VarPattern "msg")
                                             , Node { start = { row = 1, column = 12 }, end = { row = 1, column = 17 } } (VarPattern "model")
                                             ]
                                         , expression =
                                             Node { start = { row = 2, column = 3 }, end = { row = 7, column = 16 } }
                                                 (CaseExpression
-                                                    { cases =
+                                                    { expression = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } (FunctionOrValue [] "msg")
+                                                    , cases =
                                                         [ ( Node { start = { row = 3, column = 5 }, end = { row = 3, column = 14 } } (NamedPattern { moduleName = [], name = "Increment" } [])
                                                           , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
                                                                 (OperatorApplication "+"
@@ -325,13 +329,9 @@ foo = bar"""
                                                                 )
                                                           )
                                                         ]
-                                                    , expression = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } (FunctionOrValue [] "msg")
                                                     }
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } } "update"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -405,9 +405,12 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 2, column = 23 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 2, column = 23 } }
-                                        { arguments = []
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
+                                        , arguments = []
                                         , expression =
                                             Node { start = { row = 2, column = 3 }, end = { row = 2, column = 23 } }
                                                 (Application
@@ -415,10 +418,7 @@ foo = bar"""
                                                     , Node { start = { row = 2, column = 8 }, end = { row = 2, column = 23 } } (Literal "Hello, World!")
                                                     ]
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -429,9 +429,12 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 2, column = 23 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 2, column = 23 } }
-                                        { arguments = []
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
+                                        , arguments = []
                                         , expression =
                                             Node { start = { row = 2, column = 3 }, end = { row = 2, column = 23 } }
                                                 (Application
@@ -439,10 +442,7 @@ foo = bar"""
                                                     , Node { start = { row = 2, column = 8 }, end = { row = 2, column = 23 } } (Literal "Hello, World!")
                                                     ]
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -458,9 +458,9 @@ foo = bar"""
                                     , signature = Nothing
                                     , declaration =
                                         Node { start = { row = 1, column = 1 }, end = { row = 2, column = 12 } }
-                                            { arguments = []
+                                            { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
+                                            , arguments = []
                                             , expression = Node { start = { row = 2, column = 11 }, end = { row = 2, column = 12 } } (FunctionOrValue [] "x")
-                                            , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 5 } } "main"
                                             }
                                     }
                                 )
@@ -472,9 +472,12 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 83 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 1, column = 83 } }
-                                        { arguments = [ Node { start = { row = 1, column = 13 }, end = { row = 1, column = 19 } } (VarPattern "update"), Node { start = { row = 1, column = 20 }, end = { row = 1, column = 28 } } (VarPattern "sendPort") ]
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 12 } } "updateState"
+                                        , arguments = [ Node { start = { row = 1, column = 13 }, end = { row = 1, column = 19 } } (VarPattern "update"), Node { start = { row = 1, column = 20 }, end = { row = 1, column = 28 } } (VarPattern "sendPort") ]
                                         , expression =
                                             Node { start = { row = 1, column = 31 }, end = { row = 1, column = 83 } }
                                                 (OperatorApplication "<|"
@@ -504,10 +507,7 @@ foo = bar"""
                                                         )
                                                     )
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 12 } } "updateState"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -523,16 +523,20 @@ foo = bar"""
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 7, column = 16 } }
                             (FunctionDeclaration
-                                { declaration =
+                                { documentation = Nothing
+                                , signature = Nothing
+                                , declaration =
                                     Node { start = { row = 1, column = 1 }, end = { row = 7, column = 16 } }
-                                        { arguments =
+                                        { name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } } "update"
+                                        , arguments =
                                             [ Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } (VarPattern "msg")
                                             , Node { start = { row = 1, column = 12 }, end = { row = 1, column = 17 } } (VarPattern "model")
                                             ]
                                         , expression =
                                             Node { start = { row = 2, column = 3 }, end = { row = 7, column = 16 } }
                                                 (CaseExpression
-                                                    { cases =
+                                                    { expression = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } (FunctionOrValue [] "msg")
+                                                    , cases =
                                                         [ ( Node { start = { row = 3, column = 5 }, end = { row = 3, column = 14 } } (NamedPattern { moduleName = [], name = "Increment" } [])
                                                           , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
                                                                 (OperatorApplication "+"
@@ -550,13 +554,9 @@ foo = bar"""
                                                                 )
                                                           )
                                                         ]
-                                                    , expression = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } (FunctionOrValue [] "msg")
                                                     }
                                                 )
-                                        , name = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } } "update"
                                         }
-                                , documentation = Nothing
-                                , signature = Nothing
                                 }
                             )
                         )
@@ -568,16 +568,7 @@ update msg model =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 3, column = 8 } }
                             (FunctionDeclaration
-                                { declaration =
-                                    Node { start = { row = 2, column = 1 }, end = { row = 3, column = 8 } }
-                                        { arguments =
-                                            [ Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } (VarPattern "msg")
-                                            , Node { start = { row = 2, column = 12 }, end = { row = 2, column = 17 } } (VarPattern "model")
-                                            ]
-                                        , expression = Node { start = { row = 3, column = 5 }, end = { row = 3, column = 8 } } (FunctionOrValue [] "msg")
-                                        , name = Node { start = { row = 2, column = 1 }, end = { row = 2, column = 7 } } "update"
-                                        }
-                                , documentation = Nothing
+                                { documentation = Nothing
                                 , signature =
                                     Just
                                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 15 } }
@@ -585,6 +576,15 @@ update msg model =
                                             , typeAnnotation = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 15 } } (Typed (Node { start = { row = 1, column = 10 }, end = { row = 1, column = 15 } } ( [], "Model" )) [])
                                             }
                                         )
+                                , declaration =
+                                    Node { start = { row = 2, column = 1 }, end = { row = 3, column = 8 } }
+                                        { name = Node { start = { row = 2, column = 1 }, end = { row = 2, column = 7 } } "update"
+                                        , arguments =
+                                            [ Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } (VarPattern "msg")
+                                            , Node { start = { row = 2, column = 12 }, end = { row = 2, column = 17 } } (VarPattern "model")
+                                            ]
+                                        , expression = Node { start = { row = 3, column = 5 }, end = { row = 3, column = 8 } } (FunctionOrValue [] "msg")
+                                        }
                                 }
                             )
                         )

--- a/tests/Elm/Parser/ExposeTests.elm
+++ b/tests/Elm/Parser/ExposeTests.elm
@@ -21,8 +21,8 @@ all =
   .. -- foo
   )"""
                     |> expectAstWithComments
-                        { comments = [ Node { start = { row = 2, column = 6 }, end = { row = 2, column = 12 } } "-- foo" ]
-                        , ast = All { start = { row = 2, column = 3 }, end = { row = 3, column = 3 } }
+                        { ast = All { start = { row = 2, column = 3 }, end = { row = 3, column = 3 } }
+                        , comments = [ Node { start = { row = 2, column = 6 }, end = { row = 2, column = 12 } } "-- foo" ]
                         }
         , test "should fail to parse multi-line exposing all when closing parens is at the end of a line" <|
             \() ->
@@ -117,12 +117,12 @@ all =
             \() ->
                 "exposing (foo\n --bar\n )"
                     |> expectAstWithComments
-                        { comments = [ Node { start = { row = 2, column = 2 }, end = { row = 2, column = 7 } } "--bar" ]
-                        , ast =
+                        { ast =
                             Explicit
                                 [ Node { start = { row = 1, column = 11 }, end = { row = 1, column = 14 } }
                                     (FunctionExpose "foo")
                                 ]
+                        , comments = [ Node { start = { row = 2, column = 2 }, end = { row = 2, column = 7 } } "--bar" ]
                         }
         ]
 

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -131,24 +131,27 @@ caseWhitespace f = case f   of
                             { moduleDefinition =
                                 Node { start = { row = 2, column = 1 }, end = { row = 2, column = 41 } }
                                     (NormalModule
-                                        { exposingList =
+                                        { moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 27 } } [ "Trailing", "Whitespace" ]
+                                        , exposingList =
                                             Node { start = { row = 2, column = 28 }, end = { row = 2, column = 41 } }
                                                 (All { start = { row = 2, column = 38 }, end = { row = 2, column = 40 } })
-                                        , moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 27 } } [ "Trailing", "Whitespace" ]
                                         }
                                     )
-                            , comments = [ Node { start = { row = 13, column = 4 }, end = { row = 13, column = 18 } } "--some comment" ]
                             , imports = []
                             , declarations =
                                 [ Node { start = { row = 4, column = 1 }, end = { row = 11, column = 11 } }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Nothing
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 4, column = 1 }, end = { row = 11, column = 11 } }
-                                                { arguments = [ Node { start = { row = 4, column = 16 }, end = { row = 4, column = 17 } } (VarPattern "f") ]
+                                                { name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 15 } } "caseWhitespace"
+                                                , arguments = [ Node { start = { row = 4, column = 16 }, end = { row = 4, column = 17 } } (VarPattern "f") ]
                                                 , expression =
                                                     Node { start = { row = 4, column = 20 }, end = { row = 11, column = 11 } }
                                                         (CaseExpression
-                                                            { cases =
+                                                            { expression = Node { start = { row = 4, column = 25 }, end = { row = 4, column = 26 } } (FunctionOrValue [] "f")
+                                                            , cases =
                                                                 [ ( Node { start = { row = 5, column = 3 }, end = { row = 5, column = 7 } } (NamedPattern { moduleName = [], name = "True" } [])
                                                                   , Node { start = { row = 6, column = 5 }, end = { row = 6, column = 6 } } (Integer 1)
                                                                   )
@@ -156,16 +159,13 @@ caseWhitespace f = case f   of
                                                                   , Node { start = { row = 11, column = 10 }, end = { row = 11, column = 11 } } (Integer 2)
                                                                   )
                                                                 ]
-                                                            , expression = Node { start = { row = 4, column = 25 }, end = { row = 4, column = 26 } } (FunctionOrValue [] "f")
                                                             }
                                                         )
-                                                , name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 15 } } "caseWhitespace"
                                                 }
-                                        , documentation = Nothing
-                                        , signature = Nothing
                                         }
                                     )
                                 ]
+                            , comments = [ Node { start = { row = 13, column = 4 }, end = { row = 13, column = 18 } } "--some comment" ]
                             }
                         )
         , test "function declaration with lambda and trailing whitespace" <|
@@ -189,20 +189,22 @@ lambdaWhitespace =   \\ a b ->    a
                             { moduleDefinition =
                                 Node { start = { row = 2, column = 1 }, end = { row = 2, column = 41 } }
                                     (NormalModule
-                                        { exposingList =
+                                        { moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 27 } } [ "Trailing", "Whitespace" ]
+                                        , exposingList =
                                             Node { start = { row = 2, column = 28 }, end = { row = 2, column = 41 } }
                                                 (All { start = { row = 2, column = 38 }, end = { row = 2, column = 40 } })
-                                        , moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 27 } } [ "Trailing", "Whitespace" ]
                                         }
                                     )
-                            , comments = [ Node { start = { row = 11, column = 1 }, end = { row = 11, column = 15 } } "--some comment" ]
                             , imports = []
                             , declarations =
                                 [ Node { start = { row = 4, column = 1 }, end = { row = 8, column = 6 } }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Nothing
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 4, column = 1 }, end = { row = 8, column = 6 } }
-                                                { arguments = []
+                                                { name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 17 } } "lambdaWhitespace"
+                                                , arguments = []
                                                 , expression =
                                                     Node { start = { row = 4, column = 22 }, end = { row = 8, column = 6 } }
                                                         (LambdaExpression
@@ -219,13 +221,11 @@ lambdaWhitespace =   \\ a b ->    a
                                                                     )
                                                             }
                                                         )
-                                                , name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 17 } } "lambdaWhitespace"
                                                 }
-                                        , documentation = Nothing
-                                        , signature = Nothing
                                         }
                                     )
                                 ]
+                            , comments = [ Node { start = { row = 11, column = 1 }, end = { row = 11, column = 15 } } "--some comment" ]
                             }
                         )
         , test "function declaration with let and trailing whitespace" <|
@@ -249,47 +249,47 @@ letWhitespace = let
                             { moduleDefinition =
                                 Node { start = { row = 2, column = 1 }, end = { row = 2, column = 41 } }
                                     (NormalModule
-                                        { exposingList =
+                                        { moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 27 } } [ "Trailing", "Whitespace" ]
+                                        , exposingList =
                                             Node { start = { row = 2, column = 28 }, end = { row = 2, column = 41 } }
                                                 (All { start = { row = 2, column = 38 }, end = { row = 2, column = 40 } })
-                                        , moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 27 } } [ "Trailing", "Whitespace" ]
                                         }
                                     )
-                            , comments = [ Node { start = { row = 11, column = 1 }, end = { row = 11, column = 15 } } "--some comment" ]
                             , imports = []
                             , declarations =
                                 [ Node { start = { row = 4, column = 1 }, end = { row = 8, column = 3 } }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Nothing
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 4, column = 1 }, end = { row = 8, column = 3 } }
-                                                { arguments = []
+                                                { name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 14 } } "letWhitespace"
+                                                , arguments = []
                                                 , expression =
                                                     Node { start = { row = 4, column = 17 }, end = { row = 8, column = 3 } }
                                                         (LetExpression
                                                             { declarations =
                                                                 [ Node { start = { row = 5, column = 19 }, end = { row = 5, column = 26 } }
                                                                     (LetFunction
-                                                                        { declaration =
-                                                                            Node { start = { row = 5, column = 19 }, end = { row = 5, column = 26 } }
-                                                                                { arguments = []
-                                                                                , expression = Node { start = { row = 5, column = 25 }, end = { row = 5, column = 26 } } (Integer 1)
-                                                                                , name = Node { start = { row = 5, column = 19 }, end = { row = 5, column = 20 } } "b"
-                                                                                }
-                                                                        , documentation = Nothing
+                                                                        { documentation = Nothing
                                                                         , signature = Nothing
+                                                                        , declaration =
+                                                                            Node { start = { row = 5, column = 19 }, end = { row = 5, column = 26 } }
+                                                                                { name = Node { start = { row = 5, column = 19 }, end = { row = 5, column = 20 } } "b"
+                                                                                , arguments = []
+                                                                                , expression = Node { start = { row = 5, column = 25 }, end = { row = 5, column = 26 } } (Integer 1)
+                                                                                }
                                                                         }
                                                                     )
                                                                 ]
                                                             , expression = Node { start = { row = 8, column = 2 }, end = { row = 8, column = 3 } } (FunctionOrValue [] "b")
                                                             }
                                                         )
-                                                , name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 14 } } "letWhitespace"
                                                 }
-                                        , documentation = Nothing
-                                        , signature = Nothing
                                         }
                                     )
                                 ]
+                            , comments = [ Node { start = { row = 11, column = 1 }, end = { row = 11, column = 15 } } "--some comment" ]
                             }
                         )
         , test "type declaration with documentation after imports" <|
@@ -307,38 +307,38 @@ type Configuration
                     |> Elm.Parser.parseToFile
                     |> Expect.equal
                         (Ok
-                            { comments = []
+                            { moduleDefinition =
+                                Node { start = { row = 2, column = 1 }, end = { row = 2, column = 25 } }
+                                    (NormalModule
+                                        { moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } [ "Foo" ]
+                                        , exposingList =
+                                            Node { start = { row = 2, column = 12 }, end = { row = 2, column = 25 } }
+                                                (All { start = { row = 2, column = 22 }, end = { row = 2, column = 24 } })
+                                        }
+                                    )
+                            , imports =
+                                [ Node { start = { row = 4, column = 1 }, end = { row = 4, column = 12 } }
+                                    { moduleName = Node { start = { row = 4, column = 8 }, end = { row = 4, column = 12 } } [ "Dict" ]
+                                    , moduleAlias = Nothing
+                                    , exposingList = Nothing
+                                    }
+                                ]
                             , declarations =
                                 [ Node { start = { row = 6, column = 1 }, end = { row = 9, column = 20 } }
                                     (CustomTypeDeclaration
-                                        { constructors =
+                                        { documentation = Just (Node { start = { row = 6, column = 1 }, end = { row = 7, column = 3 } } "{-| Config goes here\n-}")
+                                        , name = Node { start = { row = 8, column = 6 }, end = { row = 8, column = 19 } } "Configuration"
+                                        , generics = []
+                                        , constructors =
                                             [ Node { start = { row = 9, column = 7 }, end = { row = 9, column = 20 } }
-                                                { arguments = []
-                                                , name = Node { start = { row = 9, column = 7 }, end = { row = 9, column = 20 } } "Configuration"
+                                                { name = Node { start = { row = 9, column = 7 }, end = { row = 9, column = 20 } } "Configuration"
+                                                , arguments = []
                                                 }
                                             ]
-                                        , documentation = Just (Node { start = { row = 6, column = 1 }, end = { row = 7, column = 3 } } "{-| Config goes here\n-}")
-                                        , generics = []
-                                        , name = Node { start = { row = 8, column = 6 }, end = { row = 8, column = 19 } } "Configuration"
                                         }
                                     )
                                 ]
-                            , imports =
-                                [ Node { start = { row = 4, column = 1 }, end = { row = 4, column = 12 } }
-                                    { exposingList = Nothing
-                                    , moduleAlias = Nothing
-                                    , moduleName = Node { start = { row = 4, column = 8 }, end = { row = 4, column = 12 } } [ "Dict" ]
-                                    }
-                                ]
-                            , moduleDefinition =
-                                Node { start = { row = 2, column = 1 }, end = { row = 2, column = 25 } }
-                                    (NormalModule
-                                        { exposingList =
-                                            Node { start = { row = 2, column = 12 }, end = { row = 2, column = 25 } }
-                                                (All { start = { row = 2, column = 22 }, end = { row = 2, column = 24 } })
-                                        , moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } [ "Foo" ]
-                                        }
-                                    )
+                            , comments = []
                             }
                         )
         , test "module documentation formatted like a type documentation" <|
@@ -354,32 +354,32 @@ type Configuration
                     |> Elm.Parser.parseToFile
                     |> Expect.equal
                         (Ok
-                            { comments = [ Node { start = { row = 4, column = 1 }, end = { row = 5, column = 3 } } "{-| actually module doc\n-}" ]
+                            { moduleDefinition =
+                                Node { start = { row = 2, column = 1 }, end = { row = 2, column = 25 } }
+                                    (NormalModule
+                                        { moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } [ "Foo" ]
+                                        , exposingList =
+                                            Node { start = { row = 2, column = 12 }, end = { row = 2, column = 25 } }
+                                                (All { start = { row = 2, column = 22 }, end = { row = 2, column = 24 } })
+                                        }
+                                    )
+                            , imports = []
                             , declarations =
                                 [ Node { start = { row = 6, column = 1 }, end = { row = 7, column = 20 } }
                                     (CustomTypeDeclaration
-                                        { constructors =
+                                        { documentation = Nothing
+                                        , name = Node { start = { row = 6, column = 6 }, end = { row = 6, column = 19 } } "Configuration"
+                                        , generics = []
+                                        , constructors =
                                             [ Node { start = { row = 7, column = 7 }, end = { row = 7, column = 20 } }
-                                                { arguments = []
-                                                , name = Node { start = { row = 7, column = 7 }, end = { row = 7, column = 20 } } "Configuration"
+                                                { name = Node { start = { row = 7, column = 7 }, end = { row = 7, column = 20 } } "Configuration"
+                                                , arguments = []
                                                 }
                                             ]
-                                        , documentation = Nothing
-                                        , generics = []
-                                        , name = Node { start = { row = 6, column = 6 }, end = { row = 6, column = 19 } } "Configuration"
                                         }
                                     )
                                 ]
-                            , imports = []
-                            , moduleDefinition =
-                                Node { start = { row = 2, column = 1 }, end = { row = 2, column = 25 } }
-                                    (NormalModule
-                                        { exposingList =
-                                            Node { start = { row = 2, column = 12 }, end = { row = 2, column = 25 } }
-                                                (All { start = { row = 2, column = 22 }, end = { row = 2, column = 24 } })
-                                        , moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 11 } } [ "Foo" ]
-                                        }
-                                    )
+                            , comments = [ Node { start = { row = 4, column = 1 }, end = { row = 5, column = 3 } } "{-| actually module doc\n-}" ]
                             }
                         )
         , test "documentation on a port declaration is treated as a normal comment" <|
@@ -396,7 +396,22 @@ port sendResponse : String -> Cmd msg
                     |> Elm.Parser.parseToFile
                     |> Expect.equal
                         (Ok
-                            { comments = [ Node { start = { row = 6, column = 1 }, end = { row = 7, column = 3 } } "{-| foo\n-}" ]
+                            { moduleDefinition =
+                                Node { start = { row = 2, column = 1 }, end = { row = 2, column = 30 } }
+                                    (PortModule
+                                        { moduleName = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 16 } } [ "Foo" ]
+                                        , exposingList =
+                                            Node { start = { row = 2, column = 17 }, end = { row = 2, column = 30 } }
+                                                (All { start = { row = 2, column = 27 }, end = { row = 2, column = 29 } })
+                                        }
+                                    )
+                            , imports =
+                                [ Node { start = { row = 4, column = 1 }, end = { row = 4, column = 14 } }
+                                    { moduleName = Node { start = { row = 4, column = 8 }, end = { row = 4, column = 14 } } [ "String" ]
+                                    , moduleAlias = Nothing
+                                    , exposingList = Nothing
+                                    }
+                                ]
                             , declarations =
                                 [ Node { start = { row = 8, column = 1 }, end = { row = 8, column = 38 } }
                                     (PortDeclaration
@@ -416,22 +431,7 @@ port sendResponse : String -> Cmd msg
                                         }
                                     )
                                 ]
-                            , imports =
-                                [ Node { start = { row = 4, column = 1 }, end = { row = 4, column = 14 } }
-                                    { exposingList = Nothing
-                                    , moduleAlias = Nothing
-                                    , moduleName = Node { start = { row = 4, column = 8 }, end = { row = 4, column = 14 } } [ "String" ]
-                                    }
-                                ]
-                            , moduleDefinition =
-                                Node { start = { row = 2, column = 1 }, end = { row = 2, column = 30 } }
-                                    (PortModule
-                                        { exposingList =
-                                            Node { start = { row = 2, column = 17 }, end = { row = 2, column = 30 } }
-                                                (All { start = { row = 2, column = 27 }, end = { row = 2, column = 29 } })
-                                        , moduleName = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 16 } } [ "Foo" ]
-                                        }
-                                    )
+                            , comments = [ Node { start = { row = 6, column = 1 }, end = { row = 7, column = 3 } } "{-| foo\n-}" ]
                             }
                         )
         ]

--- a/tests/Elm/Parser/ImportsTests.elm
+++ b/tests/Elm/Parser/ImportsTests.elm
@@ -17,15 +17,15 @@ all =
                 "import Foo exposing (Model, Msg(..))"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 37 } }
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
+                            , moduleAlias = Nothing
+                            , exposingList =
                                 Just
                                     (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 37 } }
                                         (Explicit
                                             [ Node { start = { row = 1, column = 22 }, end = { row = 1, column = 27 } } (TypeOrAliasExpose "Model"), Node { start = { row = 1, column = 29 }, end = { row = 1, column = 36 } } (TypeExpose { name = "Msg", open = Just { start = { row = 1, column = 32 }, end = { row = 1, column = 36 } } }) ]
                                         )
                                     )
-                            , moduleAlias = Nothing
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
                             }
                         )
         , test "import with explicits 2" <|
@@ -33,15 +33,15 @@ all =
                 "import Html exposing (text)"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 28 } }
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 12 } } [ "Html" ]
+                            , moduleAlias = Nothing
+                            , exposingList =
                                 Just
                                     (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 28 } }
                                         (Explicit
                                             [ Node { start = { row = 1, column = 23 }, end = { row = 1, column = 27 } } (FunctionExpose "text") ]
                                         )
                                     )
-                            , moduleAlias = Nothing
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 12 } } [ "Html" ]
                             }
                         )
         , test "import minimal" <|
@@ -49,9 +49,9 @@ all =
                 "import Foo"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 11 } }
-                            { exposingList = Nothing
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
                             , moduleAlias = Nothing
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
+                            , exposingList = Nothing
                             }
                         )
         , test "import with alias" <|
@@ -59,9 +59,9 @@ all =
                 "import Foo as Bar"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 18 } }
-                            { exposingList = Nothing
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
                             , moduleAlias = Just (Node { start = { row = 1, column = 15 }, end = { row = 1, column = 18 } } [ "Bar" ])
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
+                            , exposingList = Nothing
                             }
                         )
         , test "import with alias and exposing all" <|
@@ -69,13 +69,13 @@ all =
                 "import Foo as Bar exposing (..)"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 18 } }
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
+                            , moduleAlias = Just (Node { start = { row = 1, column = 15 }, end = { row = 1, column = 18 } } [ "Bar" ])
+                            , exposingList =
                                 Just
                                     (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 32 } }
                                         (All { start = { row = 1, column = 29 }, end = { row = 1, column = 31 } })
                                     )
-                            , moduleAlias = Just (Node { start = { row = 1, column = 15 }, end = { row = 1, column = 18 } } [ "Bar" ])
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
                             }
                         )
         , test "import with invalid alias containing ." <|

--- a/tests/Elm/Parser/InfixTests.elm
+++ b/tests/Elm/Parser/InfixTests.elm
@@ -19,9 +19,9 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 28 } }
                             (Declaration.InfixDeclaration
                                 { direction = Node { start = { row = 1, column = 7 }, end = { row = 1, column = 12 } } Right
-                                , function = Node { start = { row = 1, column = 23 }, end = { row = 1, column = 28 } } "slash"
-                                , operator = Node { start = { row = 1, column = 15 }, end = { row = 1, column = 20 } } "</>"
                                 , precedence = Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } 7
+                                , operator = Node { start = { row = 1, column = 15 }, end = { row = 1, column = 20 } } "</>"
+                                , function = Node { start = { row = 1, column = 23 }, end = { row = 1, column = 28 } } "slash"
                                 }
                             )
                         )
@@ -32,9 +32,9 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 35 } }
                             (Declaration.InfixDeclaration
                                 { direction = Node { start = { row = 1, column = 7 }, end = { row = 1, column = 11 } } Left
-                                , function = Node { start = { row = 1, column = 23 }, end = { row = 1, column = 35 } } "questionMark"
-                                , operator = Node { start = { row = 1, column = 15 }, end = { row = 1, column = 20 } } "<?>"
                                 , precedence = Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } 8
+                                , operator = Node { start = { row = 1, column = 15 }, end = { row = 1, column = 20 } } "<?>"
+                                , function = Node { start = { row = 1, column = 23 }, end = { row = 1, column = 35 } } "questionMark"
                                 }
                             )
                         )
@@ -45,9 +45,9 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 24 } }
                             (Declaration.InfixDeclaration
                                 { direction = Node { start = { row = 1, column = 7 }, end = { row = 1, column = 10 } } Non
-                                , function = Node { start = { row = 1, column = 22 }, end = { row = 1, column = 24 } } "eq"
-                                , operator = Node { start = { row = 1, column = 15 }, end = { row = 1, column = 19 } } "=="
                                 , precedence = Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } 4
+                                , operator = Node { start = { row = 1, column = 15 }, end = { row = 1, column = 19 } } "=="
+                                , function = Node { start = { row = 1, column = 22 }, end = { row = 1, column = 24 } } "eq"
                                 }
                             )
                         )

--- a/tests/Elm/Parser/LetExpressionTests.elm
+++ b/tests/Elm/Parser/LetExpressionTests.elm
@@ -25,26 +25,26 @@ all =
                                 { declarations =
                                     [ Node { start = { row = 2, column = 3 }, end = { row = 2, column = 12 } }
                                         (LetFunction
-                                            { declaration =
-                                                Node { start = { row = 2, column = 3 }, end = { row = 2, column = 12 } }
-                                                    { arguments = []
-                                                    , expression = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 12 } } (FunctionOrValue [] "bar")
-                                                    , name = Node { start = { row = 2, column = 3 }, end = { row = 2, column = 6 } } "foo"
-                                                    }
-                                            , documentation = Nothing
+                                            { documentation = Nothing
                                             , signature = Nothing
+                                            , declaration =
+                                                Node { start = { row = 2, column = 3 }, end = { row = 2, column = 12 } }
+                                                    { name = Node { start = { row = 2, column = 3 }, end = { row = 2, column = 6 } } "foo"
+                                                    , arguments = []
+                                                    , expression = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 12 } } (FunctionOrValue [] "bar")
+                                                    }
                                             }
                                         )
                                     , Node { start = { row = 4, column = 3 }, end = { row = 4, column = 13 } }
                                         (LetFunction
-                                            { declaration =
-                                                Node { start = { row = 4, column = 3 }, end = { row = 4, column = 13 } }
-                                                    { arguments = [ Node { start = { row = 4, column = 8 }, end = { row = 4, column = 9 } } (VarPattern "n") ]
-                                                    , expression = Node { start = { row = 4, column = 12 }, end = { row = 4, column = 13 } } (FunctionOrValue [] "n")
-                                                    , name = Node { start = { row = 4, column = 3 }, end = { row = 4, column = 7 } } "john"
-                                                    }
-                                            , documentation = Nothing
+                                            { documentation = Nothing
                                             , signature = Nothing
+                                            , declaration =
+                                                Node { start = { row = 4, column = 3 }, end = { row = 4, column = 13 } }
+                                                    { name = Node { start = { row = 4, column = 3 }, end = { row = 4, column = 7 } } "john"
+                                                    , arguments = [ Node { start = { row = 4, column = 8 }, end = { row = 4, column = 9 } } (VarPattern "n") ]
+                                                    , expression = Node { start = { row = 4, column = 12 }, end = { row = 4, column = 13 } } (FunctionOrValue [] "n")
+                                                    }
                                             }
                                         )
                                     ]
@@ -64,14 +64,14 @@ all =
                                 { declarations =
                                     [ Node { start = { row = 2, column = 3 }, end = { row = 2, column = 10 } }
                                         (LetFunction
-                                            { declaration =
-                                                Node { start = { row = 2, column = 3 }, end = { row = 2, column = 10 } }
-                                                    { arguments = []
-                                                    , expression = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } (Integer 1)
-                                                    , name = Node { start = { row = 2, column = 3 }, end = { row = 2, column = 6 } } "bar"
-                                                    }
-                                            , documentation = Nothing
+                                            { documentation = Nothing
                                             , signature = Nothing
+                                            , declaration =
+                                                Node { start = { row = 2, column = 3 }, end = { row = 2, column = 10 } }
+                                                    { name = Node { start = { row = 2, column = 3 }, end = { row = 2, column = 6 } } "bar"
+                                                    , arguments = []
+                                                    , expression = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } (Integer 1)
+                                                    }
                                             }
                                         )
                                     ]
@@ -106,14 +106,14 @@ all =
                                 { declarations =
                                     [ Node { start = { row = 2, column = 3 }, end = { row = 2, column = 10 } }
                                         (LetFunction
-                                            { declaration =
-                                                Node { start = { row = 2, column = 3 }, end = { row = 2, column = 10 } }
-                                                    { arguments = []
-                                                    , expression = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } (Integer 1)
-                                                    , name = Node { start = { row = 2, column = 3 }, end = { row = 2, column = 6 } } "bar"
-                                                    }
-                                            , documentation = Nothing
+                                            { documentation = Nothing
                                             , signature = Nothing
+                                            , declaration =
+                                                Node { start = { row = 2, column = 3 }, end = { row = 2, column = 10 } }
+                                                    { name = Node { start = { row = 2, column = 3 }, end = { row = 2, column = 6 } } "bar"
+                                                    , arguments = []
+                                                    , expression = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } (Integer 1)
+                                                    }
                                             }
                                         )
                                     ]
@@ -146,9 +146,9 @@ all =
                                                     )
                                             , declaration =
                                                 Node { start = { row = 3, column = 5 }, end = { row = 3, column = 12 } }
-                                                    { arguments = []
+                                                    { name = Node { start = { row = 3, column = 5 }, end = { row = 3, column = 8 } } "bar"
+                                                    , arguments = []
                                                     , expression = Node { start = { row = 3, column = 11 }, end = { row = 3, column = 12 } } (Integer 1)
-                                                    , name = Node { start = { row = 3, column = 5 }, end = { row = 3, column = 8 } } "bar"
                                                     }
                                             }
                                         )
@@ -182,9 +182,9 @@ all =
                                                     )
                                             , declaration =
                                                 Node { start = { row = 5, column = 5 }, end = { row = 5, column = 12 } }
-                                                    { arguments = []
+                                                    { name = Node { start = { row = 5, column = 5 }, end = { row = 5, column = 8 } } "bar"
+                                                    , arguments = []
                                                     , expression = Node { start = { row = 5, column = 11 }, end = { row = 5, column = 12 } } (Integer 1)
-                                                    , name = Node { start = { row = 5, column = 5 }, end = { row = 5, column = 8 } } "bar"
                                                     }
                                             }
                                         )
@@ -289,9 +289,12 @@ all =
                                 { declarations =
                                     [ Node { start = { row = 1, column = 5 }, end = { row = 1, column = 29 } }
                                         (LetFunction
-                                            { declaration =
+                                            { documentation = Nothing
+                                            , signature = Nothing
+                                            , declaration =
                                                 Node { start = { row = 1, column = 5 }, end = { row = 1, column = 29 } }
-                                                    { arguments = []
+                                                    { name = Node { start = { row = 1, column = 5 }, end = { row = 1, column = 11 } } "indent"
+                                                    , arguments = []
                                                     , expression =
                                                         Node { start = { row = 1, column = 14 }, end = { row = 1, column = 29 } }
                                                             (Application
@@ -299,10 +302,7 @@ all =
                                                                 , Node { start = { row = 1, column = 28 }, end = { row = 1, column = 29 } } (FunctionOrValue [] "s")
                                                                 ]
                                                             )
-                                                    , name = Node { start = { row = 1, column = 5 }, end = { row = 1, column = 11 } } "indent"
                                                     }
-                                            , documentation = Nothing
-                                            , signature = Nothing
                                             }
                                         )
                                     ]
@@ -321,14 +321,14 @@ all =
                                 { declarations =
                                     [ Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
                                         (LetFunction
-                                            { declaration =
-                                                Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
-                                                    { arguments = []
-                                                    , expression = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 14 } } (Integer 1)
-                                                    , name = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } "a"
-                                                    }
-                                            , documentation = Nothing
+                                            { documentation = Nothing
                                             , signature = Nothing
+                                            , declaration =
+                                                Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
+                                                    { name = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } "a"
+                                                    , arguments = []
+                                                    , expression = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 14 } } (Integer 1)
+                                                    }
                                             }
                                         )
                                     ]
@@ -347,14 +347,14 @@ all =
                                 { declarations =
                                     [ Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
                                         (LetFunction
-                                            { declaration =
-                                                Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
-                                                    { arguments = []
-                                                    , expression = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 14 } } (Integer 1)
-                                                    , name = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } "a"
-                                                    }
-                                            , documentation = Nothing
+                                            { documentation = Nothing
                                             , signature = Nothing
+                                            , declaration =
+                                                Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
+                                                    { name = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } "a"
+                                                    , arguments = []
+                                                    , expression = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 14 } } (Integer 1)
+                                                    }
                                             }
                                         )
                                     ]
@@ -373,14 +373,14 @@ all =
                                 { declarations =
                                     [ Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
                                         (LetFunction
-                                            { declaration =
-                                                Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
-                                                    { arguments = []
-                                                    , expression = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 14 } } (Integer 1)
-                                                    , name = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } "a"
-                                                    }
-                                            , documentation = Nothing
+                                            { documentation = Nothing
                                             , signature = Nothing
+                                            , declaration =
+                                                Node { start = { row = 2, column = 9 }, end = { row = 2, column = 14 } }
+                                                    { name = Node { start = { row = 2, column = 9 }, end = { row = 2, column = 10 } } "a"
+                                                    , arguments = []
+                                                    , expression = Node { start = { row = 2, column = 13 }, end = { row = 2, column = 14 } } (Integer 1)
+                                                    }
                                             }
                                         )
                                     ]

--- a/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/Elm/Parser/ModuleTests.elm
@@ -23,13 +23,13 @@ all =
                 "module Foo exposing (Bar)"
                     |> expectAst
                         (NormalModule
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
+                            , exposingList =
                                 Node { start = { row = 1, column = 12 }, end = { row = 1, column = 26 } }
                                     (Explicit
                                         [ Node { start = { row = 1, column = 22 }, end = { row = 1, column = 25 } } (TypeOrAliasExpose "Bar")
                                         ]
                                     )
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
                             }
                         )
         , test "port moduleDefinition" <|
@@ -37,12 +37,12 @@ all =
                 "port module Foo exposing (Bar)"
                     |> expectAst
                         (PortModule
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 13 }, end = { row = 1, column = 16 } } [ "Foo" ]
+                            , exposingList =
                                 Node { start = { row = 1, column = 17 }, end = { row = 1, column = 31 } }
                                     (Explicit
                                         [ Node { start = { row = 1, column = 27 }, end = { row = 1, column = 30 } } (TypeOrAliasExpose "Bar") ]
                                     )
-                            , moduleName = Node { start = { row = 1, column = 13 }, end = { row = 1, column = 16 } } [ "Foo" ]
                             }
                         )
         , test "port moduleDefinition with spacing" <|
@@ -50,12 +50,12 @@ all =
                 "port module Foo exposing ( Bar )"
                     |> expectAst
                         (PortModule
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 13 }, end = { row = 1, column = 16 } } [ "Foo" ]
+                            , exposingList =
                                 Node { start = { row = 1, column = 17 }, end = { row = 1, column = 33 } }
                                     (Explicit
                                         [ Node { start = { row = 1, column = 28 }, end = { row = 1, column = 31 } } (TypeOrAliasExpose "Bar") ]
                                     )
-                            , moduleName = Node { start = { row = 1, column = 13 }, end = { row = 1, column = 16 } } [ "Foo" ]
                             }
                         )
         , test "effect moduleDefinition" <|
@@ -64,9 +64,9 @@ all =
                     |> expectAst
                         (EffectModule
                             { moduleName = Node { start = { row = 1, column = 15 }, end = { row = 1, column = 18 } } [ "Foo" ]
+                            , exposingList = Node { start = { row = 1, column = 66 }, end = { row = 1, column = 80 } } (Explicit [ Node { start = { row = 1, column = 76 }, end = { row = 1, column = 79 } } (TypeOrAliasExpose "Bar") ])
                             , command = Just (Node { start = { row = 1, column = 36 }, end = { row = 1, column = 41 } } "MyCmd")
                             , subscription = Just (Node { start = { row = 1, column = 58 }, end = { row = 1, column = 63 } } "MySub")
-                            , exposingList = Node { start = { row = 1, column = 66 }, end = { row = 1, column = 80 } } (Explicit [ Node { start = { row = 1, column = 76 }, end = { row = 1, column = 79 } } (TypeOrAliasExpose "Bar") ])
                             }
                         )
         , test "unformatted" <|
@@ -74,10 +74,10 @@ all =
                 "module \n Foo \n exposing  (..)"
                     |> expectAst
                         (NormalModule
-                            { exposingList =
+                            { moduleName = Node { start = { row = 2, column = 2 }, end = { row = 2, column = 5 } } [ "Foo" ]
+                            , exposingList =
                                 Node { start = { row = 3, column = 2 }, end = { row = 3, column = 16 } }
                                     (All { start = { row = 3, column = 13 }, end = { row = 3, column = 15 } })
-                            , moduleName = Node { start = { row = 2, column = 2 }, end = { row = 2, column = 5 } } [ "Foo" ]
                             }
                         )
         , test "unformatted wrong" <|
@@ -89,10 +89,10 @@ all =
                 "module Foo exposing (..)"
                     |> expectAst
                         (NormalModule
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
+                            , exposingList =
                                 Node { start = { row = 1, column = 12 }, end = { row = 1, column = 25 } }
                                     (All { start = { row = 1, column = 22 }, end = { row = 1, column = 24 } })
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Foo" ]
                             }
                         )
         , test "module name with _" <|
@@ -100,10 +100,10 @@ all =
                 "module I_en_gb exposing (..)"
                     |> expectAst
                         (NormalModule
-                            { exposingList =
+                            { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 15 } } [ "I_en_gb" ]
+                            , exposingList =
                                 Node { start = { row = 1, column = 16 }, end = { row = 1, column = 29 } }
                                     (All { start = { row = 1, column = 26 }, end = { row = 1, column = 28 } })
-                            , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 15 } } [ "I_en_gb" ]
                             }
                         )
         , test "Regression test for Incorrect range in if expression" <|
@@ -126,13 +126,36 @@ b = 3
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = []
+                            { moduleDefinition =
+                                Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
+                                    (NormalModule
+                                        { moduleName =
+                                            Node
+                                                { start = { row = 1, column = 8 }
+                                                , end = { row = 1, column = 18 }
+                                                }
+                                                [ "TestModule" ]
+                                        , exposingList =
+                                            Node
+                                                { start = { row = 1, column = 19 }
+                                                , end =
+                                                    { row = 1
+                                                    , column = 32
+                                                    }
+                                                }
+                                                (All { start = { row = 1, column = 29 }, end = { row = 1, column = 31 } })
+                                        }
+                                    )
+                            , imports = []
                             , declarations =
                                 [ Node { start = { row = 3, column = 1 }, end = { row = 7, column = 10 } }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Nothing
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 3, column = 1 }, end = { row = 7, column = 10 } }
-                                                { arguments = []
+                                                { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 2 } } "a"
+                                                , arguments = []
                                                 , expression =
                                                     Node { start = { row = 4, column = 5 }, end = { row = 7, column = 10 } }
                                                         (IfBlock
@@ -150,15 +173,14 @@ b = 3
                                                                 (Integer 2)
                                                             )
                                                         )
-                                                , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 2 } } "a"
                                                 }
-                                        , documentation = Nothing
-                                        , signature = Nothing
                                         }
                                     )
                                 , Node { start = { row = 11, column = 1 }, end = { row = 13, column = 6 } }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Just (Node { start = { row = 11, column = 1 }, end = { row = 12, column = 3 } } "{-| doc\n-}")
+                                        , signature = Nothing
+                                        , declaration =
                                             Node
                                                 { start = { row = 13, column = 1 }
                                                 , end =
@@ -166,36 +188,14 @@ b = 3
                                                     , column = 6
                                                     }
                                                 }
-                                                { arguments = []
+                                                { name = Node { start = { row = 13, column = 1 }, end = { row = 13, column = 2 } } "b"
+                                                , arguments = []
                                                 , expression = Node { start = { row = 13, column = 5 }, end = { row = 13, column = 6 } } (Integer 3)
-                                                , name = Node { start = { row = 13, column = 1 }, end = { row = 13, column = 2 } } "b"
                                                 }
-                                        , documentation = Just (Node { start = { row = 11, column = 1 }, end = { row = 12, column = 3 } } "{-| doc\n-}")
-                                        , signature = Nothing
                                         }
                                     )
                                 ]
-                            , imports = []
-                            , moduleDefinition =
-                                Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
-                                    (NormalModule
-                                        { exposingList =
-                                            Node
-                                                { start = { row = 1, column = 19 }
-                                                , end =
-                                                    { row = 1
-                                                    , column = 32
-                                                    }
-                                                }
-                                                (All { start = { row = 1, column = 29 }, end = { row = 1, column = 31 } })
-                                        , moduleName =
-                                            Node
-                                                { start = { row = 1, column = 8 }
-                                                , end = { row = 1, column = 18 }
-                                                }
-                                                [ "TestModule" ]
-                                        }
-                                    )
+                            , comments = []
                             }
                         )
         , test "Simple module range test" <|
@@ -215,26 +215,39 @@ b = 3
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = []
+                            { moduleDefinition =
+                                Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
+                                    (NormalModule
+                                        { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 18 } } [ "TestModule" ]
+                                        , exposingList =
+                                            Node { start = { row = 1, column = 19 }, end = { row = 1, column = 32 } }
+                                                (All
+                                                    { start = { row = 1, column = 29 }
+                                                    , end = { row = 1, column = 31 }
+                                                    }
+                                                )
+                                        }
+                                    )
+                            , imports = []
                             , declarations =
                                 [ Node
                                     { start = { row = 3, column = 1 }
                                     , end = { row = 4, column = 6 }
                                     }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Nothing
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 3, column = 1 }, end = { row = 4, column = 6 } }
-                                                { arguments = []
+                                                { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 2 } } "a"
+                                                , arguments = []
                                                 , expression =
                                                     Node
                                                         { start = { row = 4, column = 5 }
                                                         , end = { row = 4, column = 6 }
                                                         }
                                                         (Integer 2)
-                                                , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 2 } } "a"
                                                 }
-                                        , documentation = Nothing
-                                        , signature = Nothing
                                         }
                                     )
                                 , Node
@@ -242,36 +255,23 @@ b = 3
                                     , end = { row = 10, column = 6 }
                                     }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Just (Node { start = { row = 8, column = 1 }, end = { row = 9, column = 3 } } "{-| doc\n-}")
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 10, column = 1 }, end = { row = 10, column = 6 } }
-                                                { arguments = []
+                                                { name = Node { start = { row = 10, column = 1 }, end = { row = 10, column = 2 } } "b"
+                                                , arguments = []
                                                 , expression =
                                                     Node
                                                         { start = { row = 10, column = 5 }
                                                         , end = { row = 10, column = 6 }
                                                         }
                                                         (Integer 3)
-                                                , name = Node { start = { row = 10, column = 1 }, end = { row = 10, column = 2 } } "b"
                                                 }
-                                        , documentation = Just (Node { start = { row = 8, column = 1 }, end = { row = 9, column = 3 } } "{-| doc\n-}")
-                                        , signature = Nothing
                                         }
                                     )
                                 ]
-                            , imports = []
-                            , moduleDefinition =
-                                Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
-                                    (NormalModule
-                                        { exposingList =
-                                            Node { start = { row = 1, column = 19 }, end = { row = 1, column = 32 } }
-                                                (All
-                                                    { start = { row = 1, column = 29 }
-                                                    , end = { row = 1, column = 31 }
-                                                    }
-                                                )
-                                        , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 18 } } [ "TestModule" ]
-                                        }
-                                    )
+                            , comments = []
                             }
                         )
         , test "File with multiple imports" <|
@@ -286,42 +286,42 @@ a = 1
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = []
-                            , moduleDefinition =
+                            { moduleDefinition =
                                 Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
                                     (NormalModule
-                                        { exposingList =
+                                        { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 18 } } [ "TestModule" ]
+                                        , exposingList =
                                             Node { start = { row = 1, column = 19 }, end = { row = 1, column = 32 } }
                                                 (All { start = { row = 1, column = 29 }, end = { row = 1, column = 31 } })
-                                        , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 18 } } [ "TestModule" ]
                                         }
                                     )
                             , imports =
                                 [ Node { start = { row = 2, column = 1 }, end = { row = 2, column = 9 } }
-                                    { exposingList = Nothing
+                                    { moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 9 } } [ "A" ]
                                     , moduleAlias = Nothing
-                                    , moduleName = Node { start = { row = 2, column = 8 }, end = { row = 2, column = 9 } } [ "A" ]
+                                    , exposingList = Nothing
                                     }
                                 , Node { start = { row = 3, column = 1 }, end = { row = 3, column = 9 } }
-                                    { exposingList = Nothing
+                                    { moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 9 } } [ "B" ]
                                     , moduleAlias = Nothing
-                                    , moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 9 } } [ "B" ]
+                                    , exposingList = Nothing
                                     }
                                 ]
                             , declarations =
                                 [ Node { start = { row = 5, column = 1 }, end = { row = 5, column = 6 } }
                                     (FunctionDeclaration
-                                        { declaration =
-                                            Node { start = { row = 5, column = 1 }, end = { row = 5, column = 6 } }
-                                                { arguments = []
-                                                , expression = Node { start = { row = 5, column = 5 }, end = { row = 5, column = 6 } } (Integer 1)
-                                                , name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 2 } } "a"
-                                                }
-                                        , documentation = Nothing
+                                        { documentation = Nothing
                                         , signature = Nothing
+                                        , declaration =
+                                            Node { start = { row = 5, column = 1 }, end = { row = 5, column = 6 } }
+                                                { name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 2 } } "a"
+                                                , arguments = []
+                                                , expression = Node { start = { row = 5, column = 5 }, end = { row = 5, column = 6 } } (Integer 1)
+                                                }
                                         }
                                     )
                                 ]
+                            , comments = []
                             }
                         )
         , test "File with multiple declarations" <|
@@ -337,50 +337,49 @@ b = 2
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = []
-                            , moduleDefinition =
+                            { moduleDefinition =
                                 Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
                                     (NormalModule
-                                        { exposingList = Node { start = { row = 1, column = 19 }, end = { row = 1, column = 32 } } (All { start = { row = 1, column = 29 }, end = { row = 1, column = 31 } })
-                                        , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 18 } } [ "TestModule" ]
+                                        { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 18 } } [ "TestModule" ]
+                                        , exposingList = Node { start = { row = 1, column = 19 }, end = { row = 1, column = 32 } } (All { start = { row = 1, column = 29 }, end = { row = 1, column = 31 } })
                                         }
                                     )
                             , imports = []
                             , declarations =
                                 [ Node { start = { row = 2, column = 1 }, end = { row = 2, column = 15 } }
                                     (CustomTypeDeclaration
-                                        { constructors =
+                                        { documentation = Nothing
+                                        , name = Node { start = { row = 2, column = 6 }, end = { row = 2, column = 7 } } "A"
+                                        , generics = []
+                                        , constructors =
                                             [ Node { start = { row = 2, column = 10 }, end = { row = 2, column = 11 } }
-                                                { arguments = []
-                                                , name = Node { start = { row = 2, column = 10 }, end = { row = 2, column = 11 } } "B"
+                                                { name = Node { start = { row = 2, column = 10 }, end = { row = 2, column = 11 } } "B"
+                                                , arguments = []
                                                 }
                                             , Node { start = { row = 2, column = 14 }, end = { row = 2, column = 15 } }
-                                                { arguments = []
-                                                , name = Node { start = { row = 2, column = 14 }, end = { row = 2, column = 15 } } "C"
+                                                { name = Node { start = { row = 2, column = 14 }, end = { row = 2, column = 15 } } "C"
+                                                , arguments = []
                                                 }
                                             ]
-                                        , documentation = Nothing
-                                        , generics = []
-                                        , name = Node { start = { row = 2, column = 6 }, end = { row = 2, column = 7 } } "A"
                                         }
                                     )
                                 , Node { start = { row = 3, column = 1 }, end = { row = 3, column = 6 } }
                                     (FunctionDeclaration
-                                        { declaration =
-                                            Node { start = { row = 3, column = 1 }, end = { row = 3, column = 6 } }
-                                                { arguments = []
-                                                , expression = Node { start = { row = 3, column = 5 }, end = { row = 3, column = 6 } } (Integer 1)
-                                                , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 2 } } "a"
-                                                }
-                                        , documentation = Nothing
+                                        { documentation = Nothing
                                         , signature = Nothing
+                                        , declaration =
+                                            Node { start = { row = 3, column = 1 }, end = { row = 3, column = 6 } }
+                                                { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 2 } } "a"
+                                                , arguments = []
+                                                , expression = Node { start = { row = 3, column = 5 }, end = { row = 3, column = 6 } } (Integer 1)
+                                                }
                                         }
                                     )
                                 , Node { start = { row = 4, column = 1 }, end = { row = 4, column = 17 } }
                                     (AliasDeclaration
                                         { documentation = Nothing
-                                        , generics = []
                                         , name = Node { start = { row = 4, column = 12 }, end = { row = 4, column = 13 } } "B"
+                                        , generics = []
                                         , typeAnnotation =
                                             Node { start = { row = 4, column = 16 }, end = { row = 4, column = 17 } }
                                                 (Typed (Node { start = { row = 4, column = 16 }, end = { row = 4, column = 17 } } ( [], "A" )) [])
@@ -398,13 +397,14 @@ b = 2
                                                 )
                                         , declaration =
                                             Node { start = { row = 6, column = 1 }, end = { row = 6, column = 6 } }
-                                                { arguments = []
+                                                { name = Node { start = { row = 6, column = 1 }, end = { row = 6, column = 2 } } "b"
+                                                , arguments = []
                                                 , expression = Node { start = { row = 6, column = 5 }, end = { row = 6, column = 6 } } (Integer 2)
-                                                , name = Node { start = { row = 6, column = 1 }, end = { row = 6, column = 2 } } "b"
                                                 }
                                         }
                                     )
                                 ]
+                            , comments = []
                             }
                         )
         , test "should fail to parse two signatures in a row" <|
@@ -436,13 +436,17 @@ fun2 n =
                     File.file
                     |> Expect.equal
                         (Just
-                            { comments = [ Node { start = { row = 5, column = 13 }, end = { row = 5, column = 17 } } "-- a", Node { start = { row = 8, column = 13 }, end = { row = 8, column = 17 } } "-- b" ]
+                            { moduleDefinition = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 31 } } (NormalModule { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } [ "A" ], exposingList = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 31 } } (Explicit [ Node { start = { row = 1, column = 20 }, end = { row = 1, column = 24 } } (FunctionExpose "fun1"), Node { start = { row = 1, column = 26 }, end = { row = 1, column = 30 } } (FunctionExpose "fun2") ]) })
+                            , imports = []
                             , declarations =
                                 [ Node { start = { row = 3, column = 1 }, end = { row = 5, column = 11 } }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Nothing
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 3, column = 1 }, end = { row = 5, column = 11 } }
-                                                { arguments = [ Node { start = { row = 3, column = 6 }, end = { row = 3, column = 7 } } (VarPattern "n") ]
+                                                { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 5 } } "fun1"
+                                                , arguments = [ Node { start = { row = 3, column = 6 }, end = { row = 3, column = 7 } } (VarPattern "n") ]
                                                 , expression =
                                                     Node { start = { row = 4, column = 3 }, end = { row = 5, column = 11 } }
                                                         (OperatorApplication "+"
@@ -462,17 +466,17 @@ fun2 n =
                                                                 )
                                                             )
                                                         )
-                                                , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 5 } } "fun1"
                                                 }
-                                        , documentation = Nothing
-                                        , signature = Nothing
                                         }
                                     )
                                 , Node { start = { row = 7, column = 1 }, end = { row = 8, column = 9 } }
                                     (FunctionDeclaration
-                                        { declaration =
+                                        { documentation = Nothing
+                                        , signature = Nothing
+                                        , declaration =
                                             Node { start = { row = 7, column = 1 }, end = { row = 8, column = 9 } }
-                                                { arguments = [ Node { start = { row = 7, column = 6 }, end = { row = 7, column = 7 } } (VarPattern "n") ]
+                                                { name = Node { start = { row = 7, column = 1 }, end = { row = 7, column = 5 } } "fun2"
+                                                , arguments = [ Node { start = { row = 7, column = 6 }, end = { row = 7, column = 7 } } (VarPattern "n") ]
                                                 , expression =
                                                     Node { start = { row = 8, column = 3 }, end = { row = 8, column = 9 } }
                                                         (Application
@@ -480,15 +484,11 @@ fun2 n =
                                                             , Node { start = { row = 8, column = 8 }, end = { row = 8, column = 9 } } (FunctionOrValue [] "n")
                                                             ]
                                                         )
-                                                , name = Node { start = { row = 7, column = 1 }, end = { row = 7, column = 5 } } "fun2"
                                                 }
-                                        , documentation = Nothing
-                                        , signature = Nothing
                                         }
                                     )
                                 ]
-                            , imports = []
-                            , moduleDefinition = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 31 } } (NormalModule { exposingList = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 31 } } (Explicit [ Node { start = { row = 1, column = 20 }, end = { row = 1, column = 24 } } (FunctionExpose "fun1"), Node { start = { row = 1, column = 26 }, end = { row = 1, column = 30 } } (FunctionExpose "fun2") ]), moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } [ "A" ] })
+                            , comments = [ Node { start = { row = 5, column = 13 }, end = { row = 5, column = 17 } } "-- a", Node { start = { row = 8, column = 13 }, end = { row = 8, column = 17 } } "-- b" ]
                             }
                         )
         ]

--- a/tests/Elm/Parser/TypingsTests.elm
+++ b/tests/Elm/Parser/TypingsTests.elm
@@ -22,8 +22,8 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 34 } }
                             (AliasDeclaration
                                 { documentation = Nothing
-                                , generics = []
                                 , name = Node { start = { row = 1, column = 12 }, end = { row = 1, column = 15 } } "Foo"
+                                , generics = []
                                 , typeAnnotation =
                                     Node { start = { row = 1, column = 18 }, end = { row = 1, column = 34 } }
                                         (Record
@@ -44,8 +44,8 @@ all =
                         (Node { start = { row = -1, column = -1 }, end = { row = 1, column = 34 } }
                             (AliasDeclaration
                                 { documentation = Just (Node { start = { row = -1, column = -1 }, end = { row = 0, column = 0 } } "{-| Foo is colorful -}")
-                                , generics = []
                                 , name = Node { start = { row = 1, column = 12 }, end = { row = 1, column = 15 } } "Foo"
+                                , generics = []
                                 , typeAnnotation =
                                     Node { start = { row = 1, column = 18 }, end = { row = 1, column = 34 } }
                                         (Record
@@ -66,8 +66,8 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
                             (AliasDeclaration
                                 { documentation = Nothing
-                                , generics = []
                                 , name = Node { start = { row = 1, column = 12 }, end = { row = 1, column = 15 } } "Foo"
+                                , generics = []
                                 , typeAnnotation =
                                     Node { start = { row = 1, column = 16 }, end = { row = 1, column = 32 } }
                                         (Record
@@ -88,8 +88,8 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 31 } }
                             (AliasDeclaration
                                 { documentation = Nothing
-                                , generics = [ Node { start = { row = 1, column = 16 }, end = { row = 1, column = 17 } } "a" ]
                                 , name = Node { start = { row = 1, column = 12 }, end = { row = 1, column = 15 } } "Foo"
+                                , generics = [ Node { start = { row = 1, column = 16 }, end = { row = 1, column = 17 } } "a" ]
                                 , typeAnnotation =
                                     Node { start = { row = 1, column = 20 }, end = { row = 1, column = 31 } }
                                         (Record
@@ -108,7 +108,10 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 39 } }
                             (Declaration.CustomTypeDeclaration
-                                { constructors =
+                                { documentation = Nothing
+                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 11 } } "Color"
+                                , generics = []
+                                , constructors =
                                     [ Node { start = { row = 1, column = 14 }, end = { row = 1, column = 25 } }
                                         { name = Node { start = { row = 1, column = 14 }, end = { row = 1, column = 18 } } "Blue"
                                         , arguments =
@@ -125,9 +128,6 @@ all =
                                         , arguments = []
                                         }
                                     ]
-                                , documentation = Nothing
-                                , generics = []
-                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 11 } } "Color"
                                 }
                             )
                         )
@@ -137,7 +137,10 @@ all =
                     |> expectAstWithDocs (Node { start = { row = -1, column = -1 }, end = { row = 0, column = 0 } } "{-| Classic RGB -}")
                         (Node { start = { row = -1, column = -1 }, end = { row = 1, column = 39 } }
                             (Declaration.CustomTypeDeclaration
-                                { constructors =
+                                { documentation = Just (Node { start = { row = -1, column = -1 }, end = { row = 0, column = 0 } } "{-| Classic RGB -}")
+                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 11 } } "Color"
+                                , generics = []
+                                , constructors =
                                     [ Node { start = { row = 1, column = 14 }, end = { row = 1, column = 25 } }
                                         { name = Node { start = { row = 1, column = 14 }, end = { row = 1, column = 18 } } "Blue"
                                         , arguments =
@@ -154,9 +157,6 @@ all =
                                         , arguments = []
                                         }
                                     ]
-                                , documentation = Just (Node { start = { row = -1, column = -1 }, end = { row = 0, column = 0 } } "{-| Classic RGB -}")
-                                , generics = []
-                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 11 } } "Color"
                                 }
                             )
                         )
@@ -166,19 +166,19 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 15 } }
                             (Declaration.CustomTypeDeclaration
-                                { constructors =
+                                { documentation = Nothing
+                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } "D"
+                                , generics = []
+                                , constructors =
                                     [ Node { start = { row = 1, column = 10 }, end = { row = 1, column = 15 } }
-                                        { arguments =
+                                        { name = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } "C"
+                                        , arguments =
                                             [ Node { start = { row = 1, column = 12 }, end = { row = 1, column = 13 } } (GenericType "a")
                                             , Node { start = { row = 1, column = 14 }, end = { row = 1, column = 15 } }
                                                 (Typed (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 15 } } ( [], "B" )) [])
                                             ]
-                                        , name = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } "C"
                                         }
                                     ]
-                                , documentation = Nothing
-                                , generics = []
-                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } "D"
                                 }
                             )
                         )
@@ -188,19 +188,19 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 15 } }
                             (Declaration.CustomTypeDeclaration
-                                { constructors =
+                                { documentation = Nothing
+                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } "D"
+                                , generics = []
+                                , constructors =
                                     [ Node { start = { row = 1, column = 10 }, end = { row = 1, column = 15 } }
-                                        { arguments =
+                                        { name = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } "C"
+                                        , arguments =
                                             [ Node { start = { row = 1, column = 12 }, end = { row = 1, column = 13 } }
                                                 (Typed (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 13 } } ( [], "B" )) [])
                                             , Node { start = { row = 1, column = 14 }, end = { row = 1, column = 15 } } (GenericType "a")
                                             ]
-                                        , name = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } "C"
                                         }
                                     ]
-                                , documentation = Nothing
-                                , generics = []
-                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } "D"
                                 }
                             )
                         )
@@ -214,19 +214,19 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 32 } }
                             (Declaration.CustomTypeDeclaration
-                                { constructors =
+                                { documentation = Nothing
+                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 11 } } "Maybe"
+                                , generics = [ Node { start = { row = 1, column = 12 }, end = { row = 1, column = 13 } } "a" ]
+                                , constructors =
                                     [ Node { start = { row = 1, column = 16 }, end = { row = 1, column = 22 } }
-                                        { arguments = [ Node { start = { row = 1, column = 21 }, end = { row = 1, column = 22 } } (GenericType "a") ]
-                                        , name = Node { start = { row = 1, column = 16 }, end = { row = 1, column = 20 } } "Just"
+                                        { name = Node { start = { row = 1, column = 16 }, end = { row = 1, column = 20 } } "Just"
+                                        , arguments = [ Node { start = { row = 1, column = 21 }, end = { row = 1, column = 22 } } (GenericType "a") ]
                                         }
                                     , Node { start = { row = 1, column = 25 }, end = { row = 1, column = 32 } }
-                                        { arguments = []
-                                        , name = Node { start = { row = 1, column = 25 }, end = { row = 1, column = 32 } } "Nothing"
+                                        { name = Node { start = { row = 1, column = 25 }, end = { row = 1, column = 32 } } "Nothing"
+                                        , arguments = []
                                         }
                                     ]
-                                , documentation = Nothing
-                                , generics = [ Node { start = { row = 1, column = 12 }, end = { row = 1, column = 13 } } "a" ]
-                                , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 11 } } "Maybe"
                                 }
                             )
                         )
@@ -240,13 +240,13 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 11 } }
                             (Declaration.CustomTypeDeclaration
-                                { constructors =
-                                    [ Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } }
-                                        { arguments = [], name = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } "B" }
-                                    ]
-                                , documentation = Nothing
-                                , generics = []
+                                { documentation = Nothing
                                 , name = Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } "A"
+                                , generics = []
+                                , constructors =
+                                    [ Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } }
+                                        { name = Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } "B", arguments = [] }
+                                    ]
                                 }
                             )
                         )

--- a/tests/Elm/ProcessingTests.elm
+++ b/tests/Elm/ProcessingTests.elm
@@ -128,9 +128,9 @@ bar = 1
                     }
       , imports =
             [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 14 } }
-                { exposingList = Nothing
+                { moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
                 , moduleAlias = Nothing
-                , moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
+                , exposingList = Nothing
                 }
             ]
       , declarations =
@@ -172,9 +172,9 @@ bar = 1
                     }
       , imports =
             [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 14 } }
-                { exposingList = Nothing
+                { moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
                 , moduleAlias = Nothing
-                , moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
+                , exposingList = Nothing
                 }
             ]
       , declarations =
@@ -263,9 +263,9 @@ bar = {- comment 3 -} 1 -- comment 4
                     , signature = Nothing
                     , declaration =
                         Node { start = { row = 5, column = 1 }, end = { row = 5, column = 24 } }
-                            { arguments = []
+                            { name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 4 } } "bar"
+                            , arguments = []
                             , expression = Node { start = { row = 5, column = 23 }, end = { row = 5, column = 24 } } (Integer 1)
-                            , name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 4 } } "bar"
                             }
                     }
                 )
@@ -337,9 +337,9 @@ type alias Foo
                     }
       , imports =
             [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 14 } }
-                { exposingList = Nothing
+                { moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
                 , moduleAlias = Nothing
-                , moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
+                , exposingList = Nothing
                 }
             ]
       , declarations =
@@ -376,13 +376,28 @@ log : Int -> Int
 log a =
     Debug.log "ok" a
 """
-    , { comments = []
+    , { moduleDefinition =
+            Node { start = { row = 1, column = 1 }, end = { row = 1, column = 42 } }
+                (NormalModule
+                    { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 27 } } [ "Simplify", "AstHelpers" ]
+                    , exposingList =
+                        Node { start = { row = 1, column = 28 }, end = { row = 1, column = 42 } }
+                            (Explicit
+                                [ Node { start = { row = 1, column = 38 }, end = { row = 1, column = 41 } } (FunctionExpose "log")
+                                ]
+                            )
+                    }
+                )
+      , imports = []
       , declarations =
             [ Node { start = { row = 4, column = 1 }, end = { row = 6, column = 21 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Just (Node { start = { row = 4, column = 1 }, end = { row = 4, column = 17 } } { name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 4 } } "log", typeAnnotation = Node { start = { row = 4, column = 7 }, end = { row = 4, column = 17 } } (FunctionTypeAnnotation (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 10 } } (Typed (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 10 } } ( [], "Int" )) [])) (Node { start = { row = 4, column = 14 }, end = { row = 4, column = 17 } } (Typed (Node { start = { row = 4, column = 14 }, end = { row = 4, column = 17 } } ( [], "Int" )) []))) })
+                    , declaration =
                         Node { start = { row = 5, column = 1 }, end = { row = 6, column = 21 } }
-                            { arguments = [ Node { start = { row = 5, column = 5 }, end = { row = 5, column = 6 } } (VarPattern "a") ]
+                            { name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 4 } } "log"
+                            , arguments = [ Node { start = { row = 5, column = 5 }, end = { row = 5, column = 6 } } (VarPattern "a") ]
                             , expression =
                                 Node { start = { row = 6, column = 5 }, end = { row = 6, column = 21 } }
                                     (Application
@@ -391,26 +406,11 @@ log a =
                                         , Node { start = { row = 6, column = 20 }, end = { row = 6, column = 21 } } (FunctionOrValue [] "a")
                                         ]
                                     )
-                            , name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 4 } } "log"
                             }
-                    , documentation = Nothing
-                    , signature = Just (Node { start = { row = 4, column = 1 }, end = { row = 4, column = 17 } } { name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 4 } } "log", typeAnnotation = Node { start = { row = 4, column = 7 }, end = { row = 4, column = 17 } } (FunctionTypeAnnotation (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 10 } } (Typed (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 10 } } ( [], "Int" )) [])) (Node { start = { row = 4, column = 14 }, end = { row = 4, column = 17 } } (Typed (Node { start = { row = 4, column = 14 }, end = { row = 4, column = 17 } } ( [], "Int" )) []))) })
                     }
                 )
             ]
-      , imports = []
-      , moduleDefinition =
-            Node { start = { row = 1, column = 1 }, end = { row = 1, column = 42 } }
-                (NormalModule
-                    { exposingList =
-                        Node { start = { row = 1, column = 28 }, end = { row = 1, column = 42 } }
-                            (Explicit
-                                [ Node { start = { row = 1, column = 38 }, end = { row = 1, column = 41 } } (FunctionExpose "log")
-                                ]
-                            )
-                    , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 27 } } [ "Simplify", "AstHelpers" ]
-                    }
-                )
+      , comments = []
       }
     )
 
@@ -428,34 +428,34 @@ type Foo
    = Red
    | Blue
 """
-    , { comments = []
+    , { moduleDefinition = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 25 } } (NormalModule { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Bar" ], exposingList = Node { start = { row = 1, column = 12 }, end = { row = 1, column = 25 } } (All { start = { row = 1, column = 22 }, end = { row = 1, column = 24 } }) })
+      , imports =
+            [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 14 } }
+                { moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
+                , moduleAlias = Nothing
+                , exposingList = Nothing
+                }
+            ]
       , declarations =
             [ Node { start = { row = 5, column = 1 }, end = { row = 8, column = 10 } }
                 (CustomTypeDeclaration
-                    { constructors =
-                        [ Node { start = { row = 7, column = 6 }, end = { row = 7, column = 9 } }
-                            { arguments = [], name = Node { start = { row = 7, column = 6 }, end = { row = 7, column = 9 } } "Red" }
-                        , Node { start = { row = 8, column = 6 }, end = { row = 8, column = 10 } }
-                            { arguments = [], name = Node { start = { row = 8, column = 6 }, end = { row = 8, column = 10 } } "Blue" }
-                        ]
-                    , documentation =
+                    { documentation =
                         Just
                             (Node { start = { row = 5, column = 1 }, end = { row = 5, column = 15 } }
                                 "{-| The Doc -}"
                             )
-                    , generics = []
                     , name = Node { start = { row = 6, column = 6 }, end = { row = 6, column = 9 } } "Foo"
+                    , generics = []
+                    , constructors =
+                        [ Node { start = { row = 7, column = 6 }, end = { row = 7, column = 9 } }
+                            { name = Node { start = { row = 7, column = 6 }, end = { row = 7, column = 9 } } "Red", arguments = [] }
+                        , Node { start = { row = 8, column = 6 }, end = { row = 8, column = 10 } }
+                            { name = Node { start = { row = 8, column = 6 }, end = { row = 8, column = 10 } } "Blue", arguments = [] }
+                        ]
                     }
                 )
             ]
-      , imports =
-            [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 14 } }
-                { exposingList = Nothing
-                , moduleAlias = Nothing
-                , moduleName = Node { start = { row = 3, column = 8 }, end = { row = 3, column = 14 } } [ "String" ]
-                }
-            ]
-      , moduleDefinition = Node { start = { row = 1, column = 1 }, end = { row = 1, column = 25 } } (NormalModule { exposingList = Node { start = { row = 1, column = 12 }, end = { row = 1, column = 25 } } (All { start = { row = 1, column = 22 }, end = { row = 1, column = 24 } }), moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 11 } } [ "Bar" ] })
+      , comments = []
       }
     )
 
@@ -624,9 +624,12 @@ bar = -(1 * 2)
       , declarations =
             [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 15 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 3, column = 1 }, end = { row = 3, column = 15 } }
-                            { arguments = []
+                            { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 4 } } "bar"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 3, column = 7 }, end = { row = 3, column = 15 } }
                                     (Negation
@@ -643,10 +646,7 @@ bar = -(1 * 2)
                                             )
                                         )
                                     )
-                            , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 4 } } "bar"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             ]
@@ -673,9 +673,12 @@ bar = (1 * 2).x
       , declarations =
             [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 16 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 3, column = 1 }, end = { row = 3, column = 16 } }
-                            { arguments = []
+                            { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 4 } } "bar"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 3, column = 7 }, end = { row = 3, column = 16 } }
                                     (RecordAccess
@@ -693,10 +696,7 @@ bar = (1 * 2).x
                                         )
                                         (Node { start = { row = 3, column = 15 }, end = { row = 3, column = 16 } } "x")
                                     )
-                            , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 4 } } "bar"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             ]
@@ -719,13 +719,25 @@ bool2 = True || True && True
 numeric1 = 1 ^ 2 * 3 + 4
 numeric2 = 1 + 2 * 3 ^ 4
 """
-    , { comments = []
+    , { moduleDefinition =
+            Node { start = { row = 1, column = 1 }, end = { row = 1, column = 23 } }
+                (NormalModule
+                    { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } [ "A" ]
+                    , exposingList =
+                        Node { start = { row = 1, column = 10 }, end = { row = 1, column = 23 } }
+                            (All { start = { row = 1, column = 20 }, end = { row = 1, column = 22 } })
+                    }
+                )
+      , imports = []
       , declarations =
             [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 29 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 3, column = 1 }, end = { row = 3, column = 29 } }
-                            { arguments = []
+                            { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 6 } } "bool1"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 3, column = 9 }, end = { row = 3, column = 29 } }
                                     (OperatorApplication "||"
@@ -739,17 +751,17 @@ numeric2 = 1 + 2 * 3 ^ 4
                                         )
                                         (Node { start = { row = 3, column = 25 }, end = { row = 3, column = 29 } } (FunctionOrValue [] "True"))
                                     )
-                            , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 6 } } "bool1"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             , Node { start = { row = 4, column = 1 }, end = { row = 4, column = 29 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 4, column = 1 }, end = { row = 4, column = 29 } }
-                            { arguments = []
+                            { name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 6 } } "bool2"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 4, column = 9 }, end = { row = 4, column = 29 } }
                                     (OperatorApplication "||"
@@ -763,17 +775,17 @@ numeric2 = 1 + 2 * 3 ^ 4
                                             )
                                         )
                                     )
-                            , name = Node { start = { row = 4, column = 1 }, end = { row = 4, column = 6 } } "bool2"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             , Node { start = { row = 6, column = 1 }, end = { row = 6, column = 25 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 6, column = 1 }, end = { row = 6, column = 25 } }
-                            { arguments = []
+                            { name = Node { start = { row = 6, column = 1 }, end = { row = 6, column = 9 } } "numeric1"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 6, column = 12 }, end = { row = 6, column = 25 } }
                                     (OperatorApplication "+"
@@ -796,17 +808,17 @@ numeric2 = 1 + 2 * 3 ^ 4
                                             (Integer 4)
                                         )
                                     )
-                            , name = Node { start = { row = 6, column = 1 }, end = { row = 6, column = 9 } } "numeric1"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             , Node { start = { row = 7, column = 1 }, end = { row = 7, column = 25 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 7, column = 1 }, end = { row = 7, column = 25 } }
-                            { arguments = []
+                            { name = Node { start = { row = 7, column = 1 }, end = { row = 7, column = 9 } } "numeric2"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 7, column = 12 }, end = { row = 7, column = 25 } }
                                     (OperatorApplication "+"
@@ -826,23 +838,11 @@ numeric2 = 1 + 2 * 3 ^ 4
                                             )
                                         )
                                     )
-                            , name = Node { start = { row = 7, column = 1 }, end = { row = 7, column = 9 } } "numeric2"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             ]
-      , imports = []
-      , moduleDefinition =
-            Node { start = { row = 1, column = 1 }, end = { row = 1, column = 23 } }
-                (NormalModule
-                    { exposingList =
-                        Node { start = { row = 1, column = 10 }, end = { row = 1, column = 23 } }
-                            (All { start = { row = 1, column = 20 }, end = { row = 1, column = 22 } })
-                    , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } [ "A" ]
-                    }
-                )
+      , comments = []
       }
     )
 
@@ -859,13 +859,25 @@ numeric1 = 1 + 2 - 3
 
 pipeline1 = 1 |> 2 |> 3
 """
-    , { comments = []
+    , { moduleDefinition =
+            Node { start = { row = 1, column = 1 }, end = { row = 1, column = 23 } }
+                (NormalModule
+                    { moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } [ "A" ]
+                    , exposingList =
+                        Node { start = { row = 1, column = 10 }, end = { row = 1, column = 23 } }
+                            (All { start = { row = 1, column = 20 }, end = { row = 1, column = 22 } })
+                    }
+                )
+      , imports = []
       , declarations =
             [ Node { start = { row = 3, column = 1 }, end = { row = 3, column = 21 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 3, column = 1 }, end = { row = 3, column = 21 } }
-                            { arguments = []
+                            { name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 9 } } "numeric1"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 3, column = 12 }, end = { row = 3, column = 21 } }
                                     (OperatorApplication "-"
@@ -879,17 +891,17 @@ pipeline1 = 1 |> 2 |> 3
                                         )
                                         (Node { start = { row = 3, column = 20 }, end = { row = 3, column = 21 } } (Integer 3))
                                     )
-                            , name = Node { start = { row = 3, column = 1 }, end = { row = 3, column = 9 } } "numeric1"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             , Node { start = { row = 5, column = 1 }, end = { row = 5, column = 24 } }
                 (FunctionDeclaration
-                    { declaration =
+                    { documentation = Nothing
+                    , signature = Nothing
+                    , declaration =
                         Node { start = { row = 5, column = 1 }, end = { row = 5, column = 24 } }
-                            { arguments = []
+                            { name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 10 } } "pipeline1"
+                            , arguments = []
                             , expression =
                                 Node { start = { row = 5, column = 13 }, end = { row = 5, column = 24 } }
                                     (OperatorApplication "|>"
@@ -903,22 +915,10 @@ pipeline1 = 1 |> 2 |> 3
                                         )
                                         (Node { start = { row = 5, column = 23 }, end = { row = 5, column = 24 } } (Integer 3))
                                     )
-                            , name = Node { start = { row = 5, column = 1 }, end = { row = 5, column = 10 } } "pipeline1"
                             }
-                    , documentation = Nothing
-                    , signature = Nothing
                     }
                 )
             ]
-      , imports = []
-      , moduleDefinition =
-            Node { start = { row = 1, column = 1 }, end = { row = 1, column = 23 } }
-                (NormalModule
-                    { exposingList =
-                        Node { start = { row = 1, column = 10 }, end = { row = 1, column = 23 } }
-                            (All { start = { row = 1, column = 20 }, end = { row = 1, column = 22 } })
-                    , moduleName = Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } [ "A" ]
-                    }
-                )
+      , comments = []
       }
     )


### PR DESCRIPTION
This removes the need for the original intent behind the `OrderedRanges` rule (which I've renamed to `AstFormatting`).

I think this is interesting to try out, but happy to disable it if anyone thinks it's painful somehow.