### PR TITLE
Fix comment order regression

### DIFF
--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -539,8 +539,8 @@ caseStatements =
                                 firstCasePatternResult.comments
                                     |> Rope.prependTo commentsAfterFirstCasePattern
                                     |> Rope.prependTo commentsAfterFirstCaseArrowRight
-                                    |> Rope.prependTo lastToSecondCase.comments
                                     |> Rope.prependTo firstCaseExpressionResult.comments
+                                    |> Rope.prependTo lastToSecondCase.comments
                             , syntax =
                                 ( ( firstCasePatternResult.syntax, firstCaseExpressionResult.syntax )
                                 , lastToSecondCase.syntax

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -113,6 +113,34 @@ f =
                             , Node { start = { row = 20, column = 1 }, end = { row = 20, column = 8 } } "{- 6 -}"
                             ]
                         )
+        , test "declarations with comments" <|
+            \() ->
+                """module Foo exposing (b, fn)
+
+fn a =
+    case a of
+        X ->
+            1
+                -- 1
+                + 2
+
+        Y ->
+            1
+
+-- 2
+
+b =
+    1
+
+"""
+                    |> Elm.Parser.parseToFile
+                    |> Result.map .comments
+                    |> Expect.equal
+                        (Ok
+                            [ Node { start = { row = 7, column = 17 }, end = { row = 7, column = 21 } } "-- 1"
+                            , Node { start = { row = 13, column = 1 }, end = { row = 13, column = 5 } } "-- 2"
+                            ]
+                        )
         , test "function declaration with a case and trailing whitespace" <|
             \() ->
                 """


### PR DESCRIPTION
The order of comments was sometimes wrong for case declarations.

This was introduced in 58e35faba1d6c342e34fe41dac9acd312358888d if I'm not mistaken, so this bug hasn't been published.