### PR TITLE
Move the operator argument for Operation and wrap it in Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@
   - `OperatorApplication`
     - Renamed `OperatorApplication` to `Operation`
     - Removed the `InfixDirection` field
-    - `OperatorApplication String InfixDirection (Node Expression) (Node Expression)` -> `Operation String (Node Expression) (Node Expression)`
+    - Moved the operator to be between the two expressions
+    - `OperatorApplication String InfixDirection (Node Expression) (Node Expression)` -> `Operation (Node Expression) String (Node Expression)`
   - Renamed `isOperatorApplication` to `isOperation`
   - Renamed `RecordExpr` to `Record`
   - Renamed `CaseExpression` to `Case`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
     - Renamed `OperatorApplication` to `Operation`
     - Removed the `InfixDirection` field
     - Moved the operator to be between the two expressions
-    - `OperatorApplication String InfixDirection (Node Expression) (Node Expression)` -> `Operation (Node Expression) String (Node Expression)`
+    - Wrapped the operator in `Node` to store its position
+    - `OperatorApplication String InfixDirection (Node Expression) (Node Expression)` -> `Operation (Node Expression) (Node String) (Node Expression)`
   - Renamed `isOperatorApplication` to `isOperation`
   - Renamed `RecordExpr` to `Record`
   - Renamed `CaseExpression` to `Case`

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1194,7 +1194,7 @@ applyExtensionRight extensionRight ((Node { start } left) as leftNode) =
                     extendRightOperation.expression
             in
             Node { start = start, end = end }
-                (Operation extendRightOperation.symbol leftNode right)
+                (Operation leftNode extendRightOperation.symbol right)
 
 
 abovePrecedence0 : Parser (WithComments ExtensionRight)

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -110,7 +110,7 @@ type Expression
     | FunctionOrValue ModuleName String
     | PrefixOperator String
     | FunctionCall (Node Expression) (Node Expression) (List (Node Expression))
-    | Operation (Node Expression) String (Node Expression)
+    | Operation (Node Expression) (Node String) (Node Expression)
     | If (Node Expression) (Node Expression) (Node Expression)
     | TupleExpression (List (Node Expression))
     | Let LetBlock

--- a/src/Elm/Syntax/Expression.elm
+++ b/src/Elm/Syntax/Expression.elm
@@ -110,7 +110,7 @@ type Expression
     | FunctionOrValue ModuleName String
     | PrefixOperator String
     | FunctionCall (Node Expression) (Node Expression) (List (Node Expression))
-    | Operation String (Node Expression) (Node Expression)
+    | Operation (Node Expression) String (Node Expression)
     | If (Node Expression) (Node Expression) (Node Expression)
     | TupleExpression (List (Node Expression))
     | Let LetBlock

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -148,7 +148,7 @@ foo = bar"""
                                             Node { start = { row = 1, column = 9 }, end = { row = 1, column = 14 } }
                                                 (Operation
                                                     (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "x"))
-                                                    "+"
+                                                    (Node { start = { row = 1, column = 11 }, end = { row = 1, column = 12 } } "+")
                                                     (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } (IntegerLiteral 1))
                                                 )
                                         }
@@ -318,7 +318,7 @@ foo = bar"""
                                                         , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
                                                             (Operation
                                                                 (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 12 } } (FunctionOrValue [] "model"))
-                                                                "+"
+                                                                (Node { start = { row = 4, column = 13 }, end = { row = 4, column = 14 } } "+")
                                                                 (Node { start = { row = 4, column = 15 }, end = { row = 4, column = 16 } } (IntegerLiteral 1))
                                                             )
                                                         )
@@ -327,7 +327,7 @@ foo = bar"""
                                                           , Node { start = { row = 7, column = 7 }, end = { row = 7, column = 16 } }
                                                                 (Operation
                                                                     (Node { start = { row = 7, column = 7 }, end = { row = 7, column = 12 } } (FunctionOrValue [] "model"))
-                                                                    "-"
+                                                                    (Node { start = { row = 7, column = 13 }, end = { row = 7, column = 14 } } "-")
                                                                     (Node { start = { row = 7, column = 15 }, end = { row = 7, column = 16 } } (IntegerLiteral 1))
                                                                 )
                                                           )
@@ -493,7 +493,7 @@ foo = bar"""
                                             Node { start = { row = 1, column = 31 }, end = { row = 1, column = 83 } }
                                                 (Operation
                                                     (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 36 } } (FunctionOrValue [] "curry"))
-                                                    "<|"
+                                                    (Node { start = { row = 1, column = 37 }, end = { row = 1, column = 39 } } "<|")
                                                     (Node { start = { row = 1, column = 40 }, end = { row = 1, column = 83 } }
                                                         (Operation
                                                             (Node { start = { row = 1, column = 40 }, end = { row = 1, column = 56 } }
@@ -507,7 +507,7 @@ foo = bar"""
                                                                     ]
                                                                 )
                                                             )
-                                                            ">>"
+                                                            (Node { start = { row = 1, column = 57 }, end = { row = 1, column = 59 } } ">>")
                                                             (Node { start = { row = 1, column = 60 }, end = { row = 1, column = 83 } }
                                                                 (FunctionCall (Node { start = { row = 1, column = 60 }, end = { row = 1, column = 74 } } (FunctionOrValue [] "batchStateCmds"))
                                                                     (Node { start = { row = 1, column = 75 }, end = { row = 1, column = 83 } } (FunctionOrValue [] "sendPort"))
@@ -552,7 +552,7 @@ foo = bar"""
                                                         , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
                                                             (Operation
                                                                 (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 12 } } (FunctionOrValue [] "model"))
-                                                                "+"
+                                                                (Node { start = { row = 4, column = 13 }, end = { row = 4, column = 14 } } "+")
                                                                 (Node { start = { row = 4, column = 15 }, end = { row = 4, column = 16 } } (IntegerLiteral 1))
                                                             )
                                                         )
@@ -562,7 +562,7 @@ foo = bar"""
                                                           , Node { start = { row = 7, column = 7 }, end = { row = 7, column = 16 } }
                                                                 (Operation
                                                                     (Node { start = { row = 7, column = 7 }, end = { row = 7, column = 12 } } (FunctionOrValue [] "model"))
-                                                                    "-"
+                                                                    (Node { start = { row = 7, column = 13 }, end = { row = 7, column = 14 } } "-")
                                                                     (Node { start = { row = 7, column = 15 }, end = { row = 7, column = 16 } } (IntegerLiteral 1))
                                                                 )
                                                           )

--- a/tests/Elm/Parser/DeclarationsTests.elm
+++ b/tests/Elm/Parser/DeclarationsTests.elm
@@ -146,8 +146,9 @@ foo = bar"""
                                         , arguments = [ Node { start = { row = 1, column = 5 }, end = { row = 1, column = 6 } } (VarPattern_ "x") ]
                                         , expression =
                                             Node { start = { row = 1, column = 9 }, end = { row = 1, column = 14 } }
-                                                (Operation "+"
+                                                (Operation
                                                     (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "x"))
+                                                    "+"
                                                     (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } (IntegerLiteral 1))
                                                 )
                                         }
@@ -315,16 +316,18 @@ foo = bar"""
                                                     , firstCase =
                                                         ( Node { start = { row = 3, column = 5 }, end = { row = 3, column = 14 } } (NamedPattern { moduleName = [], name = "Increment" } [])
                                                         , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
-                                                            (Operation "+"
+                                                            (Operation
                                                                 (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 12 } } (FunctionOrValue [] "model"))
+                                                                "+"
                                                                 (Node { start = { row = 4, column = 15 }, end = { row = 4, column = 16 } } (IntegerLiteral 1))
                                                             )
                                                         )
                                                     , restOfCases =
                                                         [ ( Node { start = { row = 6, column = 5 }, end = { row = 6, column = 14 } } (NamedPattern { moduleName = [], name = "Decrement" } [])
                                                           , Node { start = { row = 7, column = 7 }, end = { row = 7, column = 16 } }
-                                                                (Operation "-"
+                                                                (Operation
                                                                     (Node { start = { row = 7, column = 7 }, end = { row = 7, column = 12 } } (FunctionOrValue [] "model"))
+                                                                    "-"
                                                                     (Node { start = { row = 7, column = 15 }, end = { row = 7, column = 16 } } (IntegerLiteral 1))
                                                                 )
                                                           )
@@ -488,10 +491,11 @@ foo = bar"""
                                         , arguments = [ Node { start = { row = 1, column = 13 }, end = { row = 1, column = 19 } } (VarPattern_ "update"), Node { start = { row = 1, column = 20 }, end = { row = 1, column = 28 } } (VarPattern_ "sendPort") ]
                                         , expression =
                                             Node { start = { row = 1, column = 31 }, end = { row = 1, column = 83 } }
-                                                (Operation "<|"
+                                                (Operation
                                                     (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 36 } } (FunctionOrValue [] "curry"))
+                                                    "<|"
                                                     (Node { start = { row = 1, column = 40 }, end = { row = 1, column = 83 } }
-                                                        (Operation ">>"
+                                                        (Operation
                                                             (Node { start = { row = 1, column = 40 }, end = { row = 1, column = 56 } }
                                                                 (TupleExpression
                                                                     [ Node { start = { row = 1, column = 41 }, end = { row = 1, column = 55 } }
@@ -503,6 +507,7 @@ foo = bar"""
                                                                     ]
                                                                 )
                                                             )
+                                                            ">>"
                                                             (Node { start = { row = 1, column = 60 }, end = { row = 1, column = 83 } }
                                                                 (FunctionCall (Node { start = { row = 1, column = 60 }, end = { row = 1, column = 74 } } (FunctionOrValue [] "batchStateCmds"))
                                                                     (Node { start = { row = 1, column = 75 }, end = { row = 1, column = 83 } } (FunctionOrValue [] "sendPort"))
@@ -545,8 +550,9 @@ foo = bar"""
                                                         ( Node { start = { row = 3, column = 5 }, end = { row = 3, column = 14 } }
                                                             (NamedPattern { moduleName = [], name = "Increment" } [])
                                                         , Node { start = { row = 4, column = 7 }, end = { row = 4, column = 16 } }
-                                                            (Operation "+"
+                                                            (Operation
                                                                 (Node { start = { row = 4, column = 7 }, end = { row = 4, column = 12 } } (FunctionOrValue [] "model"))
+                                                                "+"
                                                                 (Node { start = { row = 4, column = 15 }, end = { row = 4, column = 16 } } (IntegerLiteral 1))
                                                             )
                                                         )
@@ -554,8 +560,9 @@ foo = bar"""
                                                         [ ( Node { start = { row = 6, column = 5 }, end = { row = 6, column = 14 } }
                                                                 (NamedPattern { moduleName = [], name = "Decrement" } [])
                                                           , Node { start = { row = 7, column = 7 }, end = { row = 7, column = 16 } }
-                                                                (Operation "-"
+                                                                (Operation
                                                                     (Node { start = { row = 7, column = 7 }, end = { row = 7, column = 12 } } (FunctionOrValue [] "model"))
+                                                                    "-"
                                                                     (Node { start = { row = 7, column = 15 }, end = { row = 7, column = 16 } } (IntegerLiteral 1))
                                                                 )
                                                           )

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -95,10 +95,11 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 12 } }
                             (TupleExpression
                                 [ Node { start = { row = 1, column = 2 }, end = { row = 1, column = 11 } }
-                                    (Operation "*"
+                                    (Operation
                                         (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 4 } }
                                             (Negation (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (IntegerLiteral 1)))
                                         )
+                                        "*"
                                         (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 11 } } (FunctionOrValue [] "sign"))
                                     )
                                 ]
@@ -119,8 +120,9 @@ all =
                 "model + 1"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } } <|
-                            Operation "+"
+                            Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } <| FunctionOrValue [] "model")
+                                "+"
                                 (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } <| IntegerLiteral 1)
                         )
         , test "application expression 2" <|
@@ -426,8 +428,9 @@ all =
                 "2-1"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } }
-                            (Operation "-"
+                            (Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (IntegerLiteral 2))
+                                "-"
                                 (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (IntegerLiteral 1))
                             )
                         )
@@ -460,8 +463,9 @@ all =
                                 (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 9 } }
                                     (TupleExpression
                                         [ Node { start = { row = 1, column = 3 }, end = { row = 1, column = 8 } }
-                                            (Operation "-"
+                                            (Operation
                                                 (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (FunctionOrValue [] "x"))
+                                                "-"
                                                 (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 8 } } (FunctionOrValue [] "y"))
                                             )
                                         ]
@@ -474,24 +478,27 @@ all =
                 "-1 + -10 * -100^2 == -100001"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 29 } }
-                            (Operation "=="
+                            (Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 18 } }
-                                    (Operation "+"
+                                    (Operation
                                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 3 } }
                                             (Negation (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 3 } } (IntegerLiteral 1)))
                                         )
+                                        "+"
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 18 } }
-                                            (Operation "*"
+                                            (Operation
                                                 (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 9 } }
                                                     (Negation (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 9 } } (IntegerLiteral 10)))
                                                 )
+                                                "*"
                                                 (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 18 } }
-                                                    (Operation "^"
+                                                    (Operation
                                                         (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 16 } }
                                                             (Negation
                                                                 (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 16 } } (IntegerLiteral 100))
                                                             )
                                                         )
+                                                        "^"
                                                         (Node { start = { row = 1, column = 17 }, end = { row = 1, column = 18 } } (IntegerLiteral 2))
                                                     )
                                                 )
@@ -499,6 +506,7 @@ all =
                                         )
                                     )
                                 )
+                                "=="
                                 (Node { start = { row = 1, column = 22 }, end = { row = 1, column = 29 } }
                                     (Negation (Node { start = { row = 1, column = 23 }, end = { row = 1, column = 29 } } (IntegerLiteral 100001)))
                                 )
@@ -510,13 +518,15 @@ all =
                     |> expectAst
                         (Node
                             { start = { row = 1, column = 2 }, end = { row = 1, column = 11 } }
-                            (Operation "-"
+                            (Operation
                                 (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 7 } }
-                                    (Operation "+"
+                                    (Operation
                                         (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 3 } } (IntegerLiteral 1))
+                                        "+"
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (IntegerLiteral 2))
                                     )
                                 )
+                                "-"
                                 (Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } (IntegerLiteral 3))
                             )
                         )
@@ -525,8 +535,9 @@ all =
                 "a |> b"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } }
-                            (Operation "|>"
+                            (Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (FunctionOrValue [] "a"))
+                                "|>"
                                 (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (FunctionOrValue [] "b"))
                             )
                         )
@@ -545,26 +556,31 @@ all =
                                                 , restOfArgs = []
                                                 , expression =
                                                     Node { start = { row = 1, column = 19 }, end = { row = 1, column = 53 } }
-                                                        (Operation "||"
+                                                        (Operation
                                                             (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 27 } }
-                                                                (Operation "=="
+                                                                (Operation
                                                                     (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 20 } } (FunctionOrValue [] "c"))
+                                                                    "=="
                                                                     (Node { start = { row = 1, column = 24 }, end = { row = 1, column = 27 } } (CharLiteral ' '))
                                                                 )
                                                             )
+                                                            "||"
                                                             (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 53 } }
-                                                                (Operation "||"
+                                                                (Operation
                                                                     (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 40 } }
-                                                                        (Operation "=="
+                                                                        (Operation
                                                                             (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 32 } } (FunctionOrValue [] "c"))
+                                                                            "=="
                                                                             (Node { start = { row = 1, column = 36 }, end = { row = 1, column = 40 } }
                                                                                 (CharLiteral '\n')
                                                                             )
                                                                         )
                                                                     )
+                                                                    "||"
                                                                     (Node { start = { row = 1, column = 44 }, end = { row = 1, column = 53 } }
-                                                                        (Operation "=="
+                                                                        (Operation
                                                                             (Node { start = { row = 1, column = 44 }, end = { row = 1, column = 45 } } (FunctionOrValue [] "c"))
+                                                                            "=="
                                                                             (Node { start = { row = 1, column = 49 }, end = { row = 1, column = 53 } }
                                                                                 (CharLiteral '\u{000D}')
                                                                             )
@@ -635,8 +651,9 @@ all =
                 "1 + -{x = 10}.x"
                     |> expectAst
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 16 } }
-                            (Operation "+"
+                            (Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (IntegerLiteral 1))
+                                "+"
                                 (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 16 } }
                                     (Negation
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 16 } }

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -99,7 +99,7 @@ all =
                                         (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 4 } }
                                             (Negation (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (IntegerLiteral 1)))
                                         )
-                                        "*"
+                                        (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 6 } } "*")
                                         (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 11 } } (FunctionOrValue [] "sign"))
                                     )
                                 ]
@@ -122,7 +122,7 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } } <|
                             Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } <| FunctionOrValue [] "model")
-                                "+"
+                                (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 8 } } "+")
                                 (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } <| IntegerLiteral 1)
                         )
         , test "application expression 2" <|
@@ -430,7 +430,7 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 4 } }
                             (Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (IntegerLiteral 2))
-                                "-"
+                                (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 3 } } "-")
                                 (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (IntegerLiteral 1))
                             )
                         )
@@ -465,7 +465,7 @@ all =
                                         [ Node { start = { row = 1, column = 3 }, end = { row = 1, column = 8 } }
                                             (Operation
                                                 (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } (FunctionOrValue [] "x"))
-                                                "-"
+                                                (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 6 } } "-")
                                                 (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 8 } } (FunctionOrValue [] "y"))
                                             )
                                         ]
@@ -484,13 +484,13 @@ all =
                                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 3 } }
                                             (Negation (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 3 } } (IntegerLiteral 1)))
                                         )
-                                        "+"
+                                        (Node { start = { row = 1, column = 4 }, end = { row = 1, column = 5 } } "+")
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 18 } }
                                             (Operation
                                                 (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 9 } }
                                                     (Negation (Node { start = { row = 1, column = 7 }, end = { row = 1, column = 9 } } (IntegerLiteral 10)))
                                                 )
-                                                "*"
+                                                (Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } "*")
                                                 (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 18 } }
                                                     (Operation
                                                         (Node { start = { row = 1, column = 12 }, end = { row = 1, column = 16 } }
@@ -498,7 +498,7 @@ all =
                                                                 (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 16 } } (IntegerLiteral 100))
                                                             )
                                                         )
-                                                        "^"
+                                                        (Node { start = { row = 1, column = 16 }, end = { row = 1, column = 17 } } "^")
                                                         (Node { start = { row = 1, column = 17 }, end = { row = 1, column = 18 } } (IntegerLiteral 2))
                                                     )
                                                 )
@@ -506,7 +506,7 @@ all =
                                         )
                                     )
                                 )
-                                "=="
+                                (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 21 } } "==")
                                 (Node { start = { row = 1, column = 22 }, end = { row = 1, column = 29 } }
                                     (Negation (Node { start = { row = 1, column = 23 }, end = { row = 1, column = 29 } } (IntegerLiteral 100001)))
                                 )
@@ -522,11 +522,11 @@ all =
                                 (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 7 } }
                                     (Operation
                                         (Node { start = { row = 1, column = 2 }, end = { row = 1, column = 3 } } (IntegerLiteral 1))
-                                        "+"
+                                        (Node { start = { row = 1, column = 4 }, end = { row = 1, column = 5 } } "+")
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (IntegerLiteral 2))
                                     )
                                 )
-                                "-"
+                                (Node { start = { row = 1, column = 8 }, end = { row = 1, column = 9 } } "-")
                                 (Node { start = { row = 1, column = 10 }, end = { row = 1, column = 11 } } (IntegerLiteral 3))
                             )
                         )
@@ -537,7 +537,7 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 7 } }
                             (Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (FunctionOrValue [] "a"))
-                                "|>"
+                                (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 5 } } "|>")
                                 (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 7 } } (FunctionOrValue [] "b"))
                             )
                         )
@@ -560,27 +560,27 @@ all =
                                                             (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 27 } }
                                                                 (Operation
                                                                     (Node { start = { row = 1, column = 19 }, end = { row = 1, column = 20 } } (FunctionOrValue [] "c"))
-                                                                    "=="
+                                                                    (Node { start = { row = 1, column = 21 }, end = { row = 1, column = 23 } } "==")
                                                                     (Node { start = { row = 1, column = 24 }, end = { row = 1, column = 27 } } (CharLiteral ' '))
                                                                 )
                                                             )
-                                                            "||"
+                                                            (Node { start = { row = 1, column = 28 }, end = { row = 1, column = 30 } } "||")
                                                             (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 53 } }
                                                                 (Operation
                                                                     (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 40 } }
                                                                         (Operation
                                                                             (Node { start = { row = 1, column = 31 }, end = { row = 1, column = 32 } } (FunctionOrValue [] "c"))
-                                                                            "=="
+                                                                            (Node { start = { row = 1, column = 33 }, end = { row = 1, column = 35 } } "==")
                                                                             (Node { start = { row = 1, column = 36 }, end = { row = 1, column = 40 } }
                                                                                 (CharLiteral '\n')
                                                                             )
                                                                         )
                                                                     )
-                                                                    "||"
+                                                                    (Node { start = { row = 1, column = 41 }, end = { row = 1, column = 43 } } "||")
                                                                     (Node { start = { row = 1, column = 44 }, end = { row = 1, column = 53 } }
                                                                         (Operation
                                                                             (Node { start = { row = 1, column = 44 }, end = { row = 1, column = 45 } } (FunctionOrValue [] "c"))
-                                                                            "=="
+                                                                            (Node { start = { row = 1, column = 46 }, end = { row = 1, column = 48 } } "==")
                                                                             (Node { start = { row = 1, column = 49 }, end = { row = 1, column = 53 } }
                                                                                 (CharLiteral '\u{000D}')
                                                                             )
@@ -653,7 +653,7 @@ all =
                         (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 16 } }
                             (Operation
                                 (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 2 } } (IntegerLiteral 1))
-                                "+"
+                                (Node { start = { row = 1, column = 3 }, end = { row = 1, column = 4 } } "+")
                                 (Node { start = { row = 1, column = 5 }, end = { row = 1, column = 16 } }
                                     (Negation
                                         (Node { start = { row = 1, column = 6 }, end = { row = 1, column = 16 } }

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -223,8 +223,9 @@ lambdaWhitespace =   \\ a b ->    a
                                                                 [ Node { start = { row = 4, column = 26 }, end = { row = 4, column = 27 } } (VarPattern_ "b") ]
                                                             , expression =
                                                                 Node { start = { row = 4, column = 34 }, end = { row = 8, column = 6 } }
-                                                                    (Operation "+"
+                                                                    (Operation
                                                                         (Node { start = { row = 4, column = 34 }, end = { row = 4, column = 35 } } (FunctionOrValue [] "a"))
+                                                                        "+"
                                                                         (Node { start = { row = 8, column = 5 }, end = { row = 8, column = 6 } } (FunctionOrValue [] "b"))
                                                                     )
                                                             }

--- a/tests/Elm/Parser/FileTests.elm
+++ b/tests/Elm/Parser/FileTests.elm
@@ -225,7 +225,7 @@ lambdaWhitespace =   \\ a b ->    a
                                                                 Node { start = { row = 4, column = 34 }, end = { row = 8, column = 6 } }
                                                                     (Operation
                                                                         (Node { start = { row = 4, column = 34 }, end = { row = 4, column = 35 } } (FunctionOrValue [] "a"))
-                                                                        "+"
+                                                                        (Node { start = { row = 6, column = 8 }, end = { row = 6, column = 9 } } "+")
                                                                         (Node { start = { row = 8, column = 5 }, end = { row = 8, column = 6 } } (FunctionOrValue [] "b"))
                                                                     )
                                                             }

--- a/tests/Elm/Parser/LambdaExpressionTests.elm
+++ b/tests/Elm/Parser/LambdaExpressionTests.elm
@@ -60,8 +60,9 @@ all =
                                     ]
                                 , expression =
                                     Node { start = { row = 1, column = 9 }, end = { row = 1, column = 14 } }
-                                        (Operation "+"
+                                        (Operation
                                             (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "a"))
+                                            "+"
                                             (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } (FunctionOrValue [] "b"))
                                         )
                                 }
@@ -83,8 +84,9 @@ all =
                                 , restOfArgs = []
                                 , expression =
                                     Node { start = { row = 1, column = 11 }, end = { row = 1, column = 16 } }
-                                        (Operation "+"
+                                        (Operation
                                             (Node { start = { row = 1, column = 11 }, end = { row = 1, column = 12 } } (FunctionOrValue [] "a"))
+                                            "+"
                                             (Node { start = { row = 1, column = 15 }, end = { row = 1, column = 16 } } (FunctionOrValue [] "b"))
                                         )
                                 }

--- a/tests/Elm/Parser/LambdaExpressionTests.elm
+++ b/tests/Elm/Parser/LambdaExpressionTests.elm
@@ -62,7 +62,7 @@ all =
                                     Node { start = { row = 1, column = 9 }, end = { row = 1, column = 14 } }
                                         (Operation
                                             (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "a"))
-                                            "+"
+                                            (Node { start = { row = 1, column = 11 }, end = { row = 1, column = 12 } } "+")
                                             (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } (FunctionOrValue [] "b"))
                                         )
                                 }
@@ -86,7 +86,7 @@ all =
                                     Node { start = { row = 1, column = 11 }, end = { row = 1, column = 16 } }
                                         (Operation
                                             (Node { start = { row = 1, column = 11 }, end = { row = 1, column = 12 } } (FunctionOrValue [] "a"))
-                                            "+"
+                                            (Node { start = { row = 1, column = 13 }, end = { row = 1, column = 14 } } "+")
                                             (Node { start = { row = 1, column = 15 }, end = { row = 1, column = 16 } } (FunctionOrValue [] "b"))
                                         )
                                 }

--- a/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/Elm/Parser/ModuleTests.elm
@@ -468,7 +468,7 @@ fun2 n =
                                                                     []
                                                                 )
                                                             )
-                                                            "+"
+                                                            (Node { start = { row = 5, column = 3 }, end = { row = 5, column = 4 } } "+")
                                                             (Node { start = { row = 5, column = 5 }, end = { row = 5, column = 11 } }
                                                                 (FunctionCall
                                                                     (Node { start = { row = 5, column = 5 }, end = { row = 5, column = 9 } } (FunctionOrValue [] "fun2"))

--- a/tests/Elm/Parser/ModuleTests.elm
+++ b/tests/Elm/Parser/ModuleTests.elm
@@ -460,7 +460,7 @@ fun2 n =
                                                 , arguments = [ Node { start = { row = 3, column = 6 }, end = { row = 3, column = 7 } } (VarPattern_ "n") ]
                                                 , expression =
                                                     Node { start = { row = 4, column = 3 }, end = { row = 5, column = 11 } }
-                                                        (Operation "+"
+                                                        (Operation
                                                             (Node { start = { row = 4, column = 3 }, end = { row = 4, column = 9 } }
                                                                 (FunctionCall
                                                                     (Node { start = { row = 4, column = 3 }, end = { row = 4, column = 7 } } (FunctionOrValue [] "fun2"))
@@ -468,6 +468,7 @@ fun2 n =
                                                                     []
                                                                 )
                                                             )
+                                                            "+"
                                                             (Node { start = { row = 5, column = 5 }, end = { row = 5, column = 11 } }
                                                                 (FunctionCall
                                                                     (Node { start = { row = 5, column = 5 }, end = { row = 5, column = 9 } } (FunctionOrValue [] "fun2"))


### PR DESCRIPTION
Wrapping it in a Node makes the position available, which I know we've used workarounds for in some `elm-review` rules.

Moving the operator is meant to make the data resemble the AST more (because it's `a + b`, not `+ a b`)

I'm not sure if we can improve the parser part more.