### PR TITLE
Add destructure pattern parser

### DIFF
--- a/src/Elm/Parser/Declarations.elm
+++ b/src/Elm/Parser/Declarations.elm
@@ -1,9 +1,9 @@
 module Elm.Parser.Declarations exposing (declaration)
 
 import Elm.Parser.Comments as Comments
+import Elm.Parser.DestructurePatterns as DestructurePatterns
 import Elm.Parser.Expression exposing (expression)
 import Elm.Parser.Layout as Layout
-import Elm.Parser.Patterns as Patterns
 import Elm.Parser.Tokens as Tokens
 import Elm.Parser.TypeAnnotation as TypeAnnotation exposing (typeAnnotation, typeAnnotationNoFnExcludingTypedWithArguments)
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
@@ -426,7 +426,7 @@ parameterPatternsEqual =
                 , syntax = patternResult.syntax
                 }
             )
-            Patterns.patternNotDirectlyComposing
+            DestructurePatterns.patternNotDirectlyComposing
             Layout.maybeLayout
         )
 

--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1,5 +1,6 @@
 module Elm.Parser.Expression exposing (expression)
 
+import Elm.Parser.DestructurePatterns as DestructurePatterns
 import Elm.Parser.Layout as Layout
 import Elm.Parser.Patterns as Patterns
 import Elm.Parser.Tokens as Tokens
@@ -498,7 +499,7 @@ lambdaExpression =
                 }
             )
             Layout.maybeLayout
-            Patterns.patternNotDirectlyComposing
+            DestructurePatterns.patternNotDirectlyComposing
             Layout.maybeLayout
             (ParserWithComments.until
                 (ParserFast.symbol "->" ())
@@ -510,7 +511,7 @@ lambdaExpression =
                         , syntax = patternResult.syntax
                         }
                     )
-                    Patterns.patternNotDirectlyComposing
+                    DestructurePatterns.patternNotDirectlyComposing
                     Layout.maybeLayout
                 )
             )
@@ -720,7 +721,7 @@ letDestructuringDeclaration =
                     (LetDestructuring pattern.syntax expressionResult.syntax)
             }
         )
-        Patterns.patternNotDirectlyComposing
+        DestructurePatterns.patternNotDirectlyComposing
         Layout.maybeLayout
         (ParserFast.symbolFollowedBy "=" Layout.maybeLayout)
         expression
@@ -855,7 +856,7 @@ parameterPatternsEqual =
                 , syntax = patternResult.syntax
                 }
             )
-            Patterns.patternNotDirectlyComposing
+            DestructurePatterns.patternNotDirectlyComposing
             Layout.maybeLayout
         )
 


### PR DESCRIPTION
In `breaking-changes-v8`, we have a separate type and parser for parser destructure patterns. I figured we could backport it to `master` without changing the type.

A benefit of having this already in the `master` branch is that rebase of the v8 branch will be smaller too, and we can continue to improve the performance of it until v8 lands.

I've updated it over successive rebases to resemble the regular `Pattern` parser, so it should have similar performance, or actually faster since it tries less things. My gut feeling says that this should therefore be faster, but in practice I measure a 1 to 3% performance decrease (using `find-regressions`), which I find surprising. Maybe it's not run enough times and therefore the JIT doesn't optimize as much or enough? :thinking: 

What do you think?