### PR TITLE
Add information to Pattern about which quotes a StringPattern is made of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 
 - Changed `Elm.Syntax.Pattern.Pattern`:
   - Removed `FloatPattern` (it was not possible to get)
+  - Added information to `StringPattern` as to whether `"""` or `"` was used:
+    - `StringPattern String` -> `StringPattern StringLiteralType String`
 
 - Changed `Elm.Syntax.TypeAnnotation.TypeAnnotation`:
   - `Tupled` -> `Tuple`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
   - Renamed `Literal` to `StringLiteral`
   - Added information to `String` literal as to whether `"""` or `"` was used:
     - `Literal String` -> `StringLiteral StringLiteralType String`
-    - Added `type StringLiteralType = TripleQuote | SingleQuote`
   - Renamed `Application` to `FunctionCall`
   - `Application (List (Node Expression))` -> `FunctionCall (Node Expression) (Node Expression) (List (Node Expression))` (function is separated, and takes a non-empty list of arguments)
   - Renamed `RecordUpdateExpression` to `RecordUpdate`
@@ -61,6 +60,8 @@
 
 - Changed `Elm.Syntax.Exposing.Exposing`:
   - `Explicit (List (Node TopLevelExpose))` -> `Explicit (Node TopLevelExpose) (List (Node TopLevelExpose))` (takes a non-empty list of elements)
+
+- Added module `Elm.Syntax.StringLiteralType` containing `type StringLiteralType = TripleQuote | SingleQuote`
 
 - Removed deprecated `Elm.Syntax.Range.emptyRange`, use `Elm.Syntax.Range.empty` instead.
 

--- a/elm.json
+++ b/elm.json
@@ -22,6 +22,8 @@
         "Elm.Syntax.Port",
         "Elm.Syntax.Range",
         "Elm.Syntax.Signature",
+        "Elm.Syntax.StringLiteralType",
+        "Elm.Syntax.TypeAlias",
         "Elm.Syntax.TypeAlias",
         "Elm.Syntax.TypeAnnotation",
         "Elm.Syntax.Type"

--- a/src/Elm/Parser/Patterns.elm
+++ b/src/Elm/Parser/Patterns.elm
@@ -259,8 +259,7 @@ unitPatternWithComments =
 stringPattern : Parser (WithComments Pattern)
 stringPattern =
     Tokens.singleOrTripleQuotedStringLiteral
-        -- TODO Store the StringLiteralType information in StringPattern
-        |> Parser.map (\( _, string ) -> { comments = Rope.empty, syntax = StringPattern string })
+        |> Parser.map (\( stringLiteralType, string ) -> { comments = Rope.empty, syntax = StringPattern stringLiteralType string })
 
 
 maybeDotTypeNamesTuple : Parser.Parser (Maybe ( List String, String ))

--- a/src/Elm/Parser/Tokens.elm
+++ b/src/Elm/Parser/Tokens.elm
@@ -21,7 +21,7 @@ module Elm.Parser.Tokens exposing
 -}
 
 import Char
-import Elm.Syntax.Expression exposing (StringLiteralType(..))
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
 import Hex
 import Parser exposing ((|.), Step(..))
 import Parser.Extra

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -1,5 +1,5 @@
 module Elm.Syntax.Expression exposing
-    ( Expression(..), StringLiteralType(..), Lambda, LetBlock, LetDeclaration(..), RecordSetter, CaseBlock, Case, Function, FunctionImplementation
+    ( Expression(..), Lambda, LetBlock, LetDeclaration(..), RecordSetter, CaseBlock, Case, Function, FunctionImplementation
     , functionRange, isLambda, isLet, isIfElse, isCase, isOperation
     )
 
@@ -9,7 +9,7 @@ Although it is a easy and simple language, you can express a lot! See the `Expre
 
 ## Types
 
-@docs Expression, StringLiteralType, Lambda, LetBlock, LetDeclaration, RecordSetter, CaseBlock, Case, Function, FunctionImplementation
+@docs Expression, Lambda, LetBlock, LetDeclaration, RecordSetter, CaseBlock, Case, Function, FunctionImplementation
 
 
 ## Functions
@@ -26,6 +26,7 @@ import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern)
 import Elm.Syntax.Range exposing (Range)
 import Elm.Syntax.Signature exposing (Signature)
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType)
 
 
 {-| Type alias for a full function
@@ -121,13 +122,6 @@ type Expression
     | RecordAccessFunction String
     | RecordUpdate (Node String) (Node RecordSetter) (List (Node RecordSetter))
     | GLSL String
-
-
-{-| Indicates whether a string literal is single (`"abc"`) or triple-quoted (`"""abc"""`).
--}
-type StringLiteralType
-    = SingleQuote
-    | TripleQuote
 
 
 {-| Expression for setting a record field

--- a/src/Elm/Syntax/Pattern.elm
+++ b/src/Elm/Syntax/Pattern.elm
@@ -23,6 +23,7 @@ For example:
 
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType)
 
 
 {-| Custom type for all patterns such as:
@@ -48,7 +49,7 @@ type Pattern
     = AllPattern
     | UnitPattern
     | CharPattern Char
-    | StringPattern String
+    | StringPattern StringLiteralType String
     | IntPattern Int
     | HexPattern Int
     | TuplePattern (List (Node Pattern))

--- a/src/Elm/Syntax/StringLiteralType.elm
+++ b/src/Elm/Syntax/StringLiteralType.elm
@@ -1,0 +1,14 @@
+module Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
+
+{-| Information about quotes.
+
+@docs StringLiteralType
+
+-}
+
+
+{-| Indicates whether a string literal is single (`"abc"`) or triple-quoted (`"""abc"""`).
+-}
+type StringLiteralType
+    = SingleQuote
+    | TripleQuote

--- a/tests/Elm/Parser/CaseExpressionTests.elm
+++ b/tests/Elm/Parser/CaseExpressionTests.elm
@@ -5,6 +5,7 @@ import Elm.Parser.ParserWithCommentsTestUtil as ParserWithCommentsUtil
 import Elm.Syntax.Expression exposing (..)
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (..)
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
 import Expect
 import Test exposing (..)
 
@@ -142,11 +143,11 @@ True -> 1"""
                                         }
                                         (FunctionOrValue [] "x")
                                 , firstCase =
-                                    ( Node { start = { row = 2, column = 9 }, end = { row = 2, column = 39 } } (StringPattern "single line triple quote")
+                                    ( Node { start = { row = 2, column = 9 }, end = { row = 2, column = 39 } } (StringPattern TripleQuote "single line triple quote")
                                     , Node { start = { row = 3, column = 13 }, end = { row = 3, column = 14 } } (IntegerLiteral 1)
                                     )
                                 , restOfCases =
-                                    [ ( Node { start = { row = 4, column = 9 }, end = { row = 5, column = 28 } } (StringPattern "multi line\n            triple quote")
+                                    [ ( Node { start = { row = 4, column = 9 }, end = { row = 5, column = 28 } } (StringPattern TripleQuote "multi line\n            triple quote")
                                       , Node { start = { row = 6, column = 13 }, end = { row = 6, column = 14 } } (IntegerLiteral 2)
                                       )
                                     , ( Node { start = { row = 7, column = 9 }, end = { row = 7, column = 10 } } AllPattern

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -8,6 +8,7 @@ import Elm.Syntax.Expression as Expression exposing (..)
 import Elm.Syntax.Infix as Infix exposing (InfixDirection(..))
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (..)
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (..)
 import Expect
 import Test exposing (..)

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -3,9 +3,10 @@ module Elm.Parser.ExpressionTests exposing (all)
 import Elm.Parser.Expression exposing (expression)
 import Elm.Parser.ParserWithCommentsTestUtil as ParserWithCommentsUtil
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern(..))
-import Elm.Syntax.Expression exposing (Expression(..), StringLiteralType(..))
+import Elm.Syntax.Expression exposing (Expression(..))
 import Elm.Syntax.Infix as Infix exposing (InfixDirection(..))
 import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
 import Expect
 import Test exposing (Test, describe, test)
 

--- a/tests/Elm/Parser/PatternTests.elm
+++ b/tests/Elm/Parser/PatternTests.elm
@@ -4,6 +4,7 @@ import Elm.Parser.ParserWithCommentsTestUtil as ParserWithCommentsUtil exposing 
 import Elm.Parser.Patterns as Parser
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (..)
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
 import Expect
 import Test exposing (..)
 
@@ -28,7 +29,11 @@ all =
         , test "String" <|
             \() ->
                 "\"Foo\""
-                    |> expectAst (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } (StringPattern "Foo"))
+                    |> expectAst (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } (StringPattern SingleQuote "Foo"))
+        , test "Multi-line string" <|
+            \() ->
+                "\"\"\"Foo\"\"\""
+                    |> expectAst (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } } (StringPattern TripleQuote "Foo"))
         , test "Char" <|
             \() ->
                 "'f'"

--- a/tests/Elm/Parser/TokenTests.elm
+++ b/tests/Elm/Parser/TokenTests.elm
@@ -2,7 +2,7 @@ module Elm.Parser.TokenTests exposing (all)
 
 import Elm.Parser.TestUtil exposing (..)
 import Elm.Parser.Tokens as Parser
-import Elm.Syntax.Expression exposing (StringLiteralType(..))
+import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
 import Expect
 import Test exposing (..)
 


### PR DESCRIPTION
- Move the definition of `StringLiteralType` to a separate eponymous module. It was previously in a `Elm.Syntax.Expression`, but that creates a cyclic reference. This is a point in favor of having all AST node types in the same module. I will likely be squashing this change into the commit that introduced the type in the first place, to keep things clean (and therefore easy to rebase).
- Add information to Pattern about which quotes a StringPattern is made of

```elm
case expr of
  StringPattern TripleQuotes str -> ...
  StringPattern SingleQuotes str -> ...
```