### PR TITLE
Use ranges more efficiently

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -71,20 +71,15 @@ functionWithNameNode start ((Node _ startName) as startNameNode) maybeDocumentat
     Combine.oneOf
         [ Combine.succeed
             (\typeAnnotation ->
-                \implementationName ->
+                \((Node implementationNameRange _) as implementationName) ->
                     \arguments ->
-                        \expression ->
-                            let
-                                end : Location
-                                end =
-                                    (Node.range expression).end
-                            in
+                        \((Node { end } _) as expression) ->
                             Node { start = start, end = end }
                                 (Declaration.FunctionDeclaration
                                     { documentation = maybeDocumentation
                                     , signature = Just (Node.combine Signature startNameNode typeAnnotation)
                                     , declaration =
-                                        Node { start = (Node.range implementationName).start, end = end }
+                                        Node { start = implementationNameRange.start, end = end }
                                             (FunctionImplementation implementationName arguments expression)
                                     }
                                 )
@@ -107,12 +102,7 @@ functionWithNameNode start ((Node _ startName) as startNameNode) maybeDocumentat
             |> Combine.keep expression
         , Combine.succeed
             (\args ->
-                \expression ->
-                    let
-                        end : Location
-                        end =
-                            (Node.range expression).end
-                    in
+                \((Node { end } _) as expression) ->
                     Node { start = start, end = end }
                         (Declaration.FunctionDeclaration
                             { documentation = maybeDocumentation
@@ -131,24 +121,19 @@ functionWithNameNode start ((Node _ startName) as startNameNode) maybeDocumentat
 functionDeclarationWithoutDocumentationWithSignatureWithNameAndMaybeLayoutBacktrackable : Parser State (Node Declaration)
 functionDeclarationWithoutDocumentationWithSignatureWithNameAndMaybeLayoutBacktrackable =
     Combine.succeed
-        (\startNameNode ->
+        (\((Node { start } _) as startNameNode) ->
             \typeAnnotation ->
-                \implementationName ->
+                \((Node implementationNameRange _) as implementationName) ->
                     \arguments ->
-                        \result ->
+                        \((Node { end } _) as result) ->
                             if Node.value implementationName == Node.value startNameNode then
-                                let
-                                    end : Location
-                                    end =
-                                        (Node.range result).end
-                                in
                                 Combine.succeed
-                                    (Node { start = (Node.range startNameNode).start, end = end }
+                                    (Node { start = start, end = end }
                                         (FunctionDeclaration
                                             { documentation = Nothing
                                             , signature = Just (Node.combine Signature startNameNode typeAnnotation)
                                             , declaration =
-                                                Node { start = (Node.range implementationName).start, end = end }
+                                                Node { start = implementationNameRange.start, end = end }
                                                     (FunctionImplementation implementationName arguments result)
                                             }
                                         )
@@ -173,18 +158,9 @@ functionDeclarationWithoutDocumentationWithSignatureWithNameAndMaybeLayoutBacktr
 functionDeclarationWithoutDocumentationWithoutSignature : Parser State (Node Declaration)
 functionDeclarationWithoutDocumentationWithoutSignature =
     Combine.succeed
-        (\startNameNode ->
+        (\((Node { start } _) as startNameNode) ->
             \args ->
-                \result ->
-                    let
-                        end : Location
-                        end =
-                            (Node.range result).end
-
-                        start : Location
-                        start =
-                            (Node.range startNameNode).start
-                    in
+                \((Node { end } _) as result) ->
                     Node { start = start, end = end }
                         (FunctionDeclaration
                             { documentation = Nothing
@@ -277,10 +253,10 @@ portDeclaration documentation =
     Combine.succeed
         (\( startRow, startColumn ) ->
             \name ->
-                \typeAnnotation ->
+                \((Node { end } _) as typeAnnotation) ->
                     Node
                         { start = { row = startRow, column = startColumn }
-                        , end = (Node.range typeAnnotation).end
+                        , end = end
                         }
                         (Declaration.PortDeclaration { name = name, typeAnnotation = typeAnnotation })
         )
@@ -309,10 +285,10 @@ portDeclarationWithoutDocumentation =
     Combine.succeed
         (\( startRow, startColumn ) ->
             \name ->
-                \typeAnnotation ->
+                \((Node { end } _) as typeAnnotation) ->
                     Node
                         { start = { row = startRow, column = startColumn }
-                        , end = (Node.range typeAnnotation).end
+                        , end = end
                         }
                         (Declaration.PortDeclaration { name = name, typeAnnotation = typeAnnotation })
         )

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -434,10 +434,10 @@ letFunctionWithSignatureWithNameAndMaybeLayoutBacktrackable =
     Combine.succeed
         (\((Node { start } startName) as startNameNode) ->
             \typeAnnotation ->
-                \((Node implementationNameRange _) as implementationName) ->
+                \((Node implementationNameRange implementationName) as implementationNameNode) ->
                     \arguments ->
                         \((Node { end } _) as result) ->
-                            if Node.value implementationName == startName then
+                            if implementationName == startName then
                                 Combine.succeed
                                     (Node { start = start, end = end }
                                         (LetFunction
@@ -445,14 +445,14 @@ letFunctionWithSignatureWithNameAndMaybeLayoutBacktrackable =
                                             , signature = Just (Node.combine Signature startNameNode typeAnnotation)
                                             , declaration =
                                                 Node { start = implementationNameRange.start, end = end }
-                                                    (FunctionImplementation implementationName arguments result)
+                                                    (FunctionImplementation implementationNameNode arguments result)
                                             }
                                         )
                                     )
 
                             else
                                 Combine.problem
-                                    ("Expected to find the declaration for " ++ Node.value startNameNode ++ " but found " ++ Node.value implementationName)
+                                    ("Expected to find the declaration for " ++ startName ++ " but found " ++ implementationName)
         )
         |> Combine.keep
             (functionNameMaybeLayout

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -50,25 +50,26 @@ type alias Function =
 functionRange : Function -> Range
 functionRange function =
     let
-        { name, expression } =
-            Node.value function.declaration
+        declarationRange : Range
+        declarationRange =
+            Node.range function.declaration
 
         startRange : Range
         startRange =
             case function.documentation of
-                Just documentation ->
-                    Node.range documentation
+                Just (Node range _) ->
+                    range
 
                 Nothing ->
                     case function.signature of
-                        Just (Node _ value) ->
-                            Node.range value.name
+                        Just (Node range _) ->
+                            range
 
                         Nothing ->
-                            Node.range name
+                            declarationRange
     in
     { start = startRange.start
-    , end = (Node.range expression).end
+    , end = declarationRange.end
     }
 
 


### PR DESCRIPTION
- Use destructuring instead of `Node.range` and `Node.value` more.
- In `Expression.functionRange` don't fetch subfields unnecessarily