### PR TITLE
Remove the Operator Expression variant

### DIFF
--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -97,7 +97,6 @@ type alias FunctionImplementation =
   - `RecordAccessFunction`: `.name`
   - `RecordUpdate`: `{ a | name = "text" }`
   - `GLSL`: `[glsl| ... |]`
-  - `Operator`: `+` (not possible to get in practice)
 
 -}
 type Expression
@@ -122,7 +121,6 @@ type Expression
     | RecordAccessFunction String
     | RecordUpdate (Node String) (Node RecordSetter) (List (Node RecordSetter))
     | GLSL String
-    | Operator String
 
 
 {-| Indicates whether a string literal is single (`"abc"`) or triple-quoted (`"""abc"""`).


### PR DESCRIPTION
Finally! All of the Pratt parser work finally paid off, and we can get rid of this weird node type!