### PR TITLE
small layout corrections and small performance improvements

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -25,7 +25,7 @@ import Rope
 declaration : Parser (WithComments (Node Declaration))
 declaration =
     Parser.oneOf
-        [ (Parser.map
+        [ Parser.map
             (\documentation ->
                 \commentsAfterDocumentation ->
                     \afterDocumentation ->
@@ -185,7 +185,6 @@ declaration =
                 , typeOrTypeAliasDefinitionAfterDocumentation
                 , portDeclarationAfterDocumentation
                 ]
-          )
             |> Parser.andThen identity
         , infixDeclaration
         , functionDeclarationWithoutDocumentation
@@ -326,7 +325,7 @@ functionAfterDocumentation =
 
 functionDeclarationWithoutDocumentation : Parser (WithComments (Node Declaration))
 functionDeclarationWithoutDocumentation =
-    (Parser.map
+    Parser.map
         (\( startNameStartRow, startNameStartColumn ) ->
             \startName ->
                 \commentsAfterStartName ->
@@ -462,7 +461,6 @@ functionDeclarationWithoutDocumentation =
         |. Tokens.equal
         |= Layout.maybeLayout
         |= expression
-    )
         |> Parser.andThen identity
 
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1116,7 +1116,8 @@ expressionHelp currentPrecedence leftExpression =
                 )
                 Layout.optimisticLayout
                 |= Parser.oneOf
-                    [ justCombineOneOfApply parser leftExpression.syntax
+                    [ Parser.oneOf parser
+                        |> Parser.map (\f -> Just (f leftExpression.syntax))
                     , parserSucceedNothing
                     ]
 
@@ -1127,18 +1128,6 @@ expressionHelp currentPrecedence leftExpression =
 parserSucceedNothing : Parser (Maybe a)
 parserSucceedNothing =
     Parser.succeed Nothing
-
-
-justCombineOneOfApply :
-    List (Parser (arg -> WithComments arg))
-    -> arg
-    -> Parser (Maybe (WithComments arg))
-justCombineOneOfApply possibilitiesForCurrentPrecedence leftExpression =
-    Parser.oneOf
-        (List.map
-            (\parser -> parser |> Parser.map (\f -> Just (f leftExpression)))
-            possibilitiesForCurrentPrecedence
-        )
 
 
 getAndThenOneOfAbovePrecedence : Int -> Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -55,7 +55,7 @@ subExpressionsOneOf =
             ]
 
 
-andThenOneOf : List ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+andThenOneOf : List ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 andThenOneOf =
     -- TODO Add tests for all operators
     -- TODO Report a syntax error when encountering multiple of the comparison operators
@@ -97,7 +97,7 @@ expression =
     subExpression 0
 
 
-recordAccess : ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+recordAccess : ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 recordAccess =
     postfix 100
         recordAccessParser
@@ -142,7 +142,7 @@ dotField =
         |= Tokens.functionName
 
 
-functionCall : ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+functionCall : ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 functionCall =
     infixLeftWithState 90
         Layout.positivelyIndented
@@ -1116,8 +1116,7 @@ expressionHelp currentPrecedence leftExpression =
                 )
                 Layout.optimisticLayout
                 |= Parser.oneOf
-                    [ Parser.map Just
-                        (combineOneOfApply parser leftExpression.syntax)
+                    [ justCombineOneOfApply parser leftExpression.syntax
                     , parserSucceedNothing
                     ]
 
@@ -1130,19 +1129,19 @@ parserSucceedNothing =
     Parser.succeed Nothing
 
 
-combineOneOfApply :
-    List (arg -> Parser (WithComments arg))
+justCombineOneOfApply :
+    List (Parser (arg -> WithComments arg))
     -> arg
-    -> Parser (WithComments arg)
-combineOneOfApply possibilitiesForCurrentPrecedence leftExpression =
+    -> Parser (Maybe (WithComments arg))
+justCombineOneOfApply possibilitiesForCurrentPrecedence leftExpression =
     Parser.oneOf
         (List.map
-            (\parser -> parser leftExpression)
+            (\parser -> parser |> Parser.map (\f -> Just (f leftExpression)))
             possibilitiesForCurrentPrecedence
         )
 
 
-getAndThenOneOfAbovePrecedence : Int -> Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+getAndThenOneOfAbovePrecedence : Int -> Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 getAndThenOneOfAbovePrecedence precedence =
     case precedence of
         0 ->
@@ -1188,72 +1187,72 @@ getAndThenOneOfAbovePrecedence precedence =
             Nothing
 
 
-justAndThenOneOfAbovePrecedence0 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence0 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence0 =
     Just (computeAndThenOneOfAbovePrecedence 0)
 
 
-justAndThenOneOfAbovePrecedence1 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence1 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence1 =
     Just (computeAndThenOneOfAbovePrecedence 1)
 
 
-justAndThenOneOfAbovePrecedence2 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence2 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence2 =
     Just (computeAndThenOneOfAbovePrecedence 2)
 
 
-justAndThenOneOfAbovePrecedence3 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence3 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence3 =
     Just (computeAndThenOneOfAbovePrecedence 3)
 
 
-justAndThenOneOfAbovePrecedence4 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence4 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence4 =
     Just (computeAndThenOneOfAbovePrecedence 4)
 
 
-justAndThenOneOfAbovePrecedence5 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence5 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence5 =
     Just (computeAndThenOneOfAbovePrecedence 5)
 
 
-justAndThenOneOfAbovePrecedence6 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence6 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence6 =
     Just (computeAndThenOneOfAbovePrecedence 6)
 
 
-justAndThenOneOfAbovePrecedence7 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence7 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence7 =
     Just (computeAndThenOneOfAbovePrecedence 7)
 
 
-justAndThenOneOfAbovePrecedence8 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence8 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence8 =
     Just (computeAndThenOneOfAbovePrecedence 8)
 
 
-justAndThenOneOfAbovePrecedence9 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence9 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence9 =
     Just (computeAndThenOneOfAbovePrecedence 9)
 
 
-justAndThenOneOfAbovePrecedence90 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence90 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence90 =
     Just (computeAndThenOneOfAbovePrecedence 90)
 
 
-justAndThenOneOfAbovePrecedence95 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence95 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence95 =
     Just (computeAndThenOneOfAbovePrecedence 95)
 
 
-justAndThenOneOfAbovePrecedence100 : Maybe (List (Node Expression -> Parser (WithComments (Node Expression))))
+justAndThenOneOfAbovePrecedence100 : Maybe (List (Parser (Node Expression -> WithComments (Node Expression))))
 justAndThenOneOfAbovePrecedence100 =
     Just (computeAndThenOneOfAbovePrecedence 100)
 
 
-computeAndThenOneOfAbovePrecedence : Int -> List (Node Expression -> Parser (WithComments (Node Expression)))
+computeAndThenOneOfAbovePrecedence : Int -> List (Parser (Node Expression -> WithComments (Node Expression)))
 computeAndThenOneOfAbovePrecedence currentPrecedence =
     andThenOneOf
         |> List.filterMap
@@ -1266,7 +1265,7 @@ computeAndThenOneOfAbovePrecedence currentPrecedence =
             )
 
 
-infixLeft : Int -> String -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixLeft : Int -> String -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixLeft precedence symbol =
     infixLeftHelp precedence
         (Parser.symbol symbol)
@@ -1277,7 +1276,7 @@ infixLeft precedence symbol =
         )
 
 
-infixNonAssociative : Int -> String -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixNonAssociative : Int -> String -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixNonAssociative precedence symbol =
     infixLeftHelp precedence
         (Parser.symbol symbol)
@@ -1288,7 +1287,7 @@ infixNonAssociative precedence symbol =
         )
 
 
-infixRight : Int -> String -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixRight : Int -> String -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixRight precedence symbol =
     infixRightHelp precedence
         (Parser.symbol symbol)
@@ -1306,7 +1305,7 @@ lookBehindOneCharacter =
         |= Parser.getSource
 
 
-infixLeftSubtraction : Int -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixLeftSubtraction : Int -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixLeftSubtraction precedence =
     infixLeftHelp precedence
         (lookBehindOneCharacter
@@ -1327,61 +1326,49 @@ infixLeftSubtraction precedence =
         )
 
 
-infixLeftHelp : Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixLeftHelp : Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixLeftHelp precedence p apply =
     infixHelp precedence precedence p apply
 
 
-infixLeftWithState : Int -> Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixLeftWithState : Int -> Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixLeftWithState precedence operator apply =
-    let
-        parser : Parser (WithComments (Node Expression))
-        parser =
-            subExpression precedence
-    in
     ( precedence
-    , \left ->
-        operator
-            |> Parser.Extra.continueWith
-                (Parser.map (\e -> { comments = e.comments, syntax = apply left e.syntax })
-                    parser
-                )
+    , operator
+        |> Parser.Extra.continueWith
+            (Parser.map (\e -> \left -> { comments = e.comments, syntax = apply left e.syntax })
+                (subExpression precedence)
+            )
     )
 
 
-infixRightHelp : Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixRightHelp : Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixRightHelp precedence p apply =
     -- To get right associativity, we use (precedence - 1) for the
     -- right precedence.
     infixHelp precedence (precedence - 1) p apply
 
 
-infixHelp : Int -> Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
+infixHelp : Int -> Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixHelp leftPrecedence rightPrecedence operator apply =
-    let
-        parser : Parser (WithComments (Node Expression))
-        parser =
-            subExpression rightPrecedence
-    in
     ( leftPrecedence
-    , \left ->
-        operator
-            |> Parser.Extra.continueWith
-                (Parser.map (\e -> { comments = e.comments, syntax = apply left e.syntax })
-                    parser
-                )
+    , operator
+        |> Parser.Extra.continueWith
+            (Parser.map (\e -> \left -> { comments = e.comments, syntax = apply left e.syntax })
+                (subExpression rightPrecedence)
+            )
     )
 
 
-postfix : Int -> Parser a -> (expr -> a -> expr) -> ( Int, expr -> Parser (WithComments expr) )
+postfix : Int -> Parser a -> (expr -> a -> expr) -> ( Int, Parser (expr -> WithComments expr) )
 postfix precedence operator apply =
     ( precedence
-    , \left ->
-        Parser.map
-            (\right ->
+    , Parser.map
+        (\right ->
+            \left ->
                 { comments = Rope.empty
                 , syntax = apply left right
                 }
-            )
-            operator
+        )
+        operator
     )

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -17,13 +17,8 @@ import ParserWithComments exposing (Comments, WithComments)
 import Rope
 
 
-subExpressions : Parser (WithComments (Node Expression))
-subExpressions =
-    Parser.lazy (\() -> subExpressionsOneOf)
-
-
-subExpressionsOneOf : Parser (WithComments (Node Expression))
-subExpressionsOneOf =
+subExpression : Parser (WithComments (Node Expression))
+subExpression =
     Parser.map
         (\( startRow, startColumn ) ->
             \expressionAndEnd ->
@@ -1154,7 +1149,7 @@ subExpressionMap toExtensionRightWith aboveCurrentPrecedenceLayout =
                     }
         )
         Layout.optimisticLayout
-        |= subExpressions
+        |= Parser.lazy (\() -> subExpression)
         |= Layout.optimisticLayout
         |> Parser.andThen
             (\leftExpression -> Parser.loop leftExpression step)

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -144,7 +144,7 @@ dotField =
 
 functionCall : ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 functionCall =
-    infixLeftWithState 90
+    infixLeftHelp 90
         Layout.positivelyIndented
         (\((Node { start } leftValue) as left) ((Node { end } _) as right) ->
             Node
@@ -1329,17 +1329,6 @@ infixLeftSubtraction precedence =
 infixLeftHelp : Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
 infixLeftHelp precedence p apply =
     infixHelp precedence precedence p apply
-
-
-infixLeftWithState : Int -> Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )
-infixLeftWithState precedence operator apply =
-    ( precedence
-    , operator
-        |> Parser.Extra.continueWith
-            (Parser.map (\e -> \left -> { comments = e.comments, syntax = apply left e.syntax })
-                (subExpression precedence)
-            )
-    )
 
 
 infixRightHelp : Int -> Parser.Parser () -> (Node Expression -> Node Expression -> Node Expression) -> ( Int, Parser (Node Expression -> WithComments (Node Expression)) )

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1138,8 +1138,7 @@ subExpressionMap toExtensionRightWith aboveCurrentPrecedenceLayout =
                     )
                     aboveCurrentPrecedenceLayout
                     |= Layout.optimisticLayout
-                , -- TODO lazy?
-                  Parser.succeed
+                , Parser.succeed
                     (Parser.Done (toExtensionRightWith leftExpressionResult))
                 ]
     in

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -911,18 +911,16 @@ referenceExpression =
             (\firstName ->
                 \after ->
                     \( endRow, endColumn ) ->
-                        case after of
-                            Nothing ->
-                                { comments = Rope.empty
-                                , end = { row = endRow, column = endColumn }
-                                , expression = FunctionOrValue [] firstName
-                                }
+                        { comments = Rope.empty
+                        , end = { row = endRow, column = endColumn }
+                        , expression =
+                            case after of
+                                Nothing ->
+                                    FunctionOrValue [] firstName
 
-                            Just ( qualificationAfter, unqualified ) ->
-                                { comments = Rope.empty
-                                , end = { row = endRow, column = endColumn }
-                                , expression = FunctionOrValue (firstName :: qualificationAfter) unqualified
-                                }
+                                Just ( qualificationAfter, unqualified ) ->
+                                    FunctionOrValue (firstName :: qualificationAfter) unqualified
+                        }
             )
             Tokens.typeName
             |= maybeDotReferenceExpressionTuple

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1188,9 +1188,13 @@ applyExtensionRight extensionRight ((Node { start } left) as leftNode) =
                     )
                 )
 
-        ExtendRightByOperation symbol direction ((Node { end } _) as right) ->
+        ExtendRightByOperation extendRightOperation ->
+            let
+                ((Node { end } _) as right) =
+                    extendRightOperation.expression
+            in
             Node { start = start, end = end }
-                (OperatorApplication symbol direction leftNode right)
+                (OperatorApplication extendRightOperation.symbol extendRightOperation.direction leftNode right)
 
 
 abovePrecedence0 : Parser (WithComments ExtensionRight)
@@ -1268,7 +1272,7 @@ infixLeft precedence possibilitiesForPrecedence symbol =
         possibilitiesForPrecedence
         (Parser.symbol symbol)
         (\right ->
-            ExtendRightByOperation symbol Infix.Left right
+            ExtendRightByOperation { symbol = symbol, direction = Infix.Left, expression = right }
         )
 
 
@@ -1278,7 +1282,7 @@ infixNonAssociative precedence possibilitiesForPrecedence symbol =
         possibilitiesForPrecedence
         (Parser.symbol symbol)
         (\right ->
-            ExtendRightByOperation symbol Infix.Non right
+            ExtendRightByOperation { symbol = symbol, direction = Infix.Non, expression = right }
         )
 
 
@@ -1291,7 +1295,7 @@ infixRight precedence possibilitiesForPrecedenceMinus1 symbol =
         possibilitiesForPrecedenceMinus1
         (Parser.symbol symbol)
         (\right ->
-            ExtendRightByOperation symbol Infix.Right right
+            ExtendRightByOperation { symbol = symbol, direction = Infix.Right, expression = right }
         )
 
 
@@ -1318,7 +1322,7 @@ infixLeftSubtraction precedence possibilitiesForPrecedence =
                 )
         )
         (\right ->
-            ExtendRightByOperation "-" Infix.Left right
+            ExtendRightByOperation { symbol = "-", direction = Infix.Left, expression = right }
         )
 
 
@@ -1357,6 +1361,6 @@ postfix precedence operator apply =
 
 
 type ExtensionRight
-    = ExtendRightByOperation String Infix.InfixDirection (Node Expression)
+    = ExtendRightByOperation { symbol : String, direction : Infix.InfixDirection, expression : Node Expression }
     | ExtendRightByApplication (Node Expression)
     | ExtendRightByRecordAccess (Node String)

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -618,14 +618,22 @@ letExpression =
 
 letDeclarations : Parser (WithComments (List (Node LetDeclaration)))
 letDeclarations =
-    Parser.map
-        (\head ->
-            \tail ->
-                { comments = head.comments |> Rope.prependTo tail.comments
-                , syntax = head.syntax :: tail.syntax
-                }
+    Layout.onTopIndentation
+        (\headLetResult ->
+            \commentsAfter ->
+                \tailLetResult ->
+                    { comments =
+                        headLetResult.comments
+                            |> Rope.prependTo commentsAfter
+                            |> Rope.prependTo tailLetResult.comments
+                    , syntax = headLetResult.syntax :: tailLetResult.syntax
+                    }
         )
-        blockElement
+        |= Parser.oneOf
+            [ letFunction
+            , letDestructuringDeclaration
+            ]
+        |= Layout.optimisticLayout
         |= ParserWithComments.many blockElement
 
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1097,7 +1097,7 @@ tupledExpressionInnerAfterOpeningParens =
         )
         expression
         |= Layout.maybeLayout
-        |= ParserWithComments.manyWithoutReverse
+        |= ParserWithComments.untilWithoutReverse Tokens.parensEnd
             (Tokens.comma
                 |> Parser.Extra.continueWith
                     (Parser.map
@@ -1116,7 +1116,6 @@ tupledExpressionInnerAfterOpeningParens =
                         |= Layout.maybeLayout
                     )
             )
-        |. Tokens.parensEnd
         |= Parser.getPosition
 
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -122,7 +122,7 @@ problemRecordAccessStartingWithSpace =
 
 dotField : Parser.Parser (Node String)
 dotField =
-    Tokens.dot
+    (Tokens.dot
         |> Parser.Extra.continueWith
             (Parser.map
                 (\( nameStartRow, nameStartColumn ) ->
@@ -131,8 +131,9 @@ dotField =
                             name
                 )
                 Parser.getPosition
-                |= Tokens.functionName
             )
+    )
+        |= Tokens.functionName
 
 
 functionCall : ( Int, Node Expression -> Parser (WithComments (Node Expression)) )
@@ -463,7 +464,7 @@ lambdaExpression =
 
 caseExpression : Parser (WithComments (Node Expression))
 caseExpression =
-    (Parser.map
+    Parser.map
         (\( startRow, startColumn ) ->
             \commentsAfterCase ->
                 \casedExpressionResult ->
@@ -500,7 +501,6 @@ caseExpression =
         |. Tokens.caseToken
         |= Layout.layout
         |= expression
-    )
         |. Layout.positivelyIndented
         |. Tokens.ofToken
         |= Layout.layout
@@ -631,7 +631,7 @@ letDestructuringDeclaration =
 
 letFunction : Parser (WithComments (Node LetDeclaration))
 letFunction =
-    (Parser.map
+    Parser.map
         (\( startNameStartRow, startNameStartColumn ) ->
             \startName ->
                 \commentsAfterStartName ->
@@ -764,7 +764,6 @@ letFunction =
                 Patterns.pattern
                 |= Layout.maybeLayout
             )
-    )
         |. Tokens.equal
         |= Layout.maybeLayout
         |= expression

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -34,8 +34,8 @@ subExpression =
         )
         Parser.getPosition
         |= Parser.oneOf
-            [ qualifiedReferenceExpression
-            , unqualifiedReferenceExpression
+            [ qualifiedOrVariantOrRecordConstructorReferenceExpression
+            , unqualifiedFunctionReferenceExpression
             , literalExpression
             , numberExpression
             , tupledExpression
@@ -933,8 +933,8 @@ problemNegationThenSpace =
     Parser.problem "negation sign cannot be followed by a space"
 
 
-qualifiedReferenceExpression : Parser { comments : Comments, end : Location, expression : Expression }
-qualifiedReferenceExpression =
+qualifiedOrVariantOrRecordConstructorReferenceExpression : Parser { comments : Comments, end : Location, expression : Expression }
+qualifiedOrVariantOrRecordConstructorReferenceExpression =
     Parser.map
         (\firstName ->
             \after ->
@@ -955,8 +955,8 @@ qualifiedReferenceExpression =
         |= Parser.getPosition
 
 
-unqualifiedReferenceExpression : Parser { comments : Comments, end : Location, expression : Expression }
-unqualifiedReferenceExpression =
+unqualifiedFunctionReferenceExpression : Parser { comments : Comments, end : Location, expression : Expression }
+unqualifiedFunctionReferenceExpression =
     Parser.map
         (\unqualified ->
             \( endRow, endColumn ) ->

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1180,8 +1180,8 @@ applyExtensionRight extensionRight ((Node { start } left) as leftNode) =
             Node { start = start, end = end }
                 (Expression.Application
                     (case left of
-                        Expression.Application args ->
-                            args ++ [ right ]
+                        Expression.Application (called :: firstArg :: secondArgUp) ->
+                            called :: firstArg :: (secondArgUp ++ [ right ])
 
                         _ ->
                             [ leftNode, right ]

--- a/src/Elm/Parser/File.elm
+++ b/src/Elm/Parser/File.elm
@@ -57,16 +57,13 @@ file =
 fileDeclarations : Parser (WithComments (List (Node Declaration)))
 fileDeclarations =
     ParserWithComments.many
-        (Parser.map
+        (Layout.moduleLevelIndentation
             (\declarationParsed ->
                 \commentsAfter ->
                     { comments = declarationParsed.comments |> Rope.prependTo commentsAfter
                     , syntax = declarationParsed.syntax
                     }
             )
-            declaration
-            |= Parser.oneOf
-                [ Layout.layoutStrict
-                , Parser.succeed Rope.empty
-                ]
+            |= declaration
+            |= Layout.optimisticLayout
         )

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -175,8 +175,7 @@ optimisticLayout =
 layoutStrict : Parser Comments
 layoutStrict =
     optimisticLayout
-        |. verifyIndent (\stateIndent current -> stateIndent == current)
-            (\stateIndent current -> "Expected indent " ++ String.fromInt stateIndent ++ ", got " ++ String.fromInt current)
+        |. onTopIndentation ()
 
 
 moduleLevelIndentation : res -> Parser res

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -199,11 +199,16 @@ problemModuleLevelIndentation =
 
 onTopIndentation : res -> Parser res
 onTopIndentation res =
+    let
+        succeedRes : Parser res
+        succeedRes =
+            Parser.succeed res
+    in
     Parser.map
         (\column ->
             \indent ->
                 if column == indent then
-                    Parser.succeed res
+                    succeedRes
 
                 else
                     problemTopIndentation

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -7,6 +7,7 @@ module Elm.Parser.Layout exposing
     , onTopIndentation
     , optimisticLayout
     , positivelyIndented
+    , positivelyIndentedPlus
     )
 
 import Elm.Parser.Comments as Comments
@@ -95,6 +96,25 @@ maybeLayout : Parser Comments
 maybeLayout =
     whitespaceAndCommentsOrEmpty
         |. positivelyIndented
+
+
+{-| Use to check that the indentation of an already parsed token
+would be valid for [`positivelyIndented`](#positivelyIndented)
+-}
+positivelyIndentedPlus : Int -> Parser.Parser ()
+positivelyIndentedPlus extraIndent =
+    Parser.map
+        (\column ->
+            \indent ->
+                if column > indent + extraIndent then
+                    succeedUnit
+
+                else
+                    problemPositivelyIndented
+        )
+        Parser.getCol
+        |= Parser.getIndent
+        |> Parser.andThen identity
 
 
 positivelyIndented : Parser.Parser ()

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -3,6 +3,7 @@ module Elm.Parser.Layout exposing
     , layoutStrict
     , maybeAroundBothSides
     , maybeLayout
+    , moduleLevelIndentation
     , onTopIndentation
     , optimisticLayout
     , positivelyIndented
@@ -178,12 +179,30 @@ layoutStrict =
             (\stateIndent current -> "Expected indent " ++ String.fromInt stateIndent ++ ", got " ++ String.fromInt current)
 
 
+moduleLevelIndentation : res -> Parser res
+moduleLevelIndentation res =
+    Parser.andThen
+        (\column ->
+            if column == 1 then
+                Parser.succeed res
+
+            else
+                problemModuleLevelIndentation
+        )
+        Parser.getCol
+
+
+problemModuleLevelIndentation : Parser.Parser a
+problemModuleLevelIndentation =
+    Parser.problem "must be on module-level indentation"
+
+
 onTopIndentation : res -> Parser res
 onTopIndentation res =
     Parser.map
         (\column ->
             \indent ->
-                if indent == column then
+                if column == indent then
                     Parser.succeed res
 
                 else

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -179,10 +179,15 @@ layoutStrict =
 
 moduleLevelIndentation : res -> Parser res
 moduleLevelIndentation res =
+    let
+        succeedRes : Parser res
+        succeedRes =
+            Parser.succeed res
+    in
     Parser.andThen
         (\column ->
             if column == 1 then
-                Parser.succeed res
+                succeedRes
 
             else
                 problemModuleLevelIndentation

--- a/src/Elm/Parser/Modules.elm
+++ b/src/Elm/Parser/Modules.elm
@@ -25,7 +25,7 @@ moduleDefinition =
 
 effectWhereClause : Parser (WithComments ( String, Node String ))
 effectWhereClause =
-    (Parser.map
+    Parser.map
         (\fnName ->
             \commentsAfterFnName ->
                 \commentsAfterEqual ->
@@ -36,7 +36,6 @@ effectWhereClause =
         )
         Tokens.functionName
         |= Layout.maybeLayout
-    )
         |. Tokens.equal
         |= Layout.maybeLayout
         |= Node.parserCore Tokens.typeName

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -142,7 +142,7 @@ parensPattern =
                         |= Layout.maybeLayout
                         |= ParserWithComments.until Tokens.parensEnd
                             (Tokens.comma |> Parser.Extra.continueWith (Layout.maybeAroundBothSides pattern))
-                    , Parser.succeed { comments = Rope.empty, syntax = UnitPattern }
+                    , Parser.map (\() -> { comments = Rope.empty, syntax = UnitPattern }) Tokens.parensEnd
                     ]
             )
 

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -260,7 +260,7 @@ stringPattern =
 maybeDotTypeNamesTuple : Parser.Parser (Maybe ( List String, String ))
 maybeDotTypeNamesTuple =
     Parser.oneOf
-        [ Tokens.dot
+        [ (Tokens.dot
             |> Parser.Extra.continueWith
                 (Parser.map
                     (\startName ->
@@ -273,8 +273,9 @@ maybeDotTypeNamesTuple =
                                     Just ( startName :: qualificationAfter, unqualified )
                     )
                     Tokens.typeName
-                    |= Parser.lazy (\() -> maybeDotTypeNamesTuple)
                 )
+          )
+            |= Parser.lazy (\() -> maybeDotTypeNamesTuple)
         , Parser.succeed Nothing
         ]
 
@@ -375,7 +376,7 @@ recordPattern =
                 |= Tokens.functionName
                 |= Layout.maybeLayout
                 |= ParserWithComments.many
-                    (Tokens.comma
+                    ((Tokens.comma
                         |> Parser.Extra.continueWith
                             (Parser.map
                                 (\beforeName ->
@@ -390,10 +391,11 @@ recordPattern =
                                                 }
                                 )
                                 Layout.maybeLayout
-                                |= Parser.getPosition
-                                |= Tokens.functionName
-                                |= Layout.maybeLayout
                             )
+                     )
+                        |= Parser.getPosition
+                        |= Tokens.functionName
+                        |= Layout.maybeLayout
                     )
             , Parser.succeed Nothing
             ]

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -17,8 +17,8 @@ composedWith =
     Parser.map
         (\commentsBefore composedWithResult ->
             case composedWithResult of
-                PatternComposedWithNothing ->
-                    PatternComposedWithNothing
+                PatternComposedWithNothing () ->
+                    PatternComposedWithNothing ()
 
                 PatternComposedWithAs composedWithAs ->
                     PatternComposedWithAs
@@ -67,12 +67,12 @@ composedWith =
                     )
               )
                 |= pattern
-            , Parser.succeed PatternComposedWithNothing
+            , Parser.succeed (PatternComposedWithNothing ())
             ]
 
 
 type PatternComposedWith
-    = PatternComposedWithNothing
+    = PatternComposedWithNothing ()
     | PatternComposedWithAs (WithComments (Node String))
     | PatternComposedWithCons (WithComments (Node Pattern))
 
@@ -88,7 +88,7 @@ composablePatternTryToCompose =
         (\x ->
             \maybeComposedWith ->
                 case maybeComposedWith of
-                    PatternComposedWithNothing ->
+                    PatternComposedWithNothing () ->
                         x
 
                     PatternComposedWithAs anotherName ->

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -142,7 +142,7 @@ parensPattern =
                         |= Layout.maybeLayout
                         |= ParserWithComments.until Tokens.parensEnd
                             (Tokens.comma |> Parser.Extra.continueWith (Layout.maybeAroundBothSides pattern))
-                    , Parser.map (\() -> { comments = Rope.empty, syntax = UnitPattern }) Tokens.parensEnd
+                    , Parser.map (\() -> unitPatternWithComments) Tokens.parensEnd
                     ]
             )
 

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -246,11 +246,38 @@ functionName =
     Parser.variable
         { inner =
             \c ->
-                -- checking for Char.isAlphaNum early is much faster
-                Char.isAlphaNum c || c == '_' || Unicode.isAlphaNum c
+                -- checking for these common ranges early is much faster
+                charIsAlphaNumFast c || c == '_' || Unicode.isAlphaNum c
         , reserved = reservedList
-        , start = \c -> Char.isLower c || Unicode.isLower c
+        , start =
+            \c -> Char.isLower c || Unicode.isLower c
         }
+
+
+charIsAlphaNumFast : Char -> Bool
+charIsAlphaNumFast char =
+    -- Char.isAlphaNum does not reuse the same Char.toCode and is therefore slightly slower
+    let
+        charCode : Int
+        charCode =
+            char |> Char.toCode
+    in
+    charCodeIsLower charCode || charCodeIsUpper charCode || charCodeIsDigit charCode
+
+
+charCodeIsLower : Int -> Bool
+charCodeIsLower code =
+    0x61 <= code && code <= 0x7A
+
+
+charCodeIsUpper : Int -> Bool
+charCodeIsUpper code =
+    code <= 0x5A && 0x41 <= code
+
+
+charCodeIsDigit : Int -> Bool
+charCodeIsDigit code =
+    code <= 0x39 && 0x30 <= code
 
 
 typeName : Parser.Parser String
@@ -258,10 +285,11 @@ typeName =
     Parser.variable
         { inner =
             \c ->
-                -- checking for Char.isAlphaNum early is much faster
-                Char.isAlphaNum c || c == '_' || Unicode.isAlphaNum c
+                -- checking for these common ranges early is much faster
+                charIsAlphaNumFast c || c == '_' || Unicode.isAlphaNum c
         , reserved = Set.empty
-        , start = \c -> Char.isUpper c || Unicode.isUpper c
+        , start =
+            \c -> Char.isUpper c || Unicode.isUpper c
         }
 
 

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -86,37 +86,37 @@ asToken =
 
 ifToken : Parser.Parser ()
 ifToken =
-    Parser.symbol "if"
+    Parser.keyword "if"
 
 
 thenToken : Parser.Parser ()
 thenToken =
-    Parser.symbol "then"
+    Parser.keyword "then"
 
 
 elseToken : Parser.Parser ()
 elseToken =
-    Parser.symbol "else"
+    Parser.keyword "else"
 
 
 caseToken : Parser.Parser ()
 caseToken =
-    Parser.symbol "case"
+    Parser.keyword "case"
 
 
 ofToken : Parser.Parser ()
 ofToken =
-    Parser.symbol "of"
+    Parser.keyword "of"
 
 
 letToken : Parser.Parser ()
 letToken =
-    Parser.symbol "let"
+    Parser.keyword "let"
 
 
 inToken : Parser.Parser ()
 inToken =
-    Parser.symbol "in"
+    Parser.keyword "in"
 
 
 aliasToken : Parser.Parser ()

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -76,7 +76,7 @@ parensTypeAnnotation =
             (Parser.oneOf
                 [ Tokens.parensEnd
                     |> Parser.map (\() -> unitWithComments)
-                , (Parser.map
+                , Parser.map
                     (\commentsBeforeFirstPart ->
                         \firstPart ->
                             \commentsAfterFirstPart ->
@@ -122,7 +122,6 @@ parensTypeAnnotation =
                             |= typeAnnotation
                             |= Layout.maybeLayout
                         )
-                  )
                     |. Tokens.parensEnd
                 ]
             )
@@ -329,7 +328,7 @@ typedTypeAnnotationWithoutArguments =
 maybeDotTypeNamesTuple : Parser.Parser (Maybe ( List String, String ))
 maybeDotTypeNamesTuple =
     Parser.oneOf
-        [ Tokens.dot
+        [ (Tokens.dot
             |> Parser.Extra.continueWith
                 (Parser.map
                     (\firstName ->
@@ -342,8 +341,9 @@ maybeDotTypeNamesTuple =
                                     Just ( firstName :: qualificationAfter, unqualified )
                     )
                     Tokens.typeName
-                    |= Parser.lazy (\() -> maybeDotTypeNamesTuple)
                 )
+          )
+            |= Parser.lazy (\() -> maybeDotTypeNamesTuple)
         , Parser.succeed Nothing
         ]
 

--- a/src/Elm/Parser/TypeAnnotation.elm
+++ b/src/Elm/Parser/TypeAnnotation.elm
@@ -102,7 +102,7 @@ parensTypeAnnotation =
                     Layout.maybeLayout
                     |= typeAnnotation
                     |= Layout.maybeLayout
-                    |= ParserWithComments.manyWithoutReverse
+                    |= ParserWithComments.untilWithoutReverse Tokens.parensEnd
                         ((Tokens.comma
                             |> Parser.Extra.continueWith
                                 (Parser.map
@@ -122,7 +122,6 @@ parensTypeAnnotation =
                             |= typeAnnotation
                             |= Layout.maybeLayout
                         )
-                    |. Tokens.parensEnd
                 ]
             )
 

--- a/src/ParserWithComments.elm
+++ b/src/ParserWithComments.elm
@@ -3,7 +3,6 @@ module ParserWithComments exposing
     , WithComments
     , many
     , manyWithoutReverse
-    , sepBy
     , sepBy1
     , until
     , untilWithoutReverse
@@ -168,27 +167,6 @@ manyWithoutReverse p =
 listEmptyWithComments : WithComments (List b)
 listEmptyWithComments =
     { comments = Rope.empty, syntax = [] }
-
-
-sepBy : String -> Parser (WithComments a) -> Parser (WithComments (List a))
-sepBy sep p =
-    Parser.oneOf
-        [ Parser.map
-            (\head ->
-                \tail ->
-                    { comments = head.comments |> Rope.prependTo tail.comments
-                    , syntax = head.syntax :: tail.syntax
-                    }
-            )
-            p
-            |= many (Parser.symbol sep |> Parser.Extra.continueWith p)
-        , parserSucceedListEmptyWithComments
-        ]
-
-
-parserSucceedListEmptyWithComments : Parser (WithComments (List a))
-parserSucceedListEmptyWithComments =
-    Parser.succeed { comments = Rope.empty, syntax = [] }
 
 
 sepBy1 : String -> Parser (WithComments a) -> Parser (WithComments (List a))

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -812,6 +812,12 @@ type Color = Blue String | Red | Green"""
             \() ->
                 parse "type Maybe a = Just a |\nNothing" Elm.Parser.Declarations.declaration
                     |> Expect.equal Nothing
+        , test "fail if declarations not on module-level" <|
+            \() ->
+                """a = f
+    3
+    b = 4"""
+                    |> expectInvalid
         , test "regression test for disallowing ( +)" <|
             \() ->
                 "a = ( +)"

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -701,6 +701,42 @@ x"""
 in
 x"""
                     |> expectInvalid
+        , test "fail if record closing curly not positively indented" <|
+            \() ->
+                """let
+    x =
+        { a = 0, b = 1
+    }
+in
+x"""
+                    |> expectInvalid
+        , test "fail if tuple closing parens not positively indented" <|
+            \() ->
+                """let
+    x =
+        ( 0, 1
+    )
+in
+x"""
+                    |> expectInvalid
+        , test "fail if operator not positively indented" <|
+            \() ->
+                """let
+    x =
+        0
+    + 1
+in
+x"""
+                    |> expectInvalid
+        , test "fail if function call argument not positively indented" <|
+            \() ->
+                """let
+    x =
+        f 0
+    1
+in
+x"""
+                    |> expectInvalid
         ]
 
 

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -665,6 +665,42 @@ all =
                                 )
                             )
                         )
+        , test "fail if `then` not positively indented" <|
+            \() ->
+                """let
+    x =
+        if True
+   then  1 else 0
+in
+x"""
+                    |> expectInvalid
+        , test "fail if if-true-branch not positively indented" <|
+            \() ->
+                """let
+    x =
+        if True then
+    1   else 0
+in
+x"""
+                    |> expectInvalid
+        , test "fail if `else` not positively indented" <|
+            \() ->
+                """let
+    x =
+        if True then 1
+   else 0
+in
+x"""
+                    |> expectInvalid
+        , test "fail if if-false-branch not positively indented" <|
+            \() ->
+                """let
+    x =
+        if True then 1 else
+    0
+in
+x"""
+                    |> expectInvalid
         ]
 
 

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -665,6 +665,15 @@ all =
                                 )
                             )
                         )
+        , test "fail if condition not positively indented" <|
+            \() ->
+                """let
+    x =
+        if
+    f y then  1 else 0
+in
+x"""
+                    |> expectInvalid
         , test "fail if `then` not positively indented" <|
             \() ->
                 """let
@@ -710,12 +719,48 @@ x"""
 in
 x"""
                     |> expectInvalid
+        , test "fail if record field value not positively indented" <|
+            \() ->
+                """let
+    x =
+        { a = 0, b =
+    1 }
+in
+x"""
+                    |> expectInvalid
+        , test "fail if record field name not positively indented" <|
+            \() ->
+                """let
+    x =
+        { a = 0,
+    b       = 1 }
+in
+x"""
+                    |> expectInvalid
+        , test "fail if record field `=` not positively indented" <|
+            \() ->
+                """let
+    x =
+        { a = 0, b
+    =         1 }
+in
+x"""
+                    |> expectInvalid
         , test "fail if tuple closing parens not positively indented" <|
             \() ->
                 """let
     x =
         ( 0, 1
     )
+in
+x"""
+                    |> expectInvalid
+        , test "fail if tuple part not positively indented" <|
+            \() ->
+                """let
+    x =
+        ( 0,
+    1   )
 in
 x"""
                     |> expectInvalid

--- a/tests/Elm/Parser/PatternTests.elm
+++ b/tests/Elm/Parser/PatternTests.elm
@@ -14,7 +14,17 @@ all =
         [ test "Unit" <|
             \() ->
                 "()"
-                    |> expectAst (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 3 } } UnitPattern)
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 3 } } UnitPattern)
+        , test "Unit with inner layout" <|
+            \() ->
+                """(
+   -- comment
+   )"""
+                    |> expectAstWithComments Parser.pattern
+                        { ast = Node { start = { row = 1, column = 1 }, end = { row = 3, column = 5 } } UnitPattern
+                        , comments = [ Node { start = { row = 2, column = 4 }, end = { row = 2, column = 14 } } "-- comment" ]
+                        }
         , test "String" <|
             \() ->
                 "\"Foo\""


### PR DESCRIPTION
The implementation of `expression` optimistically pads right (and left?). This is sometimes taken for granted, replacing layout, creating a too lenient parser. 
The "new" parser is now sometimes more strict (e.g. requiring `if else` to stay above current indent), and sometimes more lenient (e.g. allowing `case(x)of(Variant)->`).

I found these after converting the expression parser to a non-padding parser (which turned out to be slower so I never committed it but the corrections are still right).

In terms of performance, it's nothing much, the biggest change coming from an avoided `List.map` by switching from `Node Expression -> Parser (Node Expression)` to `Parser (union type)` for the pratt things.

- before (taken from last PR): 18849.700000001118 ms to do 100 runs => 188.49700000001118 ms/run
- after (before additional layout corrections): 16425.19999998808 ms to do 100 runs => 164.25199999988078 ms/run
- after (with additional layout corrections): 16782.10000000894 ms to do 100 runs => 167.8210000000894 ms/run
- after (final optimizations after that): 16077.300000000745 ms to do 100 runs => 160.77300000000744 ms/run
