### PR TITLE
Remove direction from Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@
   - Renamed `Integer` to `IntegerLiteral`
   - Renamed `Hex` to `HexLiteral`
   - Renamed `ListExpr` to `ListLiteral`
-  - Renamed `OperatorApplication` to `Operation`
+  - `OperatorApplication`
+    - Renamed `OperatorApplication` to `Operation`
+    - Removed the `InfixDirection` field
+    - `OperatorApplication String InfixDirection (Node Expression) (Node Expression)` -> `Operation String (Node Expression) (Node Expression)`
   - Renamed `isOperatorApplication` to `isOperation`
   - Renamed `RecordExpr` to `Record`
   - Renamed `CaseExpression` to `Case`

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -9,7 +9,6 @@ import Elm.Parser.Tokens as Tokens
 import Elm.Parser.TypeAnnotation as TypeAnnotation
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern)
 import Elm.Syntax.Expression as Expression exposing (Case, Expression(..), LetDeclaration(..), RecordSetter)
-import Elm.Syntax.Infix as Infix
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range exposing (Location)
 import Elm.Syntax.Signature exposing (Signature)
@@ -1195,7 +1194,7 @@ applyExtensionRight extensionRight ((Node { start } left) as leftNode) =
                     extendRightOperation.expression
             in
             Node { start = start, end = end }
-                (Operation extendRightOperation.symbol extendRightOperation.direction leftNode right)
+                (Operation extendRightOperation.symbol leftNode right)
 
 
 abovePrecedence0 : Parser (WithComments ExtensionRight)
@@ -1273,7 +1272,7 @@ infixLeft precedence possibilitiesForPrecedence symbol =
         possibilitiesForPrecedence
         (Parser.symbol symbol)
         (\right ->
-            ExtendRightByOperation { symbol = symbol, direction = Infix.Left, expression = right }
+            ExtendRightByOperation { symbol = symbol, expression = right }
         )
 
 
@@ -1283,7 +1282,7 @@ infixNonAssociative precedence possibilitiesForPrecedence symbol =
         possibilitiesForPrecedence
         (Parser.symbol symbol)
         (\right ->
-            ExtendRightByOperation { symbol = symbol, direction = Infix.Non, expression = right }
+            ExtendRightByOperation { symbol = symbol, expression = right }
         )
 
 
@@ -1296,7 +1295,7 @@ infixRight precedence possibilitiesForPrecedenceMinus1 symbol =
         possibilitiesForPrecedenceMinus1
         (Parser.symbol symbol)
         (\right ->
-            ExtendRightByOperation { symbol = symbol, direction = Infix.Right, expression = right }
+            ExtendRightByOperation { symbol = symbol, expression = right }
         )
 
 
@@ -1323,7 +1322,7 @@ infixLeftSubtraction precedence possibilitiesForPrecedence =
                 )
         )
         (\right ->
-            ExtendRightByOperation { symbol = "-", direction = Infix.Left, expression = right }
+            ExtendRightByOperation { symbol = "-", expression = right }
         )
 
 
@@ -1362,6 +1361,6 @@ postfix precedence operator apply =
 
 
 type ExtensionRight
-    = ExtendRightByOperation { symbol : String, direction : Infix.InfixDirection, expression : Node Expression }
+    = ExtendRightByOperation { symbol : String, expression : Node Expression }
     | ExtendRightByApplication (Node Expression)
     | ExtendRightByRecordAccess (Node String)

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -20,7 +20,6 @@ Although it is a easy and simple language, you can express a lot! See the `Expre
 
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern)
 import Elm.Syntax.Documentation exposing (Documentation)
-import Elm.Syntax.Infix exposing (InfixDirection)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern)
@@ -111,7 +110,7 @@ type Expression
     | FunctionOrValue ModuleName String
     | PrefixOperator String
     | FunctionCall (Node Expression) (Node Expression) (List (Node Expression))
-    | Operation String InfixDirection (Node Expression) (Node Expression)
+    | Operation String (Node Expression) (Node Expression)
     | If (Node Expression) (Node Expression) (Node Expression)
     | TupleExpression (List (Node Expression))
     | Let LetBlock
@@ -222,7 +221,7 @@ isCase e =
 isOperation : Expression -> Bool
 isOperation e =
     case e of
-        Operation _ _ _ _ ->
+        Operation _ _ _ ->
             True
 
         _ ->

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -5,7 +5,6 @@ import Elm.Parser.ParserWithCommentsTestUtil as ParserWithCommentsUtil exposing 
 import Elm.Syntax.Declaration as Declaration exposing (..)
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern(..))
 import Elm.Syntax.Expression as Expression exposing (..)
-import Elm.Syntax.Infix as Infix exposing (InfixDirection(..))
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (..)
 import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
@@ -148,7 +147,6 @@ foo = bar"""
                                         , expression =
                                             Node { start = { row = 1, column = 9 }, end = { row = 1, column = 14 } }
                                                 (Operation "+"
-                                                    Infix.Left
                                                     (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "x"))
                                                     (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } (IntegerLiteral 1))
                                                 )
@@ -318,7 +316,6 @@ foo = bar"""
                                                         ( Node { start = { row = 3, column = 5 }, end = { row = 3, column = 14 } } (NamedPattern { moduleName = [], name = "Increment" } [])
                                                         , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
                                                             (Operation "+"
-                                                                Left
                                                                 (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 12 } } (FunctionOrValue [] "model"))
                                                                 (Node { start = { row = 4, column = 15 }, end = { row = 4, column = 16 } } (IntegerLiteral 1))
                                                             )
@@ -327,7 +324,6 @@ foo = bar"""
                                                         [ ( Node { start = { row = 6, column = 5 }, end = { row = 6, column = 14 } } (NamedPattern { moduleName = [], name = "Decrement" } [])
                                                           , Node { start = { row = 7, column = 7 }, end = { row = 7, column = 16 } }
                                                                 (Operation "-"
-                                                                    Left
                                                                     (Node { start = { row = 7, column = 7 }, end = { row = 7, column = 12 } } (FunctionOrValue [] "model"))
                                                                     (Node { start = { row = 7, column = 15 }, end = { row = 7, column = 16 } } (IntegerLiteral 1))
                                                                 )
@@ -493,11 +489,9 @@ foo = bar"""
                                         , expression =
                                             Node { start = { row = 1, column = 31 }, end = { row = 1, column = 83 } }
                                                 (Operation "<|"
-                                                    Right
                                                     (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 36 } } (FunctionOrValue [] "curry"))
                                                     (Node { start = { row = 1, column = 40 }, end = { row = 1, column = 83 } }
                                                         (Operation ">>"
-                                                            Right
                                                             (Node { start = { row = 1, column = 40 }, end = { row = 1, column = 56 } }
                                                                 (TupleExpression
                                                                     [ Node { start = { row = 1, column = 41 }, end = { row = 1, column = 55 } }
@@ -552,7 +546,6 @@ foo = bar"""
                                                             (NamedPattern { moduleName = [], name = "Increment" } [])
                                                         , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
                                                             (Operation "+"
-                                                                Left
                                                                 (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 12 } } (FunctionOrValue [] "model"))
                                                                 (Node { start = { row = 4, column = 15 }, end = { row = 4, column = 16 } } (IntegerLiteral 1))
                                                             )
@@ -562,7 +555,6 @@ foo = bar"""
                                                                 (NamedPattern { moduleName = [], name = "Decrement" } [])
                                                           , Node { start = { row = 7, column = 7 }, end = { row = 7, column = 16 } }
                                                                 (Operation "-"
-                                                                    Left
                                                                     (Node { start = { row = 7, column = 7 }, end = { row = 7, column = 12 } } (FunctionOrValue [] "model"))
                                                                     (Node { start = { row = 7, column = 15 }, end = { row = 7, column = 16 } } (IntegerLiteral 1))
                                                                 )

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -4,7 +4,6 @@ import Elm.Parser.Expression exposing (expression)
 import Elm.Parser.ParserWithCommentsTestUtil as ParserWithCommentsUtil
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern(..))
 import Elm.Syntax.Expression exposing (Expression(..))
-import Elm.Syntax.Infix as Infix exposing (InfixDirection(..))
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.StringLiteralType exposing (StringLiteralType(..))
 import Expect
@@ -97,7 +96,6 @@ all =
                             (TupleExpression
                                 [ Node { start = { row = 1, column = 2 }, end = { row = 1, column = 11 } }
                                     (Operation "*"
-                                        Left
                                         (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 4 } }
                                             (Negation (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (IntegerLiteral 1)))
                                         )
@@ -122,7 +120,6 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } } <|
                             Operation "+"
-                                Infix.Left
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } <| FunctionOrValue [] "model")
                                 (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } <| IntegerLiteral 1)
                         )
@@ -430,7 +427,6 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } }
                             (Operation "-"
-                                Left
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (IntegerLiteral 2))
                                 (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (IntegerLiteral 1))
                             )
@@ -465,7 +461,6 @@ all =
                                     (TupleExpression
                                         [ Node { start = { row = 1, column = 3 }, end = { row = 1, column = 8 } }
                                             (Operation "-"
-                                                Left
                                                 (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (FunctionOrValue [] "x"))
                                                 (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 8 } } (FunctionOrValue [] "y"))
                                             )
@@ -480,22 +475,18 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 29 } }
                             (Operation "=="
-                                Non
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 18 } }
                                     (Operation "+"
-                                        Left
                                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 3 } }
                                             (Negation (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 3 } } (IntegerLiteral 1)))
                                         )
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 18 } }
                                             (Operation "*"
-                                                Left
                                                 (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 9 } }
                                                     (Negation (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 9 } } (IntegerLiteral 10)))
                                                 )
                                                 (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 18 } }
                                                     (Operation "^"
-                                                        Right
                                                         (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 16 } }
                                                             (Negation
                                                                 (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 16 } } (IntegerLiteral 100))
@@ -520,10 +511,8 @@ all =
                         (Node
                             { start = { row = 1, column = 2 }, end = { row = 1, column = 11 } }
                             (Operation "-"
-                                Left
                                 (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 7 } }
                                     (Operation "+"
-                                        Left
                                         (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 3 } } (IntegerLiteral 1))
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (IntegerLiteral 2))
                                     )
@@ -537,7 +526,6 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } }
                             (Operation "|>"
-                                Left
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (FunctionOrValue [] "a"))
                                 (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (FunctionOrValue [] "b"))
                             )
@@ -558,20 +546,16 @@ all =
                                                 , expression =
                                                     Node { start = { row = 1, column = 19 }, end = { row = 1, column = 53 } }
                                                         (Operation "||"
-                                                            Right
                                                             (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 27 } }
                                                                 (Operation "=="
-                                                                    Non
                                                                     (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 20 } } (FunctionOrValue [] "c"))
                                                                     (Node { start = { row = 1, column = 24 }, end = { row = 1, column = 27 } } (CharLiteral ' '))
                                                                 )
                                                             )
                                                             (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 53 } }
                                                                 (Operation "||"
-                                                                    Right
                                                                     (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 40 } }
                                                                         (Operation "=="
-                                                                            Non
                                                                             (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 32 } } (FunctionOrValue [] "c"))
                                                                             (Node { start = { row = 1, column = 36 }, end = { row = 1, column = 40 } }
                                                                                 (CharLiteral '\n')
@@ -580,7 +564,6 @@ all =
                                                                     )
                                                                     (Node { start = { row = 1, column = 44 }, end = { row = 1, column = 53 } }
                                                                         (Operation "=="
-                                                                            Non
                                                                             (Node { start = { row = 1, column = 44 }, end = { row = 1, column = 45 } } (FunctionOrValue [] "c"))
                                                                             (Node { start = { row = 1, column = 49 }, end = { row = 1, column = 53 } }
                                                                                 (CharLiteral '\u{000D}')
@@ -653,7 +636,6 @@ all =
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 16 } }
                             (Operation "+"
-                                Left
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (IntegerLiteral 1))
                                 (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 16 } }
                                     (Negation

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -7,7 +7,6 @@ import Elm.Syntax.Declaration exposing (Declaration(..))
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern(..))
 import Elm.Syntax.Exposing exposing (Exposing(..))
 import Elm.Syntax.Expression exposing (Expression(..), LetDeclaration(..))
-import Elm.Syntax.Infix exposing (InfixDirection(..))
 import Elm.Syntax.Module exposing (Module(..))
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern(..))
@@ -225,7 +224,6 @@ lambdaWhitespace =   \\ a b ->    a
                                                             , expression =
                                                                 Node { start = { row = 4, column = 34 }, end = { row = 8, column = 6 } }
                                                                     (Operation "+"
-                                                                        Left
                                                                         (Node { start = { row = 4, column = 34 }, end = { row = 4, column = 35 } } (FunctionOrValue [] "a"))
                                                                         (Node { start = { row = 8, column = 5 }, end = { row = 8, column = 6 } } (FunctionOrValue [] "b"))
                                                                     )

--- a/tests/Elm/Parser/LambdaExpressionTests.elm
+++ b/tests/Elm/Parser/LambdaExpressionTests.elm
@@ -4,7 +4,6 @@ import Elm.Parser.Expression exposing (expression)
 import Elm.Parser.ParserWithCommentsTestUtil as ParserWithCommentsUtil
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern(..))
 import Elm.Syntax.Expression exposing (..)
-import Elm.Syntax.Infix exposing (InfixDirection(..))
 import Elm.Syntax.Node exposing (Node(..))
 import Expect
 import Test exposing (..)
@@ -62,7 +61,6 @@ all =
                                 , expression =
                                     Node { start = { row = 1, column = 9 }, end = { row = 1, column = 14 } }
                                         (Operation "+"
-                                            Left
                                             (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "a"))
                                             (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } (FunctionOrValue [] "b"))
                                         )
@@ -86,7 +84,6 @@ all =
                                 , expression =
                                     Node { start = { row = 1, column = 11 }, end = { row = 1, column = 16 } }
                                         (Operation "+"
-                                            Left
                                             (Node { start = { row = 1, column = 11 }, end = { row = 1, column = 12 } } (FunctionOrValue [] "a"))
                                             (Node { start = { row = 1, column = 15 }, end = { row = 1, column = 16 } } (FunctionOrValue [] "b"))
                                         )

--- a/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/Elm/Parser/ModuleTests.elm
@@ -7,7 +7,6 @@ import Elm.Syntax.Declaration exposing (Declaration(..))
 import Elm.Syntax.DestructurePattern exposing (DestructurePattern(..))
 import Elm.Syntax.Exposing exposing (..)
 import Elm.Syntax.Expression exposing (Expression(..))
-import Elm.Syntax.Infix exposing (InfixDirection(..))
 import Elm.Syntax.Module exposing (..)
 import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
@@ -462,7 +461,6 @@ fun2 n =
                                                 , expression =
                                                     Node { start = { row = 4, column = 3 }, end = { row = 5, column = 11 } }
                                                         (Operation "+"
-                                                            Left
                                                             (Node { start = { row = 4, column = 3 }, end = { row = 4, column = 9 } }
                                                                 (FunctionCall
                                                                     (Node { start = { row = 4, column = 3 }, end = { row = 4, column = 7 } } (FunctionOrValue [] "fun2"))


### PR DESCRIPTION
This information is not available in the syntax, and is very rarely useful. The list of operators is also fully known, so this information does not need to be stored in the AST.