### PR TITLE
correct float handling of the custom parser

### DIFF
--- a/src/ParserFast.elm
+++ b/src/ParserFast.elm
@@ -1803,7 +1803,24 @@ skipFloatAfterIntegerDecimal : Int -> String -> Int
 skipFloatAfterIntegerDecimal offset src =
     case String.slice offset (offset + 1) src of
         "." ->
-            skip1OrMoreDigits0To9 (offset + 1) src
+            let
+                offsetAfterDigits : Int
+                offsetAfterDigits =
+                    skip1OrMoreDigits0To9 (offset + 1) src
+            in
+            if offsetAfterDigits == -1 then
+                -1
+
+            else
+                case String.slice offsetAfterDigits (offsetAfterDigits + 1) src of
+                    "e" ->
+                        skipAfterFloatExponentMark (offsetAfterDigits + 1) src
+
+                    "E" ->
+                        skipAfterFloatExponentMark (offsetAfterDigits + 1) src
+
+                    _ ->
+                        offsetAfterDigits
 
         "e" ->
             skipAfterFloatExponentMark (offset + 1) src

--- a/tests/Elm/Parser/NumbersTests.elm
+++ b/tests/Elm/Parser/NumbersTests.elm
@@ -32,6 +32,76 @@ all =
                         )
                         |> Expect.equal
                             (Ok 42)
+            , test "float" <|
+                \() ->
+                    parseToResult "2.0"
+                        (ParserFast.floatOrIntegerDecimalOrHexadecimalMapWithRange
+                            (\_ n -> n)
+                            (\_ _ -> -1)
+                            (\_ _ -> -1)
+                        )
+                        |> Expect.equal
+                            (Ok 2.0)
+            , test "integer with negative exponent" <|
+                \() ->
+                    parseToResult "2e-2"
+                        (ParserFast.floatOrIntegerDecimalOrHexadecimalMapWithRange
+                            (\_ n -> n)
+                            (\_ _ -> -1)
+                            (\_ _ -> -1)
+                        )
+                        |> Expect.equal
+                            (Ok 2.0e-2)
+            , test "integer with negative exponent (uppercase E)" <|
+                \() ->
+                    parseToResult "2E-2"
+                        (ParserFast.floatOrIntegerDecimalOrHexadecimalMapWithRange
+                            (\_ n -> n)
+                            (\_ _ -> -1)
+                            (\_ _ -> -1)
+                        )
+                        |> Expect.equal
+                            (Ok 2.0e-2)
+            , test "integer with positive exponent" <|
+                \() ->
+                    parseToResult "2e+2"
+                        (ParserFast.floatOrIntegerDecimalOrHexadecimalMapWithRange
+                            (\_ n -> n)
+                            (\_ _ -> -1)
+                            (\_ _ -> -1)
+                        )
+                        |> Expect.equal
+                            (Ok 2.0e2)
+            , test "float with negative exponent" <|
+                \() ->
+                    parseToResult "2.0e-2"
+                        (ParserFast.floatOrIntegerDecimalOrHexadecimalMapWithRange
+                            (\_ n -> n)
+                            (\_ _ -> -1)
+                            (\_ _ -> -1)
+                        )
+                        |> Expect.equal
+                            (Ok 2.0e-2)
+            , test "float with negative exponent (uppercase E)" <|
+                \() ->
+                    parseToResult "2.0E-2"
+                        (ParserFast.floatOrIntegerDecimalOrHexadecimalMapWithRange
+                            (\_ n -> n)
+                            (\_ _ -> -1)
+                            (\_ _ -> -1)
+                        )
+                        |> Expect.equal
+                            (Ok 2.0e-2)
+            , test "float with positive exponent" <|
+                \() ->
+                    parseToResult "2.0e+2"
+                        (ParserFast.floatOrIntegerDecimalOrHexadecimalMapWithRange
+                            (\_ n -> n)
+                            (\_ _ -> -1)
+                            (\_ _ -> -1)
+                        )
+                        |> Expect.equal
+                            (Ok 2.0e2)
 
             -- TODO handling overflow like elm-format / the elm compiler
             -- would technically be a breaking change and maybe somewhat difficult to implement


### PR DESCRIPTION
I'm not getting regression notices anymore. Issue was bad float handling in the new custom parser replacement