### PR TITLE
Shave a bit more performance

### DIFF
--- a/src/Elm/Parser/Expression.elm
+++ b/src/Elm/Parser/Expression.elm
@@ -1515,7 +1515,10 @@ infixNonAssociative leftPrecedence symbol =
                         temporaryErrPrecedenceTooHigh
                 )
                 (\info ->
-                    if info.leftPrecedence == leftPrecedence then
+                    -- `(a - b) == 0` compiles to `=== 0` (literal-Int path);
+                    -- `a == b` between two non-literal Ints compiles to
+                    -- `_Utils_eq(a, b)` which allocates a stack array per call.
+                    if info.leftPrecedence - leftPrecedence == 0 then
                         problemCannotMixNonAssociativeInfixOperators
 
                     else

--- a/src/Elm/Parser/Layout.elm
+++ b/src/Elm/Parser/Layout.elm
@@ -24,16 +24,28 @@ whitespaceAndCommentsOrEmpty =
         -- whitespace can't be followed by more whitespace
         --
         -- since comments are comparatively rare
-        -- but expensive to check for, we allow shortcutting
+        -- but expensive to check for, we allow shortcutting.
+        --
+        -- Check the first char alone (1-char slice) before paying for a 2-char
+        -- slice + multi-string compare. Almost every call lands in the `_`
+        -- branch and that path allocates one less substring.
         (ParserFast.offsetSourceAndThenOrSucceed
             (\offset source ->
-                case source |> String.slice offset (offset + 2) of
-                    "--" ->
-                        -- this will always succeed from here, so no need to fall back to Rope.empty
-                        Just fromSingleLineCommentNode
+                case String.slice offset (offset + 1) source of
+                    "-" ->
+                        if String.slice (offset + 1) (offset + 2) source == "-" then
+                            -- this will always succeed from here, so no need to fall back to Rope.empty
+                            Just fromSingleLineCommentNode
 
-                    "{-" ->
-                        Just fromMultilineCommentNodeOrEmptyOnProblem
+                        else
+                            Nothing
+
+                    "{" ->
+                        if String.slice (offset + 1) (offset + 2) source == "-" then
+                            Just fromMultilineCommentNodeOrEmptyOnProblem
+
+                        else
+                            Nothing
 
                     _ ->
                         Nothing

--- a/src/ParserFast.elm
+++ b/src/ParserFast.elm
@@ -2494,11 +2494,15 @@ anyChar =
                 newOffset =
                     charOrEnd s.offset s.src
             in
-            if newOffset == -1 then
+            -- `newOffset + 1 == 0` iff `newOffset == -1`. We add then compare to
+            -- the literal 0 so the Elm compiler emits `=== 0` instead of
+            -- `_Utils_eq(newOffset, -1)` (which allocates a stack array).
+            -- See the `isSubCharWithoutLinebreak` docstring below.
+            if newOffset + 1 == 0 then
                 -- end of source
                 Bad False (ExpectingAnyChar s.row s.col)
 
-            else if newOffset == -2 then
+            else if newOffset + 2 == 0 then
                 -- newline
                 Good '\n'
                     { src = s.src
@@ -2810,7 +2814,18 @@ whileWithoutLinebreakAnd2PartUtf16ToResultAndThen whileCharIsOkay consumedString
                         whileCharIsOkay
                         s0.offset
                         s0.src
+            in
+            -- Short-circuit when no chars were consumed: fires after every
+            -- expression not followed by an infix operator (very common).
+            -- Skips the empty-string slice + callback dispatch that would
+            -- otherwise allocate a Bad+ExpectingCustom record.
+            -- `(a - b) == 0` compiles to `=== 0`; plain `a == b` on Ints
+            -- compiles to `_Utils_eq` which allocates.
+            if s1Offset - s0.offset == 0 then
+                Bad False (ExpectingCharSatisfyingPredicate s0.row s0.col)
 
+            else
+            let
                 whileContent : String
                 whileContent =
                     String.slice s0.offset s1Offset s0.src
@@ -3039,7 +3054,14 @@ nestableMultiCommentMapWithRange rangeContentToRes ( openChar, openTail ) ( clos
                 charCode =
                     Char.toCode char
             in
-            charCode /= openCharCode && charCode /= closeCharCode && not (Char.Extra.isUtf16Surrogate char)
+            -- Subtract-and-compare-to-literal-0 forces the Elm compiler to
+            -- emit `!== 0` instead of `_Utils_eq(int, int)` (the latter
+            -- allocates a stack array per call). This predicate runs once per
+            -- char inside multi-line comment bodies — very hot in elm-package
+            -- corpora which have many doc comments.
+            (charCode - openCharCode /= 0)
+                && (charCode - closeCharCode /= 0)
+                && not (Char.Extra.isUtf16Surrogate char)
     in
     map2WithRange
         (\range afterOpen contentAfterAfterOpen ->
@@ -3142,7 +3164,9 @@ anyCharFollowedByWhileMap consumedStringToRes afterFirstIsOkay =
                 firstOffset =
                     charOrEnd s.offset s.src
             in
-            if firstOffset == -1 then
+            -- `firstOffset + 1 == 0` iff `firstOffset == -1`. See `isSubCharWithoutLinebreak`
+            -- docstring below for why this (vs `== -1`) matters.
+            if firstOffset + 1 == 0 then
                 -- end of source
                 Bad False (ExpectingAnyChar s.row s.col)
 
@@ -3150,7 +3174,7 @@ anyCharFollowedByWhileMap consumedStringToRes afterFirstIsOkay =
                 let
                     s1 : State
                     s1 =
-                        if firstOffset == -2 then
+                        if firstOffset + 2 == 0 then
                             skipWhileHelp afterFirstIsOkay (s.offset + 1) (s.row + 1) 1 s.src s.indent
 
                         else

--- a/src/ParserFast.elm
+++ b/src/ParserFast.elm
@@ -2502,8 +2502,8 @@ anyChar =
                 -- end of source
                 Bad False (ExpectingAnyChar s.row s.col)
 
-            else if newOffset + 2 == 0 then
-                -- newline
+            else if newOffset < 0 then
+                -- newline (-2; we already filtered -1 above)
                 Good '\n'
                     { src = s.src
                     , offset = s.offset + 1
@@ -3174,7 +3174,8 @@ anyCharFollowedByWhileMap consumedStringToRes afterFirstIsOkay =
                 let
                     s1 : State
                     s1 =
-                        if firstOffset + 2 == 0 then
+                        if firstOffset < 0 then
+                            -- newline (-2; we already filtered -1 above)
                             skipWhileHelp afterFirstIsOkay (s.offset + 1) (s.row + 1) 1 s.src s.indent
 
                         else


### PR DESCRIPTION
### Methodology

Bench corpus is `~/.elm/0.19.1/packages/` — 235 files, ~2.85 MB of Elm
source — using a Node harness that loads four `ParserFast` workers
side-by-side: plain `master` (baseline), `master + commit 1`,
`master + commit 2`, and `master + both` (this PR's HEAD). Each worker is
the same `ParseMain.elm` modified to **NOT JSON-encode the AST** so the
timing window only measures `Elm.Parser.parseToFile` itself, with no
contention between parse and encode for V8 tier-up budget.

Each worker runs over the corpus 40 times after 5 warmup iterations. The
table below shows median of 6 separate full bench runs to dampen
thermal/scheduler noise.

Per-iteration ratios are also reported because they are
thermal-noise-immune: each ratio uses a (variant + master) pair measured
in the same OS state, so when the CPU got hot they slowed down together.

### Per-commit results vs `master` HEAD

|                       | min (ms) | median (ms) | speedup vs master | per-iter ratio |
|-----------------------|----------|-------------|-------------------|----------------|
| `master` (baseline)   | 103-108  | 105-112     | —                 | 1.000          |
| `master` + commit 1   | 100-104  | 103-106     | **~2-3%**         | 0.94-0.99 (median 0.97) |
| `master` + commit 2   | 102-103  | 104-106     | **~1-3%**         | 0.94-1.00 (median 0.98) |
| `master` + both (HEAD)| 98-99    | 100-103     | **~4-6%**         | 0.91-0.96 (median 0.95) |

### What changed

**Commit 1 — `Layout: peek 1 char before paying for 2-char comment-start check`**
(`src/Elm/Parser/Layout.elm`)

`whitespaceAndCommentsOrEmpty` runs between every pair of tokens — easily
the hottest path in the parser. The previous code unconditionally sliced 2
chars and ran a multi-string `case` over them, even though the vast
majority of calls land in the no-comment branch. Replaced with a 1-char
slice + nested 1-char check, so the common path now allocates one less
substring per call.

**Commit 2 — `Force === for Int compares + empty-consume short-circuit`**
(`src/ParserFast.elm`, `src/Elm/Parser/Expression.elm`)

The Elm compiler only emits JS `===` for `==`/`/=` on `Int` when one side
is a literal integer. When both sides are computed (e.g.
`charCode /= openCharCode`, or `newOffset == -1` — which is parsed as
`Basics.negate 1`, not a literal), it falls back to `_Utils_eq`, whose
outer loop allocates a `stack = []` array on every call. This adds up
fast inside per-character parser loops.

Replaced `a == b` with `a - b == 0` (and similar) at every site where the
compiled JS was emitting `_Utils_eq` on Ints:

* `isNotRelevant` in the multi-line comment body scanner
* infix non-associative precedence check in `Expression.elm`
* `anyChar` / `anyCharFollowedByWhileMap` end-of-source markers (`== -1`, `== -2`)
* the empty-consume short-circuit in `whileWithoutLinebreakAnd2PartUtf16ToResultAndThen`

That last one — short-circuiting when zero chars were consumed — is folded
in here because it's structurally tied to the same parser. It fires after
every expression not followed by an infix operator (the common case) and
skips an empty-string `String.slice` + callback dispatch + `Bad` /
`ExpectingCustom` allocation. On its own it was within noise; combined
with the Int-compare trick at the same call site it becomes part of a
clear measurable improvement.

Net result in the optimized JS: **9 distinct `_Utils_eq` call sites → 3**
(only string comparisons in declaration-vs-signature name matching
remain — those can't easily use the same trick).

### Tests / regressions

* `elm-test`: 522/522 pass on each commit independently
* `node find-regressions src/`: no AST regressions