### PR TITLE
Successfully parse 'a + b /= c'

### DIFF
--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -72,14 +72,14 @@ extensionRightByPrecedence =
     , infixLeft 9 (ParserFast.lazy (\() -> abovePrecedence9)) "<<"
     , infixNonAssociative 4 (ParserFast.lazy (\() -> abovePrecedence4)) "/="
     , infixLeft 7 (ParserFast.lazy (\() -> abovePrecedence7)) "//"
-    , infixLeft 7 (ParserFast.lazy (\() -> abovePrecedence7)) "/"
+    , infixLeftWithException 7 (ParserFast.lazy (\() -> abovePrecedence7)) "/" "="
     , infixRight 7 (ParserFast.lazy (\() -> abovePrecedence6)) "</>"
     , infixRight 2 (ParserFast.lazy (\() -> abovePrecedence1)) "||"
     , infixNonAssociative 4 (ParserFast.lazy (\() -> abovePrecedence4)) "<="
     , infixNonAssociative 4 (ParserFast.lazy (\() -> abovePrecedence4)) ">="
     , infixNonAssociative 4 (ParserFast.lazy (\() -> abovePrecedence4)) ">"
     , infixLeft 8 (ParserFast.lazy (\() -> abovePrecedence8)) "<?>"
-    , infixNonAssociative 4 (ParserFast.lazy (\() -> abovePrecedence4)) "<"
+    , infixNonAssociativeWithException 4 (ParserFast.lazy (\() -> abovePrecedence4)) "<" "|"
     , infixRight 8 (ParserFast.lazy (\() -> abovePrecedence7)) "^"
     ]
 
@@ -1256,11 +1256,31 @@ infixLeft precedence possibilitiesForPrecedence symbol =
         )
 
 
+infixLeftWithException : Int -> Parser (WithComments ExtensionRight) -> String -> String -> ( Int, Parser (WithComments ExtensionRight) )
+infixLeftWithException precedence possibilitiesForPrecedence symbol exceptionSymbol =
+    infixHelp precedence
+        possibilitiesForPrecedence
+        (ParserFast.symbolWithExceptionFollowedBy symbol exceptionSymbol)
+        (\right ->
+            ExtendRightByOperation { symbol = symbol, direction = Infix.Left, expression = right }
+        )
+
+
 infixNonAssociative : Int -> Parser (WithComments ExtensionRight) -> String -> ( Int, Parser (WithComments ExtensionRight) )
 infixNonAssociative precedence possibilitiesForPrecedence symbol =
     infixHelp precedence
         possibilitiesForPrecedence
         (ParserFast.symbolFollowedBy symbol)
+        (\right ->
+            ExtendRightByOperation { symbol = symbol, direction = Infix.Non, expression = right }
+        )
+
+
+infixNonAssociativeWithException : Int -> Parser (WithComments ExtensionRight) -> String -> String -> ( Int, Parser (WithComments ExtensionRight) )
+infixNonAssociativeWithException precedence possibilitiesForPrecedence symbol exceptionSymbol =
+    infixHelp precedence
+        possibilitiesForPrecedence
+        (ParserFast.symbolWithExceptionFollowedBy symbol exceptionSymbol)
         (\right ->
             ExtendRightByOperation { symbol = symbol, direction = Infix.Non, expression = right }
         )

--- a/src/ParserFast.elm
+++ b/src/ParserFast.elm
@@ -1,6 +1,6 @@
 module ParserFast exposing
     ( Parser, run
-    , int, intOrHexMapWithRange, floatOrIntOrHexMapWithRange, symbol, symbolWithEndLocation, symbolWithRange, symbolFollowedBy, symbolBacktrackableFollowedBy, followedBySymbol, keyword, keywordFollowedBy, while, whileWithoutLinebreak, whileMap, ifFollowedByWhileWithoutLinebreak, ifFollowedByWhileMapWithoutLinebreak, ifFollowedByWhileMapWithRangeWithoutLinebreak, ifFollowedByWhileValidateWithoutLinebreak, ifFollowedByWhileValidateMapWithRangeWithoutLinebreak, anyChar, end
+    , int, intOrHexMapWithRange, floatOrIntOrHexMapWithRange, symbol, symbolWithEndLocation, symbolWithRange, symbolFollowedBy, symbolWithExceptionFollowedBy, symbolBacktrackableFollowedBy, followedBySymbol, keyword, keywordFollowedBy, while, whileWithoutLinebreak, whileMap, ifFollowedByWhileWithoutLinebreak, ifFollowedByWhileMapWithoutLinebreak, ifFollowedByWhileMapWithRangeWithoutLinebreak, ifFollowedByWhileValidateWithoutLinebreak, ifFollowedByWhileValidateMapWithRangeWithoutLinebreak, anyChar, end
     , succeed, problem, lazy, map, map2, map2WithStartLocation, map2WithRange, map3, map3WithStartLocation, map3WithRange, map4, map4WithRange, map5, map5WithStartLocation, map5WithRange, map6, map6WithStartLocation, map6WithRange, map7WithRange, map8WithStartLocation, map9WithRange, validate
     , orSucceed, mapOrSucceed, map2OrSucceed, map3OrSucceed, map4OrSucceed, oneOf2, oneOf2Map, oneOf2MapWithStartRowColumnAndEndRowColumn, oneOf2OrSucceed, oneOf3, oneOf4, oneOf5, oneOf7, oneOf10, oneOf14, oneOf
     , loopWhileSucceeds, loopUntil
@@ -14,7 +14,7 @@ module ParserFast exposing
 
 @docs Parser, run
 
-@docs int, intOrHexMapWithRange, floatOrIntOrHexMapWithRange, symbol, symbolWithEndLocation, symbolWithRange, symbolFollowedBy, symbolBacktrackableFollowedBy, followedBySymbol, keyword, keywordFollowedBy, while, whileWithoutLinebreak, whileMap, ifFollowedByWhileWithoutLinebreak, ifFollowedByWhileMapWithoutLinebreak, ifFollowedByWhileMapWithRangeWithoutLinebreak, ifFollowedByWhileValidateWithoutLinebreak, ifFollowedByWhileValidateMapWithRangeWithoutLinebreak, anyChar, end
+@docs int, intOrHexMapWithRange, floatOrIntOrHexMapWithRange, symbol, symbolWithEndLocation, symbolWithRange, symbolFollowedBy, symbolWithExceptionFollowedBy, symbolBacktrackableFollowedBy, followedBySymbol, keyword, keywordFollowedBy, while, whileWithoutLinebreak, whileMap, ifFollowedByWhileWithoutLinebreak, ifFollowedByWhileMapWithoutLinebreak, ifFollowedByWhileMapWithRangeWithoutLinebreak, ifFollowedByWhileValidateWithoutLinebreak, ifFollowedByWhileValidateMapWithRangeWithoutLinebreak, anyChar, end
 
 
 # Flow
@@ -2027,6 +2027,38 @@ symbolFollowedBy str (Parser parseNext) =
                     , indent = s.indent
                     , row = s.row
                     , col = s.col + strLength
+                    }
+                    |> pStepCommit
+
+            else
+                Bad False (ExpectingSymbol s.row s.col str) ()
+        )
+
+
+{-| Same as `symbolFollowedBy` but the following character must not be another given character.
+
+Assumes both symbols are only 1 character long.
+
+-}
+symbolWithExceptionFollowedBy : String -> String -> Parser next -> Parser next
+symbolWithExceptionFollowedBy str exception (Parser parseNext) =
+    Parser
+        (\s ->
+            let
+                newOffset : Int
+                newOffset =
+                    s.offset + 1
+            in
+            if
+                (String.slice s.offset newOffset s.src == str ++ "")
+                    && (String.slice newOffset (newOffset + 1) s.src /= exception ++ "")
+            then
+                parseNext
+                    { src = s.src
+                    , offset = newOffset
+                    , indent = s.indent
+                    , row = s.row
+                    , col = s.col + 1
                     }
                     |> pStepCommit
 

--- a/tests/Elm/Parser/ExpressionTests.elm
+++ b/tests/Elm/Parser/ExpressionTests.elm
@@ -115,7 +115,7 @@ all =
                                 , Node { start = { row = 1, column = 13 }, end = { row = 1, column = 15 } } <| ListExpr []
                                 ]
                         )
-        , test "application expression with operator" <|
+        , test "Binary operation" <|
             \() ->
                 "model + 1"
                     |> expectAst
@@ -663,6 +663,74 @@ all =
                                         )
                                     )
                                 )
+                            )
+                        )
+        , test "Nested binary operations (+ and ==)" <|
+            \() ->
+                "count + 1 == 1"
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 15 } }
+                            (OperatorApplication "=="
+                                Non
+                                (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } }
+                                    (OperatorApplication "+"
+                                        Left
+                                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } (FunctionOrValue [] "count"))
+                                        (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (Integer 1))
+                                    )
+                                )
+                                (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 15 } } (Integer 1))
+                            )
+                        )
+        , test "Nested binary operations (+ and /=)" <|
+            \() ->
+                "count + 1 /= 1"
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 15 } }
+                            (OperatorApplication "/="
+                                Non
+                                (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } }
+                                    (OperatorApplication "+"
+                                        Left
+                                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } (FunctionOrValue [] "count"))
+                                        (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (Integer 1))
+                                    )
+                                )
+                                (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 15 } } (Integer 1))
+                            )
+                        )
+        , test "Nested binary operations (+ and //)" <|
+            \() ->
+                "count + 1 // 2"
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 15 } }
+                            (OperatorApplication "+"
+                                Left
+                                (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 6 } } (FunctionOrValue [] "count"))
+                                (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 15 } }
+                                    (OperatorApplication "//"
+                                        Left
+                                        (Node { start = { row = 1, column = 9 }, end = { row = 1, column = 10 } } (Integer 1))
+                                        (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 15 } } (Integer 2))
+                                    )
+                                )
+                            )
+                        )
+        , test "Nested binary operations (&& and <|)" <|
+            \() ->
+                "condition && condition <| f"
+                    |> expectAst
+                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 28 } }
+                            (OperatorApplication "<|"
+                                Right
+                                (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 23 } }
+                                    (OperatorApplication "&&"
+                                        Right
+                                        (Node { start = { row = 1, column = 1 }, end = { row = 1, column = 10 } } (FunctionOrValue [] "condition"))
+                                        (Node { start = { row = 1, column = 14 }, end = { row = 1, column = 23 } } (FunctionOrValue [] "condition"))
+                                    )
+                                )
+                                (Node { start = { row = 1, column = 27 }, end = { row = 1, column = 28 } } (FunctionOrValue [] "f"))
                             )
                         )
         , test "fail if condition not positively indented" <|

--- a/tests/Elm/Parser/ParserWithCommentsTestUtil.elm
+++ b/tests/Elm/Parser/ParserWithCommentsTestUtil.elm
@@ -70,8 +70,8 @@ expectAst : ParserFast.Parser (WithComments a) -> a -> String -> Expect.Expectat
 expectAst parser =
     \expected source ->
         case ParserFast.run (ParserFast.withIndent 0 (ParserFast.map2 (\res () -> res) parser ParserFast.end)) source of
-            Err error ->
-                Expect.fail ("Expected the source to be parsed correctly:\n" ++ Debug.toString error)
+            Err deadEnds ->
+                Expect.fail ("Expected the source to be parsed correctly:\n[ " ++ (List.map deadEndToString deadEnds |> String.join "\n, ") ++ "\n]")
 
             Ok actual ->
                 Expect.all
@@ -83,6 +83,11 @@ expectAst parser =
                             |> Expect.onFail "This parser should not produce any comments. If this is expected, then you should use expectAstWithComments instead."
                     ]
                     ()
+
+
+deadEndToString : Parser.DeadEnd -> String
+deadEndToString { row, col, problem } =
+    "{ problem: " ++ Debug.toString problem ++ ", row = " ++ String.fromInt row ++ ", col = " ++ String.fromInt col ++ " }"
 
 
 expectAstWithComments : ParserFast.Parser (WithComments a) -> { ast : a, comments : List (Node String) } -> String -> Expect.Expectation


### PR DESCRIPTION
Fixes https://github.com/stil4m/elm-syntax/issues/258

We usually attempt to parse '/=' before we parse '/', which parses successfully.
But because in this expression we previously encountered a '+', we're at a precedence leve where we are only evaluating operators with a higher precedence than '/='. So we don't check for '/=', and then we see a '/' which commits, and then we get stuck because we don't expect a '='.

This fixes the issue by checking, for the '/' operator, that it is not followed by a '='. Ideally we should only do this if the operator
precedence is higher than the precendence for '/=', but that data is not available for the parser.

Similarly, this fixes the parsing of 'a && b <| c' which has the same problem.

cc @lue-bird, let me know if I missed something or if there is a better or more performant way to do this.

---

On top of this, I also made a small improvement to the printing of `DeadEnd`s in the tests.