### PR TITLE
Remove superfluous exposure of imported `Problem` type to top-level

### DIFF
--- a/src/ParserFast.elm
+++ b/src/ParserFast.elm
@@ -125,7 +125,7 @@ Once a path is chosen, it does not come back and try the others.
 
 import Char.Extra
 import Elm.Syntax.Range exposing (Location, Range)
-import Parser exposing (Problem(..))
+import Parser
 
 
 type Problem


### PR DESCRIPTION
Looks like that `exposing (Problem(..))` was introduced with commit <https://github.com/stil4m/elm-syntax/commit/61c89e7cc0d7c84da0108edd049323fe3b72707d> but that seems more like an accidental automated transformation than intended.