### PR TITLE
Better file sample tests

### DIFF
--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -1,10 +1,12 @@
 module Elm.Parser.FileTests exposing (all)
 
+import Combine
 import Elm.Internal.RawFile as InternalRawFile
 import Elm.Parser
 import Elm.Parser.CombineTestUtil exposing (..)
 import Elm.Parser.File as Parser
 import Elm.Parser.Samples as Samples
+import Elm.Parser.State exposing (emptyState)
 import Elm.RawFile as RawFile exposing (RawFile)
 import Elm.Syntax.Declaration exposing (Declaration(..))
 import Elm.Syntax.Exposing exposing (Exposing(..))
@@ -28,7 +30,12 @@ all =
                 (\( n, s ) ->
                     test ("sample " ++ String.fromInt (n + 1)) <|
                         \() ->
-                            parse s Parser.file |> Expect.notEqual Nothing
+                            case Combine.runParser (Parser.file |> Combine.ignore Combine.end) emptyState s of
+                                Err error ->
+                                    Expect.fail (error |> Debug.toString)
+
+                                Ok _ ->
+                                    Expect.pass
                 )
                 Samples.allSamples
 

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -24,8 +24,8 @@ all : Test
 all =
     Test.concat
         [ describe "FileTests" <|
-            List.indexedMap
-                (\n s ->
+            List.map
+                (\( n, s ) ->
                     test ("sample " ++ String.fromInt (n + 1)) <|
                         \() ->
                             parse s Parser.file |> Expect.notEqual Nothing
@@ -49,8 +49,8 @@ all =
         --     ]
         , describe "FileTests - serialisation"
             (Samples.allSamples
-                |> List.indexedMap
-                    (\n s ->
+                |> List.map
+                    (\( n, s ) ->
                         test ("sample " ++ String.fromInt (n + 1)) <|
                             \() ->
                                 let

--- a/tests/Elm/Parser/Samples.elm
+++ b/tests/Elm/Parser/Samples.elm
@@ -1,57 +1,57 @@
 module Elm.Parser.Samples exposing (allSamples)
 
 
-allSamples : List String
+allSamples : List ( Int, String )
 allSamples =
-    [ sample1
-    , sample2
-    , sample3
-    , sample4
-    , sample5
-    , sample6
-    , sample7
-    , sample8
-    , sample9
-    , sample11
-    , sample12
-    , sample14
-    , sample15
-    , sample16
-    , sample17
-    , sample18
-    , sample19
-    , sample20
-    , sample21
-    , sample22
-    , sample23
-    , sample24
-    , sample25
-    , sample26
-    , sample27
-    , sample28
-    , sample29
-    , sample30
-    , sample31
-    , sample32
-    , sample33
-    , sample34
-    , sample35
-    , sample36
-    , sample37
-    , sample38
-    , sample39
-    , sample40
-    , sample41
-    , sample42
-    , sample43
-    , sample44
-    , sample45
-    , sample46
-    , sample47
-    , sample48
-    , sample49
-    , sample50
-    , sample51
+    [ ( 1, sample1 )
+    , ( 2, sample2 )
+    , ( 3, sample3 )
+    , ( 4, sample4 )
+    , ( 5, sample5 )
+    , ( 6, sample6 )
+    , ( 7, sample7 )
+    , ( 8, sample8 )
+    , ( 9, sample9 )
+    , ( 11, sample11 )
+    , ( 12, sample12 )
+    , ( 14, sample14 )
+    , ( 15, sample15 )
+    , ( 16, sample16 )
+    , ( 17, sample17 )
+    , ( 18, sample18 )
+    , ( 19, sample19 )
+    , ( 20, sample20 )
+    , ( 21, sample21 )
+    , ( 22, sample22 )
+    , ( 23, sample23 )
+    , ( 24, sample24 )
+    , ( 25, sample25 )
+    , ( 26, sample26 )
+    , ( 27, sample27 )
+    , ( 28, sample28 )
+    , ( 29, sample29 )
+    , ( 30, sample30 )
+    , ( 31, sample31 )
+    , ( 32, sample32 )
+    , ( 33, sample33 )
+    , ( 34, sample34 )
+    , ( 35, sample35 )
+    , ( 36, sample36 )
+    , ( 37, sample37 )
+    , ( 38, sample38 )
+    , ( 39, sample39 )
+    , ( 40, sample40 )
+    , ( 41, sample41 )
+    , ( 42, sample42 )
+    , ( 43, sample43 )
+    , ( 44, sample44 )
+    , ( 45, sample45 )
+    , ( 46, sample46 )
+    , ( 47, sample47 )
+    , ( 48, sample48 )
+    , ( 49, sample49 )
+    , ( 50, sample50 )
+    , ( 51, sample51 )
     ]
 
 

--- a/tests/Elm/Parser/Samples.elm
+++ b/tests/Elm/Parser/Samples.elm
@@ -470,7 +470,7 @@ type alias Post = {
   id: Int,
   title: String,
   text: Maybe String
-}
+  }
 
 """
 


### PR DESCRIPTION
- a sample file contained a parsing error (it's a bug in elm-syntax that it was parsed in the first place, will fix in the next PR)
- there aren't samples for numbers you might expect, which means going through the list of them using `List.indexedMap` as was done in the file tests gave the wrong sample indexes
- The errors produced by these sample tests were displayed as `Nothing |expectNotEqual Nothing`. Now it shows the actual info for debugging

I thought I was going insane for about an hour due to the combination of these 3 (4) things, so I'm glad this is fixed now.